### PR TITLE
Fix numpy version in ddp test case requirements

### DIFF
--- a/3.test_cases/4.DDP/requirements.txt
+++ b/3.test_cases/4.DDP/requirements.txt
@@ -1,7 +1,7 @@
 catalyst==22.4
 imageio==2.16.1
 matplotlib==3.5.1
-numpy==1.21.5
+numpy==1.22.0
 opencv_python==4.5.5.64
 pandas==1.5.0
 Pillow==9.4.0


### PR DESCRIPTION
Fixes #1 , bump version of Numpy to 1.22.0

> Incomplete string comparison in the numpy.core component in NumPy1.9.x, which allows attackers to fail the APIs via constructing specific string objects.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
