### PR TITLE
Add more information on placement group usage

### DIFF
--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de-base.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de-base.yaml
@@ -31,7 +31,7 @@ Scheduling:
         SubnetIds:
           - PLACEHOLDER_PRIVATE_SUBNET
         PlacementGroup:
-          Enabled: true
+          Enabled: true # set this to false if using a targeted ODCR
       ComputeSettings:
         LocalStorage:
           EphemeralVolume:

--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de_postinstall_scripts.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de_postinstall_scripts.yaml
@@ -25,6 +25,8 @@ HeadNode:
       Sequence:
         - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/docker/postinstall.sh'
         - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/pyxis/postinstall.sh'
+          Args:
+            - /fsx # cache enroot images on /fsx
 Scheduling:
   Scheduler: slurm
   SlurmSettings:
@@ -36,7 +38,7 @@ Scheduling:
         SubnetIds:
           - PLACEHOLDER_PRIVATE_SUBNET
         PlacementGroup:
-          Enabled: true
+          Enabled: true  # set this to false if using a targeted ODCR
       ComputeSettings:
         LocalStorage:
           EphemeralVolume:
@@ -62,6 +64,8 @@ Scheduling:
           Sequence:
             - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/docker/postinstall.sh'
             - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/pyxis/postinstall.sh'
+              Args:
+                - /fsx # cache enroot images on /fsx
 SharedStorage:
   - MountDir: /fsx
     Name: fsx


### PR DESCRIPTION
* Placement groups should be added in addition to targeted ODCR's
* Multiple placement groups can be mapped into a single group and provided to parallelcluster
* Enroot defaults to cacheing on the user's `/home/<user>` directory, by explicitly setting the path to `/fsx` we avoid filling up the home directory (and thus making the headnode crash). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
