### PR TITLE
Enable simple, text-based Slurm accounting

### DIFF
--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de-base.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de-base.yaml
@@ -24,6 +24,17 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: 60
+    CustomSlurmSettings:
+      # Simple accounting to text file /home/slurm/slurm-job-completions.txt.
+      #
+      # Must be disabled should you prefer to setup Slurm accounting to database
+      # (https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-accounting-v3.html).
+      #
+      # NOTE: JobCompType entry will be duplicated, hence will cause a harmless
+      # warning message in `systemctl status --no-pager slurmctld`.
+      - JobCompType: jobcomp/filetxt
+      - JobCompLoc: /home/slurm/slurm-job-completions.txt
+      - JobAcctGatherType: jobacct_gather/linux
   SlurmQueues:
     - Name: compute-gpu
       CapacityType: ONDEMAND

--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de_batch-inference-g5_custom_ami.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de_batch-inference-g5_custom_ami.yaml
@@ -28,6 +28,17 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: 60
+    CustomSlurmSettings:
+      # Simple accounting to text file /home/slurm/slurm-job-completions.txt.
+      #
+      # Must be disabled should you prefer to setup Slurm accounting to database
+      # (https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-accounting-v3.html).
+      #
+      # NOTE: JobCompType entry will be duplicated, hence will cause a harmless
+      # warning message in `systemctl status --no-pager slurmctld`.
+      - JobCompType: jobcomp/filetxt
+      - JobCompLoc: /home/slurm/slurm-job-completions.txt
+      - JobAcctGatherType: jobacct_gather/linux
   SlurmQueues:
     - Name: compute-gpu
       CapacityType: ONDEMAND

--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de_custom_ami.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de_custom_ami.yaml
@@ -25,6 +25,17 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: 60
+    CustomSlurmSettings:
+      # Simple accounting to text file /home/slurm/slurm-job-completions.txt.
+      #
+      # Must be disabled should you prefer to setup Slurm accounting to database
+      # (https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-accounting-v3.html).
+      #
+      # NOTE: JobCompType entry will be duplicated, hence will cause a harmless
+      # warning message in `systemctl status --no-pager slurmctld`.
+      - JobCompType: jobcomp/filetxt
+      - JobCompLoc: /home/slurm/slurm-job-completions.txt
+      - JobAcctGatherType: jobacct_gather/linux
   SlurmQueues:
     - Name: compute-gpu
       CapacityType: ONDEMAND

--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de_postinstall_scripts.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de_postinstall_scripts.yaml
@@ -31,6 +31,17 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: 60
+    CustomSlurmSettings:
+      # Simple accounting to text file /home/slurm/slurm-job-completions.txt.
+      #
+      # Must be disabled should you prefer to setup Slurm accounting to database
+      # (https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-accounting-v3.html).
+      #
+      # NOTE: JobCompType entry will be duplicated, hence will cause a harmless
+      # warning message in `systemctl status --no-pager slurmctld`.
+      - JobCompType: jobcomp/filetxt
+      - JobCompLoc: /home/slurm/slurm-job-completions.txt
+      - JobAcctGatherType: jobacct_gather/linux
   SlurmQueues:
     - Name: compute-gpu
       CapacityType: ONDEMAND

--- a/1.architectures/2.aws-parallelcluster/distributed-training-trn1_custom_ami.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-trn1_custom_ami.yaml
@@ -27,6 +27,17 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: 60
+    CustomSlurmSettings:
+      # Simple accounting to text file /home/slurm/slurm-job-completions.txt.
+      #
+      # Must be disabled should you prefer to setup Slurm accounting to database
+      # (https://docs.aws.amazon.com/parallelcluster/latest/ug/slurm-accounting-v3.html).
+      #
+      # NOTE: JobCompType entry will be duplicated, hence will cause a harmless
+      # warning message in `systemctl status --no-pager slurmctld`.
+      - JobCompType: jobcomp/filetxt
+      - JobCompLoc: /home/slurm/slurm-job-completions.txt
+      - JobAcctGatherType: jobacct_gather/linux
   SlurmQueues:
     - Name: compute-gpu
       CapacityType: ONDEMAND


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Enable text-based Slurm accounting, which stores the data ina text file on head node. No external database required for this simplistic setup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
