### PR TITLE
Docker images cleanup + unttests

### DIFF
--- a/3.test_cases/1.megatron-lm/README.md
+++ b/3.test_cases/1.megatron-lm/README.md
@@ -91,6 +91,7 @@ Below are the steps you need to follow:
     wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-vocab.json
     wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-merges.txt
     xz -d oscar-1GB.jsonl.xz
+    cd ${TEST_CASE_PATH} # return to original testcase directory
     ```
 
 6. Now you copy the file `1.data-preprocessing.sbatch` or its content on your cluster then submit a preprocessing jobs with the command below:

--- a/3.test_cases/1.megatron-lm/test_megatron_lm.py
+++ b/3.test_cases/1.megatron-lm/test_megatron_lm.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env  python3
+import pytest
+import os
+
+def test_img_data_processing(docker_build):
+    print(f"module file {os.path.dirname(__file__)}")
+    print(f"cwd {os.getcwd()}")
+    docker_build('megatron-preprocess', '0.data-preprocessing.Dockerfile')
+
+def test_img_megatron_training(docker_build, docker_run):
+    img = docker_build('megatron-preprocess', '2.distributed-training.Dockerfile')
+    docker_run(img, ['python3', '-c', 'import torch'])

--- a/3.test_cases/2.nemo-launcher/0.NemoMegatron-aws-optimized.Dockerfile
+++ b/3.test_cases/2.nemo-launcher/0.NemoMegatron-aws-optimized.Dockerfile
@@ -4,38 +4,53 @@
 # DOCKER_BUILDKIT=1 docker build --progress plain -t aws-nemo-megatron:latest .
 # Customized from: https://github.com/NVIDIA/NeMo-Megatron-Launcher/blob/<VERSION>/csp_tools/aws/Dockerfile
 
-FROM nvcr.io/ea-bignlp/nemofw-training:23.07-py3
+FROM nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.08.03
 
 ARG DEBIAN_FRONTEND=noninteractive
-ENV EFA_INSTALLER_VERSION=latest
-ENV NCCL_VERSION=inc_nsteps
-ENV AWS_OFI_NCCL_VERSION=1.4.0-aws
+ENV EFA_INSTALLER_VERSION=1.28.0
+ENV NCCL_VERSION=2.18.5-1+cuda12.2
+ENV AWS_OFI_NCCL_VERSION=1.7.3-aws
 
-# Install AWS NCCL
-RUN cd /tmp \
-    && git clone https://github.com/NVIDIA/nccl.git -b ${NCCL_VERSION} \
-    && cd nccl \
-    && make -j src.build BUILDDIR=/usr/local \
-    # nvcc to target p4 instances
-    NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80" \
-    && rm -rf /tmp/nccl
+
+RUN apt-get update -y \
+    && apt-get remove -y --allow-change-held-packages \
+                       libmlx5-1 ibverbs-utils libibverbs-dev libibverbs1 \
+    && rm -rf /opt/hpcx/ompi \
+    && rm -rf /usr/local/mpi \
+    && rm -rf /usr/local/ucx \
+    && ldconfig
+
+RUN  echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64 /" >> //etc/apt/sources.list.d/cuda.list \
+     && curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub > /tmp/3bf863cc.pub \
+     && echo "34bb9f7e66744d7b2944d0565db6687560d5d6e3 /tmp/3bf863cc.pub" | sha1sum --check \
+     && apt-key add /tmp/3bf863cc.pub \
+     && unlink /tmp/3bf863cc.pub \
+     && apt-get update -y \
+     && apt-get install -y libnccl2=${NCCL_VERSION} libnccl-dev=${NCCL_VERSION} \
+     && apt-get clean
+
 
 # EFA
 RUN apt-get update && \
+    apt-get install -y libhwloc-dev && \
     cd /tmp && \
     curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz  && \
     tar -xf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz && \
     cd aws-efa-installer && \
-    ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf && \
+    ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify && \
     ldconfig && \
     rm -rf /tmp/aws-efa-installer /var/lib/apt/lists/* && \
+    apt-get clean && \
     /opt/amazon/efa/bin/fi_info --version
 
-ENV LD_LIBRARY_PATH=/opt/amazon/efa/lib:$LD_LIBRARY_PATH
-ENV PATH=/opt/amazon/efa/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:$PATH
 
 # NCCL EFA Plugin (Dockefile original)
 # NOTE: Stick to this version! Otherwise, will get 'ncclInternalError: Internal check failed.'
+RUN apt-get update -y \
+    && apt-get install -y libhwloc-dev
+
 RUN mkdir -p /tmp && \
     cd /tmp && \
     curl -LO https://github.com/aws/aws-ofi-nccl/archive/refs/tags/v${AWS_OFI_NCCL_VERSION}.tar.gz && \
@@ -52,8 +67,7 @@ RUN mkdir -p /tmp && \
     rm -rf /tmp/aws-ofi/nccl
 
 # NCCL
-RUN echo "/usr/local/lib"      >> /etc/ld.so.conf.d/local.conf && \
-    echo "/opt/amazon/efa/lib" >> /etc/ld.so.conf.d/efa.conf &&  \
+RUN echo "/opt/amazon/efa/lib" >> /etc/ld.so.conf.d/efa.conf &&  \
     ldconfig
 
 ENV OMPI_MCA_pml=^ucx                \

--- a/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
+++ b/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -exo pipefail
+[[ -z "${TARGET_PATH}" ]] \
+    && { echo Please set environment variable TARGET_PATH ; exit 1 ; } \
+    || echo TARGET_PATH=$TARGET_PATH
+
+################################################################################
+# 000: Modify this section to define pre-training configuration: model size,
+# number of nodes, max. pre-training steps, job's max. runtime.
+################################################################################
+## Pre-train llama2-7b on 2 nodes for 5 steps
+export MODEL=llama
+export MODEL_SIZE=llama2_7b
+export NUM_NODES=2
+export RUNTIME=4h
+export MAX_STEPS=30
+export MBS=2 # setting for A100 80GB (p4de, p5), reduce to 1 for A100 40GB (p4d)
+declare -a MODEL_ARGS=(
+    training.model.micro_batch_size=${MBS}
+
+    training.model.tokenizer.model=${TARGET_PATH}/data/llama2/tokenizer.model
+    # When node_count < 8, needs full activations checkpointing. These're settings found on
+    # Nemo repo's Jenkin script.
+    #
+    # Below settings is similar to 22.09, except that 22.09 funnily didn't OOM with
+    # activations_checkpoint_num_layers=0.
+    training.model.activations_checkpoint_granularity='full'
+    training.model.activations_checkpoint_method='block'
+    training.model.activations_checkpoint_num_layers=1
+)
+
+
+################################################################################
+# 010: Advance users can modify this stanza to customize benchmarking behavior.
+################################################################################
+declare -a BMK_ARGS=(
+    # Disable validation, as we're only interested to measure the training time.
+    training.trainer.limit_val_batches=0.0
+
+    # Disable wandb_logger
+    training.exp_manager.create_wandb_logger=False
+
+    # Ignore checkpoints
+    training.exp_manager.create_checkpoint_callback=False
+    training.exp_manager.resume_if_exists=False
+
+    # https://github.com/NVIDIA/NeMo/pull/6181/files
+    training.model.data.data_impl=mock
+    training.model.data.data_prefix=[]
+)
+
+
+################################################################################
+# 020: Internal settings.
+################################################################################
+WORKSPACE_CONT=$TARGET_PATH
+CONT_RESULT_DIR=${WORKSPACE_CONT}/results
+
+
+# Dev/test feature (off by default) to force each pre-training run outputs to a separate directory.
+: "${UNIQUE_OUTPUT_DIR:=0}"
+if [[ ${UNIQUE_OUTPUT_DIR} -eq 1 ]]; then
+    # For debugging: each run has its own output dir.
+    TIMESTAMP=$(date +'%Y%m%d-%H%M%Sutc-%N')-$((RANDOM))
+    CONT_RESULT_DIR=${CONT_RESULT_DIR}-${TIMESTAMP}
+
+    BMK_ARGS+=(base_results_dir=${CONT_RESULT_DIR})
+
+    echo "
+    ####################
+    This run will write to directory ${CONT_RESULT_DIR}
+    ####################
+    "
+fi
+
+
+################################################################################
+# 030: Here we go...
+################################################################################
+HYDRA_FULL_ERROR=1 python3 $TARGET_PATH/launcher_scripts/main.py \
+    stages=[training] \
+    training=${MODEL}/${MODEL_SIZE} \
+    training.trainer.num_nodes=$NUM_NODES \
+    training.trainer.max_steps=$MAX_STEPS \
+    training.trainer.val_check_interval=$MAX_STEPS \
+    "${BMK_ARGS[@]}" "${MODEL_ARGS[@]}" "$@"

--- a/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
+++ b/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -exo pipefail
+[[ -z "${TARGET_PATH}" ]] \
+    && { echo Please set environment variable TARGET_PATH ; exit 1 ; } \
+    || echo TARGET_PATH=$TARGET_PATH
+
+################################################################################
+# 000: Modify this section to define pre-training configuration: model size,
+# number of nodes, max. pre-training steps, job's max. runtime.
+################################################################################
+## Pre-train llama2-7b on 2 nodes for 5 steps
+export MODEL=llama
+export MODEL_SIZE=llama2_70b
+export NUM_NODES=16
+export TIME_LIMIT="7-00:00:00"
+export MAX_STEPS=100
+export MBS=1
+
+declare -a MODEL_ARGS=(
+    training.model.micro_batch_size=${MBS}
+    training.model.tensor_model_parallel_size=4
+    training.model.pipeline_model_parallel_size=4
+    training.model.virtual_pipeline_model_parallel_size=20
+    training.model.overlap_p2p_comm=True
+    training.model.batch_p2p_comm=False
+    training.model.gc_interval=0
+
+    training.model.tokenizer.model=${TARGET_PATH}/data/llama2/tokenizer.model
+
+    ## Activation checkpointing
+    #training.model.activations_checkpoint_granularity='full'
+    #training.model.activations_checkpoint_method='block'
+    #training.model.activations_checkpoint_num_layers=1
+    #
+    ## Not applicable for A100
+    #training.model.transformer_engine=False
+    #training.model.ub_tp_comm_overlap=False
+)
+
+
+################################################################################
+# 010: Advance users can modify this stanza to customize benchmarking behavior.
+################################################################################
+declare -a BMK_ARGS=(
+    # Disable validation, as we're only interested to measure the training time.
+    training.trainer.limit_val_batches=0.0
+
+    # Disable wandb_logger
+    training.exp_manager.create_wandb_logger=False
+
+    # Ignore checkpoints
+    training.exp_manager.create_checkpoint_callback=False
+    training.exp_manager.resume_if_exists=False
+
+    ################################
+
+    # https://github.com/NVIDIA/NeMo/pull/6181/files
+    training.model.data.data_impl=mock
+    training.model.data.data_prefix=[]
+)
+
+
+################################################################################
+# 020: Internal settings.
+################################################################################
+WORKSPACE_CONT=$TARGET_PATH
+CONT_RESULT_DIR=${WORKSPACE_CONT}/results-v2
+CONT_TOKENIZER_DIR=${WORKSPACE_CONT}/data/bpe
+
+# Dev/test feature (off by default) to force each pre-training run outputs to a separate directory.
+: "${UNIQUE_OUTPUT_DIR:=0}"
+if [[ ${UNIQUE_OUTPUT_DIR} -eq 1 ]]; then
+    # For debugging: each run has its own output dir.
+    TIMESTAMP=$(date +'%Y%m%d-%H%M%Sutc-%N')-$((RANDOM))
+    CONT_RESULT_DIR=${CONT_RESULT_DIR}-${TIMESTAMP}
+
+    BMK_ARGS+=(base_results_dir=${CONT_RESULT_DIR})
+
+    echo "
+    ####################
+    This run will write to directory ${CONT_RESULT_DIR}
+    ####################
+    "
+fi
+
+
+################################################################################
+# 030: Here we go...
+################################################################################
+HYDRA_FULL_ERROR=1 python3 $TARGET_PATH/launcher_scripts/main.py \
+    stages=[training] \
+    training=${MODEL}/${MODEL_SIZE} \
+    training.run.time_limit=$TIME_LIMIT \
+    training.trainer.num_nodes=$NUM_NODES \
+    training.trainer.max_steps=$MAX_STEPS \
+    training.trainer.val_check_interval=$MAX_STEPS \
+    "${BMK_ARGS[@]}" "${MODEL_ARGS[@]}" "$@"

--- a/3.test_cases/2.nemo-launcher/README.md
+++ b/3.test_cases/2.nemo-launcher/README.md
@@ -35,7 +35,7 @@ cd $TEST_CASE_PATH
 
 You will retrieve the container image from Nvidia, build an optimized container for EFA and, convert it into an Enroot file so we can run it on our cluster.
 
-1. You have a registered account with Nvidia and can access NGC. Retrieve the NGC API key following [instructions from Nvidia](https://docs.nvidia.com/ngc/gpu-cloud/ngc-user-guide/index.html#generating-api-key).
+1. You have a registered account with Nvidia and can access NGC. Retrieve the NGC API key following [instructions from Nvidia](https://docs.nvidia.com/ngc/gpu-cloud/ngc-user-guide/index.html#generating-api-key) and request access [here](https://developer.nvidia.com/nemo-framework/join) in order to be able to pull NeMo images.
 2. Configure NGC as shown below using the command below, when requested use `$oauthtoken` for the login and the API key from NGC fro the password.
 
 ```bash

--- a/3.test_cases/2.nemo-launcher/README.md
+++ b/3.test_cases/2.nemo-launcher/README.md
@@ -217,9 +217,28 @@ training.trainer.num_nodes=$NUM_NODES
                 |
                 └── key 'trainer -> num_nodes' in the `.yaml` file.
 ```
+## 8. Pre-Training llama2
 
+This section assumes that you went through the previous sections and 1/ retrieved and built the AWS optimized NemoMegatron container, 2/ setup the NemoMegatron environment, and 3/ download the vocabularies. Actions will be almost the same as for 5/ Pre-training GPT3, let do it.
 
-## 8. References
+1. Download llama2 tokenizer
+```
+mkdir -p $TARGET_PATH/data/llama2
+curl -L https://github.com/microsoft/Llama-2-Onnx/raw/main/tokenizer.model > $TARGET_PATH/data/llama2/tokenizer.model
+
+```
+2. Source the NemoMegatron environment created earlier.
+    ```bash
+    source ${TARGET_PATH}/.venv/bin/activate
+    ```
+3. To pre-train a llama2-7b on two instances with mock dataset, run the commands below to let :
+    ```bash
+    cd $TARGET_PATH
+    $TEST_CASE_PATH/5.bmk-pretrain-llama-7b.sh
+    ```
+4. Next stests are absolutely the same as for 5/ Pre-training GPT3, the only difference is that result directory is `$TARGET_PATH/results/llama2_7b`
+
+## 9. References
 
 - Nvidia NemoMegatron Documentation: https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/megatron.html
 - Train Large Scale NLP with Nemo Megatron from Nvidia: https://docs.nvidia.com/launchpad/ai/base-command-nemo/latest/index.html

--- a/3.test_cases/2.nemo-launcher/README.md
+++ b/3.test_cases/2.nemo-launcher/README.md
@@ -22,9 +22,9 @@ The following pre-requisites are needed to run this example:
 You will need to setup the following environment variables before running the scripts. :
 
 ```bash
-export NEMO_VERSION=23.07
+export NEMO_VERSION=23.08.03
 export REPO=aws-nemo-megatron
-export TAG=$NEMO_VERSION-py3
+export TAG=$NEMO_VERSION
 export TARGET_PATH=/fsx/nemo-launcher-$NEMO_VERSION   # must be a shared filesystem
 export TEST_CASE_PATH=/home/ec2-user/2.nemo-launcher  # where you copy the test case or set to your test case path
 export ENROOT_IMAGE=/apps/${REPO}_${TAG}.sqsh
@@ -73,7 +73,7 @@ cd $TARGET_PATH
 enroot start --mount $TARGET_PATH:/workspace/mount_dir \
              --env NVIDIA_VISIBLE_DEVICES=void \
              $ENROOT_IMAGE \
-             cp -a /opt/NeMo-Megatron-Launcher/launcher_scripts /opt/NeMo-Megatron-Launcher/auto_configurator /opt/FasterTransformer /workspace/mount_dir/
+             cp -a /opt/NeMo-Megatron-Launcher/launcher_scripts /opt/NeMo-Megatron-Launcher/auto_configurator /workspace/mount_dir/
 ```
 
 The `NVIDIA_VISIBLE_DEVICES` variable is set to void to prevent the process to check for the Nvidia driver presence (since we don't need GPUs here).

--- a/3.test_cases/2.nemo-launcher/test_nemo_launcher.py
+++ b/3.test_cases/2.nemo-launcher/test_nemo_launcher.py
@@ -1,0 +1,7 @@
+import pytest
+import os
+
+
+def test_0_aws_nemo_megatron(docker_build, docker_run):
+    img = docker_build('aws-nemo-megatron', '0.NemoMegatron-aws-optimized.Dockerfile')
+    docker_run(img, ['python3', '-c', 'import torch'])

--- a/4.validation_scripts/0.nccl-tests/test_nccl_tests.py
+++ b/4.validation_scripts/0.nccl-tests/test_nccl_tests.py
@@ -1,0 +1,7 @@
+import pytest
+import os
+
+
+def test_0_nccl_test(docker_build, docker_run):
+    img = docker_build('nccl-test', '0.nccl-tests.Dockerfile')
+    #docker_run(img, ['python3', '-c', 'import torch'])

--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ All test cases are under `3.test_cases/`. You can go in each test case directory
 
 Utilities scripts and micro-benchmarks examples are set under `4.validation_scripts/`.
 
-## 5. Contributors
+## 5. CI
+
+Integration tests are written in [pytest](https://docs.pytest.org). Just run:
+```
+pytest .
+```
+
+Alternatively you can run tests with out capturing stdout and keeping all docker images an other artifacts.
+```
+pytest -s --keep-artifacts=t
+```
+
+## 6. Contributors
 
 Thanks to all the contributors for building, reviewing and testing.
 
@@ -64,3 +76,4 @@ Thanks to all the contributors for building, reviewing and testing.
 - Sean Smith - seaam@
 - Jianying Lang - langjian@
 - Maxime Hugues - maxhaws@
+- Dmitry Monakhov dmonakhov@

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+import subprocess
+import os
+
+
+def pytest_addoption(parser):
+    parser.addoption("--keep-artifacts", action="store")
+
+@pytest.fixture
+def change_test_dir(request):
+    _orig_dir = os.getcwd()
+    os.chdir(os.path.dirname(request.path))
+    yield
+    os.chdir(_orig_dir)
+
+@pytest.fixture
+def docker_build(change_test_dir, request):
+    img_list = []
+    def _build(name, dockerfile, test_tag=".test"):
+        img_name=name + test_tag
+        subprocess.check_call(['docker', 'build', '-t', img_name, '-f', dockerfile, '.'])
+        img_list.append(img_name)
+        return img_name
+
+    yield _build
+    if request.config.option.keep_artifacts == None:
+        for img in img_list:
+            subprocess.check_call(['docker', 'image', 'rm', img])
+
+@pytest.fixture
+def docker_run(change_test_dir):
+    def _run(name, cmd, args=["--rm"]):
+        subprocess.check_call(['docker', 'run'] + args + [name] + cmd)
+
+    yield _run


### PR DESCRIPTION
Hi,

I try to use this repo for a very first time and it is appeared very useful source of knowledge. But some recipes are broken and fail to build. This is likely because there are no easy way to test changes so I've added trivial unittest which validate that dockerfiles are healthy.  Ideally this unittests should be executed as CI scripts on commit.

List of changes
 - Add unittest to validate dockerimages
 - Update images to use most recent libraries, EFA-installer-1.28.0, aws_ofi_nccl-1.7.3-aws
 - Fix broken docker images.
 - Add hpc-benchmarks guide to run xhpl on AWS platforms.  