### PR TITLE
smhp/easy-ssh: support custom controller group name

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
@@ -3,10 +3,43 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-(( ! $# == 1 )) && { echo "Must define cluster name" ; exit -1 ; }
+declare -a HELP=(
+    "[-h|--help]"
+    "[-c|--controller-group]"
+    "CLUSTER_NAME"
+)
 
-cluster_id=$(aws sagemaker describe-cluster --cluster-name $1 | jq '.ClusterArn' | awk -F/ '{gsub(/"/, "", $NF); print $NF}')
+cluster_name=""
 node_group="controller-machine"
+
+parse_args() {
+    local key
+    while [[ $# -gt 0 ]]; do
+        key="$1"
+        case $key in
+        -h|--help)
+            echo "Access a HyperPod Slurm controller via ssh-over-ssm."
+            echo "Usage: $(basename ${BASH_SOURCE[0]}) ${HELP[@]}"
+            exit 0
+            ;;
+        -c|--controller-group)
+            node_group="$2"
+            shift 2
+            ;;
+        *)
+            [[ "$cluster_name" == "" ]] \
+                && cluster_name="$key" \
+                || { echo "Must define one cluster name only" ; exit -1 ;  }
+            shift
+            ;;
+        esac
+    done
+
+    [[ "$cluster_name" == "" ]] && { echo "Must define a cluster name" ; exit -1 ;  }
+}
+
+parse_args $@
+cluster_id=$(aws sagemaker describe-cluster --cluster-name $cluster_name | jq '.ClusterArn' | awk -F/ '{gsub(/"/, "", $NF); print $NF}')
 instance_id=$(aws sagemaker list-cluster-nodes --cluster-name $1 --region us-west-2 --instance-group-name-contains ${node_group} | jq '.ClusterNodeSummaries[0].InstanceId' | tr -d '"')
 
 echo "Cluster id: ${cluster_id}"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* SageMaker HyperPod's eash-ssh to allow custom controller's instance group name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
