### PR TITLE
Add SSM Proxy command

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
@@ -57,6 +57,17 @@ echo "Cluster id: ${cluster_id}"
 echo "Instance id: ${instance_id}"
 echo "Node Group: ${node_group}"
 
-echo "aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}"
+echo -e "aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}"
+
+echo -e "Add the following to your ~/.ssh/config to easily connect:"
+echo "
+Host ${cluster_name}
+  User ubuntu
+  ProxyCommand sh -c \"aws ssm start-session ${aws_cli_args[@]} --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AWS-StartSSHSession --parameters 'portNumber=%p'\"
+
+Add your ssh keypair and then you can do:
+
+$ ssh ${cluster_name}
+"
 
 aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}


### PR DESCRIPTION
Instructions on connecting to HyperPod via SSH, i.e.

```bash
cat <<EOF >> ~/.ssh/config 
Host ml-cluster
  User ubuntu
  ProxyCommand sh -c "aws ssm start-session --target sagemaker-cluster:mo40psfake_controller-machine-i-0d0be2299d10fake --region us-west-2 --document-name AWS-StartSSHSession --parameters 'portNumber=%p'""
EOF
```
Then add your keypair to the head node ~/.ssh/authorized_keys and you can run:
```bash
$ ssh ml-cluster
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
