### PR TITLE
Add home path to user creation script

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/add_users.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/add_users.sh
@@ -37,22 +37,6 @@ create_user() {
   bash_path=$(which bash)
   useradd -m "$username" --uid "$uid" -d "$homepath" --shell "$bash_path" || (echo "Failed to create user $username with uid $uid" && return)
 
-  usermod -aG sudo "$username"
-
-  if getent group ubuntu >/dev/null; then
-    echo "Group ubuntu exists."
-    usermod -aG ubuntu "$username"
-  else
-    echo "Group ubuntu does not exist."
-  fi
-
-  if getent group docker >/dev/null; then
-    echo "Group docker exists."
-    usermod -aG docker "$username"
-  else
-    echo "Group docker does not exist."
-  fi
-
   if test ! -e "$homepath/.ssh/id_rsa"; then
     echo "No ssh keygen, creating a new one"
     mkdir -p "$homepath/.ssh/"

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
@@ -119,8 +119,6 @@ def main(args):
     params = ProvisioningParameters(args.provisioning_parameters)
     resource_config = ResourceConfig(args.resource_config)
 
-    ExecuteBashScript("./add_users.sh").run()
-
     fsx_dns_name, fsx_mountname = params.fsx_settings
     if fsx_dns_name and fsx_mountname:
         print(f"Mount fsx: {fsx_dns_name}. Mount point: {fsx_mountname}")
@@ -154,7 +152,10 @@ def main(args):
         # Note: Uncomment the below lines to install docker and enroot
         ExecuteBashScript("./utils/install_docker.sh").run()
         ExecuteBashScript("./utils/install_enroot_pyxis.sh").run(node_type)
-        
+
+    # We execute this after everything else
+    ExecuteBashScript("./add_users.sh").run()
+
     print("[INFO]: Success: All provisioning scripts completed")
 
 

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/shared_users_sample.txt
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/shared_users_sample.txt
@@ -1,4 +1,4 @@
-user1,2001
-user2,2002
-user3,2003
-user4,2004
+user1,2001,/fsx/users/user1
+user2,2002,/fsx/users/user2
+user3,2003,/fsx/users/user3
+user4,2004,/fsx/users/user4


### PR DESCRIPTION
*Issue #, if available:*
Adds the feature to specify the user home path during the lifecycle script

*Description of changes:*
In our use case we want to have the user home directories on the shared `/fsx` volume. This change adapts the script to help in that regard. The goal is to have an automated version of the script specified in [https://catalog.workshops.aws/sagemaker-hyperpod/en-US/04-advanced/01-multi-user](https://catalog.workshops.aws/sagemaker-hyperpod/en-US/04-advanced/01-multi-user)

This code change does the following:

- updates the create user script to allow specifying a custom home path (other than `/home/user`)
- adds the user to the docker group
- adds the user to the sudo group
- creates SSH key pairs in the home directory if there isn't already one
- changes the order in `lifecycle_script.py` such that user creation happens **AFTER** mounting of FSX and installation of docker


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
