### PR TITLE
Fix nan loss for training FSDP example with transformers version 4.31.0

### DIFF
--- a/3.test_cases/10.FSDP/1.distributed-training.sbatch
+++ b/3.test_cases/10.FSDP/1.distributed-training.sbatch
@@ -51,6 +51,7 @@ declare -a TRAINING_ARGS=(
     --num_layers=32 \ # 7b: 32 13b: 40 70b: 80
     --num_heads=32 \ # 7b: 32 13b: 40 70b: 64
     --model_type=llama_v2 \
+    --tokenizer="hf-internal-testing/llama-tokenizer" \
     --checkpoint_freq=50 \
     --validation_freq=500 \
     --checkpoint_dir=./checkpoints \

--- a/3.test_cases/10.FSDP/train.py
+++ b/3.test_cases/10.FSDP/train.py
@@ -45,7 +45,7 @@ def create_streaming_dataloaders(dataset,
                       val_batch_size=1, 
                       max_context_width=4096,
                       workers=4):
-    tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer)
     data = load_dataset(dataset, 'en', streaming=True).shuffle(42+global_rank)
     train_concat_dataset = ConcatTokensDataset(data['train'], tokenizer, max_context_width, True)
     val_concat_dataset = ConcatTokensDataset(data['validation'], tokenizer, max_context_width, True)
@@ -252,7 +252,7 @@ def main(args):
                                                           global_rank=global_rank, 
                                                           train_batch_size=args.train_batch_size, 
                                                           val_batch_size=args.val_batch_size, 
-                                                          max_context_width=4096,
+                                                          max_context_width=args.max_context_width,
                                                           workers=4)
     
     train(model, 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We observed a `nan` loss when training llama model with the FSDP example when the default tokenizer `EleutherAI/gpt-neox-20b` was used with `transformers v4.31.0`. This PR switches the tokenizer to `hf-interal-testing/llama-tokenizer` that fixes this issue. Tested with both `transformers` versions v4.31.0 and v4.36.0 (latest). 

Also fixed some argument parsing issues:
- Use `args.tokenizer` during tokenizer creation instead of the hardcoded value.
- Use `args.max_context_width` when creating dataloader


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
