### PR TITLE
Update to nemo-launcher 23.11

### DIFF
--- a/3.test_cases/2.nemo-launcher/0.NemoMegatron-aws-optimized.Dockerfile
+++ b/3.test_cases/2.nemo-launcher/0.NemoMegatron-aws-optimized.Dockerfile
@@ -3,11 +3,11 @@
 
 # DOCKER_BUILDKIT=1 docker build --progress plain -t aws-nemo-megatron:latest .
 
-FROM nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.08.03
+FROM nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.11
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV EFA_INSTALLER_VERSION=latest
-ENV AWS_OFI_NCCL_VERSION=1.7.3-aws
+ENV AWS_OFI_NCCL_VERSION=1.7.4-aws
 ENV NCCL_TESTS_VERSION=master
 
 RUN apt-get update -y
@@ -40,15 +40,15 @@ RUN apt-get install -y --allow-unauthenticated \
 
 # Uncomment below stanza to install the latest NCCL
 # Require efa-installer>=1.29.0 for nccl-2.19.0 to avoid libfabric gave NCCL error.
-#ENV NCCL_VERSION=2.19.3-1
-#RUN apt-get remove -y libnccl2 libnccl-dev \
-#    && cd /tmp \
-#    && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION} \
-#    && cd nccl \
-#    && make -j src.build BUILDDIR=/usr/local \
-#    # nvcc to target p5 and p4 instances
-#    NVCC_GENCODE="-gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_80,code=sm_80" \
-#    && rm -rf /tmp/nccl
+ENV NCCL_VERSION=2.19.4-1
+RUN apt-get remove -y libnccl2 libnccl-dev \
+   && cd /tmp \
+   && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION} \
+   && cd nccl \
+   && make -j src.build BUILDDIR=/usr/local \
+   # nvcc to target p5 and p4 instances
+   NVCC_GENCODE="-gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_80,code=sm_80" \
+   && rm -rf /tmp/nccl
 
 # EFA
 RUN apt-get update && \
@@ -87,8 +87,7 @@ ENV OMPI_MCA_pml=^cm,ucx            \
     OMPI_MCA_btl=tcp,self           \
     OMPI_MCA_btl_tcp_if_exclude=lo,docker0 \
     OPAL_PREFIX=/opt/amazon/openmpi \
-    NCCL_SOCKET_IFNAME=^docker,lo   \
-    FI_EFA_USE_HUGE_PAGE=0
+    NCCL_SOCKET_IFNAME=^docker,lo
 
 # NCCL-tests
 RUN git clone https://github.com/NVIDIA/nccl-tests.git /opt/nccl-tests \

--- a/3.test_cases/2.nemo-launcher/1.bmk-pretrain-gpt3-126m.sh
+++ b/3.test_cases/2.nemo-launcher/1.bmk-pretrain-gpt3-126m.sh
@@ -12,7 +12,7 @@ set -exo pipefail
 # 000: Modify this section to define pre-training configuration: model size,
 # number of nodes, max. pre-training steps, job's max. runtime.
 ################################################################################
-## Pre-train gpt3-126m on 2 nodes for 40 steps.
+## Pre-train gpt3-126m on 2 nodes for 100 steps.
 export MODEL_SIZE=126m
 export NUM_NODES=2
 export RUNTIME=30m

--- a/3.test_cases/2.nemo-launcher/1.bmk-pretrain-gpt3-126m.sh
+++ b/3.test_cases/2.nemo-launcher/1.bmk-pretrain-gpt3-126m.sh
@@ -45,13 +45,16 @@ CONT_RESULT_DIR=${WORKSPACE_CONT}/results
 CONT_TOKENIZER_DIR=${WORKSPACE_CONT}/data/bpe
 
 # Dev/test feature (off by default) to force each pre-training run outputs to a separate directory.
-: "${UNIQUE_OUTPUT_DIR:=0}"
-if [[ ${UNIQUE_OUTPUT_DIR} -eq 1 ]]; then
+: "${BMK_MODE:=0}"
+if [[ ${BMK_MODE} -eq 1 ]]; then
     # For debugging: each run has its own output dir.
     TIMESTAMP=$(date +'%Y%m%d-%H%M%Sutc-%N')-$((RANDOM))
     CONT_RESULT_DIR=${CONT_RESULT_DIR}-${TIMESTAMP}
 
-    BMK_ARGS+=(base_results_dir=${CONT_RESULT_DIR})
+    BMK_ARGS+=(
+        base_results_dir=${CONT_RESULT_DIR}
+        training.run.dependency=null
+    )
 
     echo "
     ####################

--- a/3.test_cases/2.nemo-launcher/2.bmk-pretrain-gpt3-5b.sh
+++ b/3.test_cases/2.nemo-launcher/2.bmk-pretrain-gpt3-5b.sh
@@ -12,7 +12,7 @@ set -exo pipefail
 # 000: Modify this section to define pre-training configuration: model size,
 # number of nodes, max. pre-training steps, job's max. runtime.
 ################################################################################
-## Pre-train gpt3-5b on 2 nodes for 5 steps
+## Pre-train gpt3-5b on 2 nodes for 30 steps
 export MODEL=gpt3
 export MODEL_SIZE=5b
 export NUM_NODES=2
@@ -21,6 +21,10 @@ export MAX_STEPS=30
 export MBS=2 # setting for A100 80GB (p4de, p5), reduce to 1 for A100 40GB (p4d)
 declare -a MODEL_ARGS=(
     training.model.micro_batch_size=${MBS}
+
+    ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
+    #training.model.transformer_engine=True
+    #training.model.fp8=True
 )
 
 

--- a/3.test_cases/2.nemo-launcher/2.bmk-pretrain-gpt3-5b.sh
+++ b/3.test_cases/2.nemo-launcher/2.bmk-pretrain-gpt3-5b.sh
@@ -53,13 +53,16 @@ CONT_RESULT_DIR=${WORKSPACE_CONT}/results
 CONT_TOKENIZER_DIR=${WORKSPACE_CONT}/data/bpe
 
 # Dev/test feature (off by default) to force each pre-training run outputs to a separate directory.
-: "${UNIQUE_OUTPUT_DIR:=0}"
-if [[ ${UNIQUE_OUTPUT_DIR} -eq 1 ]]; then
+: "${BMK_MODE:=0}"
+if [[ ${BMK_MODE} -eq 1 ]]; then
     # For debugging: each run has its own output dir.
     TIMESTAMP=$(date +'%Y%m%d-%H%M%Sutc-%N')-$((RANDOM))
     CONT_RESULT_DIR=${CONT_RESULT_DIR}-${TIMESTAMP}
 
-    BMK_ARGS+=(base_results_dir=${CONT_RESULT_DIR})
+    BMK_ARGS+=(
+        base_results_dir=${CONT_RESULT_DIR}
+        training.run.dependency=null
+    )
 
     echo "
     ####################

--- a/3.test_cases/2.nemo-launcher/2.bmk-pretrain-gpt3-5b.sh
+++ b/3.test_cases/2.nemo-launcher/2.bmk-pretrain-gpt3-5b.sh
@@ -21,15 +21,6 @@ export MAX_STEPS=30
 export MBS=2 # setting for A100 80GB (p4de, p5), reduce to 1 for A100 40GB (p4d)
 declare -a MODEL_ARGS=(
     training.model.micro_batch_size=${MBS}
-
-    # When node_count < 8, needs full activations checkpointing. These're settings found on
-    # Nemo repo's Jenkin script.
-    #
-    # Below settings is similar to 22.09, except that 22.09 funnily didn't OOM with
-    # activations_checkpoint_num_layers=0.
-    training.model.activations_checkpoint_granularity='full'
-    training.model.activations_checkpoint_method='block'
-    training.model.activations_checkpoint_num_layers=1
 )
 
 

--- a/3.test_cases/2.nemo-launcher/3.bmk-pretrain-gpt3-40b.sh
+++ b/3.test_cases/2.nemo-launcher/3.bmk-pretrain-gpt3-40b.sh
@@ -22,10 +22,9 @@ export MBS=1   # Down from the default value (=4) to run on 2x p4de (16x A100-80
 declare -a MODEL_ARGS=(
     training.model.micro_batch_size=${MBS}
 
-    # TE is not applicable for A100 (p4d or p4de).
-    # On p5 instances, comment or remove below stanza.
-    training.model.transformer_engine=False
-    training.model.ub_tp_comm_overlap=False
+    ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
+    #training.model.transformer_engine=True
+    #training.model.fp8=True
 )
 
 

--- a/3.test_cases/2.nemo-launcher/3.bmk-pretrain-gpt3-40b.sh
+++ b/3.test_cases/2.nemo-launcher/3.bmk-pretrain-gpt3-40b.sh
@@ -53,13 +53,16 @@ CONT_RESULT_DIR=${WORKSPACE_CONT}/results
 CONT_TOKENIZER_DIR=${WORKSPACE_CONT}/data/bpe
 
 # Dev/test feature (off by default) to force each pre-training run outputs to a separate directory.
-: "${UNIQUE_OUTPUT_DIR:=0}"
-if [[ ${UNIQUE_OUTPUT_DIR} -eq 1 ]]; then
+: "${BMK_MODE:=0}"
+if [[ ${BMK_MODE} -eq 1 ]]; then
     # For debugging: each run has its own output dir.
     TIMESTAMP=$(date +'%Y%m%d-%H%M%Sutc-%N')-$((RANDOM))
     CONT_RESULT_DIR=${CONT_RESULT_DIR}-${TIMESTAMP}
 
-    BMK_ARGS+=(base_results_dir=${CONT_RESULT_DIR})
+    BMK_ARGS+=(
+        base_results_dir=${CONT_RESULT_DIR}
+        training.run.dependency=null
+    )
 
     echo "
     ####################

--- a/3.test_cases/2.nemo-launcher/3.bmk-pretrain-gpt3-40b.sh
+++ b/3.test_cases/2.nemo-launcher/3.bmk-pretrain-gpt3-40b.sh
@@ -18,16 +18,12 @@ export MODEL_SIZE=40b
 export NUM_NODES=2
 export RUNTIME=4h
 export MAX_STEPS=5
-export MBS=1 # setting for A100 80GB (p4de, p5), reduce to 1 for A100 40GB (p4d)
+export MBS=1   # Down from the default value (=4) to run on 2x p4de (16x A100-80GB GPUs)
 declare -a MODEL_ARGS=(
     training.model.micro_batch_size=${MBS}
 
-    # Activation checkpointing
-    training.model.activations_checkpoint_granularity='full'
-    training.model.activations_checkpoint_method='block'
-    training.model.activations_checkpoint_num_layers=1
-
-    # Not applicable for A100
+    # TE is not applicable for A100 (p4d or p4de).
+    # On p5 instances, comment or remove below stanza.
     training.model.transformer_engine=False
     training.model.ub_tp_comm_overlap=False
 )

--- a/3.test_cases/2.nemo-launcher/4.bmk-pretrain-gpt3-175b.sh
+++ b/3.test_cases/2.nemo-launcher/4.bmk-pretrain-gpt3-175b.sh
@@ -50,13 +50,16 @@ CONT_RESULT_DIR=${WORKSPACE_CONT}/results
 CONT_TOKENIZER_DIR=${WORKSPACE_CONT}/data/bpe
 
 # Dev/test feature (off by default) to force each pre-training run outputs to a separate directory.
-: "${UNIQUE_OUTPUT_DIR:=0}"
-if [[ ${UNIQUE_OUTPUT_DIR} -eq 1 ]]; then
+: "${BMK_MODE:=0}"
+if [[ ${BMK_MODE} -eq 1 ]]; then
     # For debugging: each run has its own output dir.
     TIMESTAMP=$(date +'%Y%m%d-%H%M%Sutc-%N')-$((RANDOM))
     CONT_RESULT_DIR=${CONT_RESULT_DIR}-${TIMESTAMP}
 
-    BMK_ARGS+=(base_results_dir=${CONT_RESULT_DIR})
+    BMK_ARGS+=(
+        base_results_dir=${CONT_RESULT_DIR}
+        training.run.dependency=null
+    )
 
     echo "
     ####################

--- a/3.test_cases/2.nemo-launcher/4.bmk-pretrain-gpt3-175b.sh
+++ b/3.test_cases/2.nemo-launcher/4.bmk-pretrain-gpt3-175b.sh
@@ -19,12 +19,9 @@ export NUM_NODES=16
 export RUNTIME=4h
 export MAX_STEPS=5
 declare -a MODEL_ARGS=(
-    training.model.micro_batch_size=${MBS}
-
-    # TE is not applicable for A100 (p4d or p4de).
-    # On p5 instances, comment or remove below stanza.
-    training.model.transformer_engine=False
-    training.model.ub_tp_comm_overlap=False
+    ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
+    #training.model.transformer_engine=True
+    #training.model.fp8=True
 )
 
 

--- a/3.test_cases/2.nemo-launcher/4.bmk-pretrain-gpt3-175b.sh
+++ b/3.test_cases/2.nemo-launcher/4.bmk-pretrain-gpt3-175b.sh
@@ -18,16 +18,11 @@ export MODEL_SIZE=175b
 export NUM_NODES=16
 export RUNTIME=4h
 export MAX_STEPS=5
-export MBS=2
 declare -a MODEL_ARGS=(
     training.model.micro_batch_size=${MBS}
 
-    # Activation checkpointing
-    training.model.activations_checkpoint_granularity='full'
-    training.model.activations_checkpoint_method='block'
-    training.model.activations_checkpoint_num_layers=1
-
-    # Not applicable for A100
+    # TE is not applicable for A100 (p4d or p4de).
+    # On p5 instances, comment or remove below stanza.
     training.model.transformer_engine=False
     training.model.ub_tp_comm_overlap=False
 )

--- a/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
+++ b/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
@@ -22,7 +22,6 @@ declare -a MODEL_ARGS=(
     training.model.tokenizer.model=${TARGET_PATH}/data/llama2/tokenizer.model
 
     ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
-    #training.model.transformer_engine=True
     #training.model.fp8=True
     #training.model.fp8_hybrid=True
 )

--- a/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
+++ b/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
@@ -18,19 +18,8 @@ export MODEL_SIZE=llama2_7b
 export NUM_NODES=2
 export RUNTIME=4h
 export MAX_STEPS=30
-export MBS=2 # setting for A100 80GB (p4de, p5), reduce to 1 for A100 40GB (p4d)
 declare -a MODEL_ARGS=(
-    training.model.micro_batch_size=${MBS}
-
     training.model.tokenizer.model=${TARGET_PATH}/data/llama2/tokenizer.model
-    # When node_count < 8, needs full activations checkpointing. These're settings found on
-    # Nemo repo's Jenkin script.
-    #
-    # Below settings is similar to 22.09, except that 22.09 funnily didn't OOM with
-    # activations_checkpoint_num_layers=0.
-    training.model.activations_checkpoint_granularity='full'
-    training.model.activations_checkpoint_method='block'
-    training.model.activations_checkpoint_num_layers=1
 )
 
 

--- a/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
+++ b/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
@@ -24,6 +24,7 @@ declare -a MODEL_ARGS=(
     ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
     #training.model.transformer_engine=True
     #training.model.fp8=True
+    #training.model.fp8_hybrid=True
 )
 
 

--- a/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
+++ b/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
@@ -12,7 +12,7 @@ set -exo pipefail
 # 000: Modify this section to define pre-training configuration: model size,
 # number of nodes, max. pre-training steps, job's max. runtime.
 ################################################################################
-## Pre-train llama2-7b on 2 nodes for 5 steps
+## Pre-train llama2-7b on 2 nodes for 30 steps
 export MODEL=llama
 export MODEL_SIZE=llama2_7b
 export NUM_NODES=2
@@ -20,6 +20,10 @@ export RUNTIME=4h
 export MAX_STEPS=30
 declare -a MODEL_ARGS=(
     training.model.tokenizer.model=${TARGET_PATH}/data/llama2/tokenizer.model
+
+    ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
+    #training.model.transformer_engine=True
+    #training.model.fp8=True
 )
 
 

--- a/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
+++ b/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
@@ -55,13 +55,16 @@ CONT_RESULT_DIR=${WORKSPACE_CONT}/results
 
 
 # Dev/test feature (off by default) to force each pre-training run outputs to a separate directory.
-: "${UNIQUE_OUTPUT_DIR:=0}"
-if [[ ${UNIQUE_OUTPUT_DIR} -eq 1 ]]; then
+: "${BMK_MODE:=0}"
+if [[ ${BMK_MODE} -eq 1 ]]; then
     # For debugging: each run has its own output dir.
     TIMESTAMP=$(date +'%Y%m%d-%H%M%Sutc-%N')-$((RANDOM))
     CONT_RESULT_DIR=${CONT_RESULT_DIR}-${TIMESTAMP}
 
-    BMK_ARGS+=(base_results_dir=${CONT_RESULT_DIR})
+    BMK_ARGS+=(
+        base_results_dir=${CONT_RESULT_DIR}
+        training.run.dependency=null
+    )
 
     echo "
     ####################

--- a/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
+++ b/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
@@ -12,27 +12,20 @@ set -exo pipefail
 # 000: Modify this section to define pre-training configuration: model size,
 # number of nodes, max. pre-training steps, job's max. runtime.
 ################################################################################
-## Pre-train llama2-7b on 2 nodes for 5 steps
+## Pre-train llama2-7b on 16 nodes for 5 steps
 export MODEL=llama
 export MODEL_SIZE=llama2_70b
 export NUM_NODES=16
 export TIME_LIMIT="7-00:00:00"
-export MAX_STEPS=100
+export MAX_STEPS=5
 
 declare -a MODEL_ARGS=(
-    training.model.micro_batch_size=${MBS}
-    training.model.tensor_model_parallel_size=4
-    training.model.pipeline_model_parallel_size=4
-    training.model.virtual_pipeline_model_parallel_size=20
-    training.model.overlap_p2p_comm=True
-    training.model.batch_p2p_comm=False
+    training.model.tokenizer.model=${TARGET_PATH}/data/llama2/tokenizer.model
     training.model.gc_interval=0
 
-    training.model.tokenizer.model=${TARGET_PATH}/data/llama2/tokenizer.model
-
-    ## Not applicable for A100
-    #training.model.transformer_engine=False
-    #training.model.ub_tp_comm_overlap=False
+    ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
+    #training.model.transformer_engine=True
+    #training.model.fp8=True
 )
 
 

--- a/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
+++ b/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
@@ -26,6 +26,7 @@ declare -a MODEL_ARGS=(
     ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
     #training.model.transformer_engine=True
     #training.model.fp8=True
+    #training.model.fp8_hybrid=True
 )
 
 

--- a/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
+++ b/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
@@ -43,8 +43,6 @@ declare -a BMK_ARGS=(
     training.exp_manager.create_checkpoint_callback=False
     training.exp_manager.resume_if_exists=False
 
-    ################################
-
     # https://github.com/NVIDIA/NeMo/pull/6181/files
     training.model.data.data_impl=mock
     training.model.data.data_prefix=[]
@@ -59,13 +57,16 @@ CONT_RESULT_DIR=${WORKSPACE_CONT}/results-v2
 CONT_TOKENIZER_DIR=${WORKSPACE_CONT}/data/bpe
 
 # Dev/test feature (off by default) to force each pre-training run outputs to a separate directory.
-: "${UNIQUE_OUTPUT_DIR:=0}"
-if [[ ${UNIQUE_OUTPUT_DIR} -eq 1 ]]; then
+: "${BMK_MODE:=0}"
+if [[ ${BMK_MODE} -eq 1 ]]; then
     # For debugging: each run has its own output dir.
     TIMESTAMP=$(date +'%Y%m%d-%H%M%Sutc-%N')-$((RANDOM))
     CONT_RESULT_DIR=${CONT_RESULT_DIR}-${TIMESTAMP}
 
-    BMK_ARGS+=(base_results_dir=${CONT_RESULT_DIR})
+    BMK_ARGS+=(
+        base_results_dir=${CONT_RESULT_DIR}
+        training.run.dependency=null
+    )
 
     echo "
     ####################

--- a/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
+++ b/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
@@ -24,7 +24,6 @@ declare -a MODEL_ARGS=(
     training.model.gc_interval=0
 
     ## Uncomment below to enable fp8 training (Transformers Engine) on p5 instances (H100 GPUs)
-    #training.model.transformer_engine=True
     #training.model.fp8=True
     #training.model.fp8_hybrid=True
 )

--- a/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
+++ b/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
@@ -18,7 +18,6 @@ export MODEL_SIZE=llama2_70b
 export NUM_NODES=16
 export TIME_LIMIT="7-00:00:00"
 export MAX_STEPS=100
-export MBS=1
 
 declare -a MODEL_ARGS=(
     training.model.micro_batch_size=${MBS}
@@ -31,11 +30,6 @@ declare -a MODEL_ARGS=(
 
     training.model.tokenizer.model=${TARGET_PATH}/data/llama2/tokenizer.model
 
-    ## Activation checkpointing
-    #training.model.activations_checkpoint_granularity='full'
-    #training.model.activations_checkpoint_method='block'
-    #training.model.activations_checkpoint_num_layers=1
-    #
     ## Not applicable for A100
     #training.model.transformer_engine=False
     #training.model.ub_tp_comm_overlap=False

--- a/3.test_cases/2.nemo-launcher/README.md
+++ b/3.test_cases/2.nemo-launcher/README.md
@@ -164,7 +164,7 @@ This section assumes that you went through the previous sections and 1/ retrieve
         └── nemo_log_globalrank-*.txt               # Log of each rank
     ```
 
-    Please note that except for `log-nemo-megatron-gpt3_126m_<JOB_ID>.out`, the other files will be overridden when you launch another pre-training of that same model size. To completely separate the output among jobs, edit `TEST_CASE_PATH/bmk-pretrain-gpt3-126m.sh` and uncomment the `#export UNIQUE_OUTPUT_DIR=1` line to produce this output dir instead:
+    Please note that except for `log-nemo-megatron-gpt3_126m_<JOB_ID>.out`, the other files will be overridden when you launch another pre-training of that same model size. To completely separate the output among jobs, run the script in benchmark mode: `BMK_MODE=1 $TEST_CASE_PATH/bmk-pretrain-gpt3-126m.sh` which produces output dir `$TARGET_PATH/results-<YYYYMMDD>-<HHMMSS>utc-<RANDOM_STR>/gpt3_126m/`.
 
 4. You can use Slurm command `squeue` to monitor the job status in the queue. The ample output below shows a `nemo-megatron` job with job id `1234` is in running state (`ST` = `R`). A queued job will have state `ST` = `PD` (pending). Please refer to the complete of job states in this [Slurm documentation](https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES).
 

--- a/3.test_cases/2.nemo-launcher/README.md
+++ b/3.test_cases/2.nemo-launcher/README.md
@@ -19,13 +19,13 @@ Table of contents:
 The following pre-requisites are needed to run this example:
 
 - You are using p4de.24xlarge instances with A100 80GB or newer, with at least 80GB of memory per GPU.
-- You have access to the base image [`nemofw-training`](https://registry.ngc.nvidia.com/orgs/ea-bignlp/containers/bignlp-training) is available through NVIDIA's open-beta [here](https://developer.nvidia.com/nemo-framework-open-beta).
+- You have access to the base image [NeMo Framework Training](https://registry.ngc.nvidia.com/orgs/ea-bignlp/teams/ga-participants/containers/nemofw-training). To gain access to this image, go to [Get Access to NeMo Framework](https://developer.nvidia.com/nemo-framework) to enroll to organization/team `ea-bignlp/ga-participant`.
 - Docker, [Enroot](https://github.com/NVIDIA/enroot) and [Pixys](https://github.com/NVIDIA/pyxis) installed on the cluster and available on all nodes. It is assumed you are using a Custom AMI ([example](../../2.ami_and_containers/1.amazon_machine_image))
 
 You will need to setup the following environment variables before running the scripts. :
 
 ```bash
-export NEMO_VERSION=23.08.03
+export NEMO_VERSION=23.11
 export REPO=aws-nemo-megatron
 export TAG=$NEMO_VERSION
 export TARGET_PATH=/fsx/nemo-launcher-$NEMO_VERSION   # must be a shared filesystem
@@ -76,10 +76,10 @@ cd $TARGET_PATH
 enroot start --mount $TARGET_PATH:/workspace/mount_dir \
              --env NVIDIA_VISIBLE_DEVICES=void \
              $ENROOT_IMAGE \
-             cp -a /opt/NeMo-Megatron-Launcher/launcher_scripts /opt/NeMo-Megatron-Launcher/auto_configurator /opt/nemo-data-curator /opt/nemo-rlhf /workspace/mount_dir/
+             cp -a /opt/NeMo-Megatron-Launcher/launcher_scripts /opt/NeMo-Megatron-Launcher/auto_configurator /opt/nemo-data-curator /workspace/mount_dir/
 ```
 
-The `NVIDIA_VISIBLE_DEVICES` variable is set to void to prevent the process to check for the Nvidia driver presence (since we don't need GPUs here).
+The `NVIDIA_VISIBLE_DEVICES` variable is set to `void` to prevent the process to check for the Nvidia driver presence (since we don't need GPUs here).
 
 3. Install the NemoMegatron requirements in a Python VirtualEnv by running the set of commands below.
 

--- a/3.test_cases/2.nemo-launcher/conf.template/config.yaml
+++ b/3.test_cases/2.nemo-launcher/conf.template/config.yaml
@@ -40,6 +40,9 @@ env_vars:
   TRANSFORMER_OFFLINE: 1
   NCCL_LAUNCH_MODE: parallel
   NCCL_ASYNC_ERROR_HANDLING: 1
+  NCCL_NVLS_ENABLE: 0
+  NCCL_AVOID_RECORD_STREAMS: 1        # torch<2.2
+  TORCH_NCCL_AVOID_RECORD_STREAMS: 1  # torch>=2.2
 
 # GPU Mapping
 numa_mapping:

--- a/3.test_cases/2.nemo-launcher/conf.template/config.yaml
+++ b/3.test_cases/2.nemo-launcher/conf.template/config.yaml
@@ -64,3 +64,5 @@ ia3_learning_config: ${hydra:runtime.choices.ia3_learning}
 evaluation_config: ${hydra:runtime.choices.evaluation}
 conversion_config: ${hydra:runtime.choices.conversion}
 export_config: ${hydra:runtime.choices.export}
+rlhf_rm_config: ${hydra:runtime.choices.rlhf_rm}
+rlhf_ppo_config: ${hydra:runtime.choices.rlhf_ppo}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- update Dockerfile
- update transformer engine (fp8) flags
- backport `conf/config.yaml` from NVidia upstream repo
- clean-up flags; notably, do not repeat default flags.
- default activation checkpointing no longer OOM on small nodes
- fix `llama2-7b` to work out-of-the-box on 2x `p4de.24xlarge` (80GB/GPU)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
