### PR TITLE
MIT-0

### DIFF
--- a/1.architectures/0.s3/0.private-bucket.yaml
+++ b/1.architectures/0.s3/0.private-bucket.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: This CloudFormation template to create S3 Bucket

--- a/1.architectures/1.vpc_network/1.vpc-multi-az.yaml
+++ b/1.architectures/1.vpc_network/1.vpc-multi-az.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >

--- a/1.architectures/1.vpc_network/2.vpc-one-az.yaml
+++ b/1.architectures/1.vpc_network/2.vpc-one-az.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >

--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de-base.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de-base.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 Imds:
   ImdsSupport: v2.0

--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de_batch-inference-g5_custom_ami.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de_batch-inference-g5_custom_ami.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 Imds:
   ImdsSupport: v2.0

--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de_custom_ami.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de_custom_ami.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 Imds:
   ImdsSupport: v2.0

--- a/1.architectures/2.aws-parallelcluster/distributed-training-p4de_postinstall_scripts.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-p4de_postinstall_scripts.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 Imds:
   ImdsSupport: v2.0

--- a/1.architectures/2.aws-parallelcluster/distributed-training-trn1_custom_ami.yaml
+++ b/1.architectures/2.aws-parallelcluster/distributed-training-trn1_custom_ami.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 # For additional examples please refer to this [Github repository](https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/blob/master/examples/jobs/neuronx-nemo-megatron-llamav2-job.md) from aws-neuron.
 

--- a/1.architectures/3.aws-batch/0.aws-batch-distributed-training.yaml
+++ b/1.architectures/3.aws-batch/0.aws-batch-distributed-training.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >

--- a/1.architectures/5.sagemaker-hyperpod/2.SageMakerVPC.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/2.SageMakerVPC.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >

--- a/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 declare -a HELP=(
     "[-h|--help]"

--- a/2.ami_and_containers/2.docker/0.nvcr-pytorch-aws.dockerfile
+++ b/2.ami_and_containers/2.docker/0.nvcr-pytorch-aws.dockerfile
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 ####################################################################################################
 # This is a sample Dockerfile, with optional stanzas. Please read through this Dockerfile,

--- a/3.test_cases/1.megatron-lm/0.distributed-training.Dockerfile
+++ b/3.test_cases/1.megatron-lm/0.distributed-training.Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 FROM nvcr.io/nvidia/pytorch:23.09-py3
 

--- a/3.test_cases/1.megatron-lm/1.data-preprocessing.sbatch
+++ b/3.test_cases/1.megatron-lm/1.data-preprocessing.sbatch
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 #SBATCH -N 1 # number of nodes we want
 #SBATCH --exclusive # job has exclusive use of the resource, no sharing

--- a/3.test_cases/1.megatron-lm/2.distributed-training.sbatch
+++ b/3.test_cases/1.megatron-lm/2.distributed-training.sbatch
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 #SBATCH --nodes=2 # number of nodes to use, 2 p4d(e) = 16 A100 GPUs
 #SBATCH --job-name=megatron_gpt # name of your job

--- a/3.test_cases/2.nemo-launcher/0.NemoMegatron-aws-optimized.Dockerfile
+++ b/3.test_cases/2.nemo-launcher/0.NemoMegatron-aws-optimized.Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 # DOCKER_BUILDKIT=1 docker build --progress plain -t aws-nemo-megatron:latest .
 

--- a/3.test_cases/2.nemo-launcher/1.bmk-pretrain-gpt3-126m.sh
+++ b/3.test_cases/2.nemo-launcher/1.bmk-pretrain-gpt3-126m.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 set -exo pipefail
 [[ -z "${TARGET_PATH}" ]] \

--- a/3.test_cases/2.nemo-launcher/2.bmk-pretrain-gpt3-5b.sh
+++ b/3.test_cases/2.nemo-launcher/2.bmk-pretrain-gpt3-5b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 set -exo pipefail
 [[ -z "${TARGET_PATH}" ]] \

--- a/3.test_cases/2.nemo-launcher/3.bmk-pretrain-gpt3-40b.sh
+++ b/3.test_cases/2.nemo-launcher/3.bmk-pretrain-gpt3-40b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 set -exo pipefail
 [[ -z "${TARGET_PATH}" ]] \

--- a/3.test_cases/2.nemo-launcher/4.bmk-pretrain-gpt3-175b.sh
+++ b/3.test_cases/2.nemo-launcher/4.bmk-pretrain-gpt3-175b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 set -exo pipefail
 [[ -z "${TARGET_PATH}" ]] \

--- a/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
+++ b/3.test_cases/2.nemo-launcher/5.bmk-pretrain-llama-7b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 set -exo pipefail
 [[ -z "${TARGET_PATH}" ]] \

--- a/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
+++ b/3.test_cases/2.nemo-launcher/6.bmk-pretrain-llama-70b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 set -exo pipefail
 [[ -z "${TARGET_PATH}" ]] \

--- a/4.validation_and_observability/0.nccl-tests/0.nccl-tests.Dockerfile
+++ b/4.validation_and_observability/0.nccl-tests/0.nccl-tests.Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
 ARG EFA_INSTALLER_VERSION=1.28.0

--- a/4.validation_and_observability/0.nccl-tests/1.nccl-tests.sbatch
+++ b/4.validation_and_observability/0.nccl-tests/1.nccl-tests.sbatch
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 #SBATCH -N 2 # number of nodes to use, 24 p4d(e) = 192 A100 GPUs
 #SBATCH --job-name=megatron_gpt # name of your job

--- a/4.validation_and_observability/0.nccl-tests/2.nccl-3collectives.sbatch
+++ b/4.validation_and_observability/0.nccl-tests/2.nccl-3collectives.sbatch
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 #SBATCH -N 2 # number of nodes to use, 24 p4d(e) = 192 A100 GPUs
 #SBATCH --job-name=megatron_gpt # name of your job

--- a/4.validation_and_observability/0.nccl-tests/3.nccl-validate.sbatch
+++ b/4.validation_and_observability/0.nccl-tests/3.nccl-validate.sbatch
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 #SBATCH -N 2 # number of nodes to use, 24 p4d(e) = 192 A100 GPUs
 #SBATCH --job-name=megatron_gpt # name of your job

--- a/4.validation_and_observability/1.pytorch-env-validation/0.pytorch-screen.Dockerfile
+++ b/4.validation_and_observability/1.pytorch-env-validation/0.pytorch-screen.Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 ARG AWS_REGION=us-west-2
 

--- a/4.validation_and_observability/1.pytorch-env-validation/1.torch-screen.sbatch
+++ b/4.validation_and_observability/1.pytorch-env-validation/1.torch-screen.sbatch
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 #SBATCH -N 2 # number of nodes to run the scrip on, use 2 here
 #SBATCH --job-name=megatron_gpt # name of your job

--- a/4.validation_and_observability/1.pytorch-env-validation/pytorch-screen.py
+++ b/4.validation_and_observability/1.pytorch-env-validation/pytorch-screen.py
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 import torch
 

--- a/4.validation_and_observability/efa-versions.sh
+++ b/4.validation_and_observability/efa-versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 
 # Fetch software versions related to EFA.
 # Currently only tested on Ubuntu 20.04


### PR DESCRIPTION
Switch all the code headers to the repo license `MIT-0`. 

Some of the code i.e. https://github.com/aws-samples/awsome-distributed-training/blob/4db1238b3512fb9c5815c8e227692699e0736feb/3.test_cases/11.modelparallel/data/prep/_prepare_nemo_megatron_dataset.py#L1 needs to maintain the original Apache-2.0 license and can't be switched.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
