### PR TITLE
SMHP: Docker and enroot to use /opt/dlami/nvme if available.

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/enroot.conf
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/enroot.conf
@@ -14,7 +14,7 @@ ENROOT_DATA_PATH           /tmp/enroot/data/user-$(id -u)
 #ENROOT_ZSTD_OPTIONS        -1
 
 # Options passed to mksquashfs to produce container images.
-ENROOT_SQUASH_OPTIONS -noI -noD -noF -noX -no-duplicates
+ENROOT_SQUASH_OPTIONS -comp lzo -noI -noD -noF -noX -no-duplicates
 
 # Make the container root filesystem writable by default.
 ENROOT_ROOTFS_WRITABLE     yes

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
@@ -8,8 +8,8 @@ echo "
 ###################################
 "
 
-apt-get -y update
-apt-get -y install \
+apt-get -y -o DPkg::Lock::Timeout=120 update
+apt-get -y -o DPkg::Lock::Timeout=120 install \
     ca-certificates \
     curl \
     gnupg \
@@ -19,8 +19,8 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/
 echo \
 "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
 $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get -y update
-apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+apt-get -y -o DPkg::Lock::Timeout=120 update
+apt-get -y -o DPkg::Lock::Timeout=120 install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 chgrp docker $(which docker)
 chmod g+s $(which docker)
 systemctl enable docker.service
@@ -31,7 +31,27 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dear
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
     sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-sudo apt-get install -y nvidia-container-toolkit
+sudo apt-get install -y -o DPkg::Lock::Timeout=120 nvidia-container-toolkit
 
 # add user to docker group
 sudo usermod -aG docker ubuntu
+
+
+# Opportunistically use /opt/dlami/nvme if present. Let's be extra careful in the probe.
+# See: https://github.com/aws-samples/awsome-distributed-training/issues/127
+#
+# Docker workdir doesn't like Lustre. Tried with storage driver overlay2, fuse-overlayfs, & vfs.
+if [[ $(mount | grep /opt/dlami/nvme) ]]; then
+    cat <<EOL >> /etc/docker/daemon.json
+{
+    "data-root": "/opt/dlami/nvme/docker/data-root"
+}
+EOL
+
+    sed -i \
+        's|^\[Service\]$|[Service]\nEnvironment="DOCKER_TMPDIR=/opt/dlami/nvme/docker/tmp"|' \
+        /usr/lib/systemd/system/docker.service
+fi
+
+systemctl daemon-reload
+systemctl restart docker

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
@@ -3,6 +3,7 @@
 set -e
 
 BIN_DIR=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
+
 ################################################################################
 # Install enroot & pyxis
 ################################################################################
@@ -12,6 +13,15 @@ if [[ -f /opt/slurm/etc/cgroup.conf ]]; then
   grep ^ConstrainDevices /opt/slurm/etc/cgroup.conf &> /dev/null \
 	  || echo "ConstrainDevices=yes" >> /opt/slurm/etc/cgroup.conf
 fi
+
+apt-get -y -o DPkg::Lock::Timeout=120 install squashfs-tools parallel libnvidia-container-tools
+
+## These are needed for `enroot start xxx.sqsh`, but on SMHP, `enroot start xxx.sqsh` hangs, hence
+## not needed.
+##
+## The hang behavior may be the same as https://github.com/NVIDIA/enroot/issues/130 and the solution
+## is to `enroot create xxx.sqsh ; enroot start xxx ; enroot remove xxx`.
+#apt-get -y -o DPkg::Lock::Timeout=120 install fuse-overlayfs squashfuse
 
 SLURM_INSTALL_DIR='/opt/slurm'
 PYXIS_TMP_DIR='/tmp/pyxis'
@@ -45,3 +55,35 @@ ln -fs /usr/local/share/pyxis/pyxis.conf $SLURM_INSTALL_DIR/etc/plugstack.conf.d
 mkdir -p /run/pyxis/ /tmp/enroot/data /opt/enroot/
 chmod 777 -R /tmp/enroot /opt/enroot
 ################################################################################
+
+
+# Opportunistically use /opt/dlami/nvme if present. Let's be extra careful in the probe.
+#
+# Note: ENROOT_TEMP_PATH on Lustre throws "Unrecognised xattr prefix lustre.lov".
+# See: https://github.com/aws-samples/awsome-distributed-training/issues/127
+if [[ $(mount | grep /opt/dlami/nvme) ]]; then
+    sed -i \
+        -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/user-$(id -u)|' \
+        -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/dlami/nvme/enroot|' \
+        -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/data/user-$(id -u)|' \
+        -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/dlami/nvme/tmp|' \
+        /etc/enroot/enroot.conf
+
+    mkdir -p /opt/dlami/nvme/tmp/enroot/
+    chmod 1777 /opt/dlami/nvme/tmp
+    chmod 1777 /opt/dlami/nvme/tmp/enroot/
+
+    #mkdir -p /opt/dlami/nvme/tmp/enroot/data/
+    #chmod 1777 /opt/dlami/nvme/tmp/enroot/data/
+
+    # mkdir -p /opt/dlami/nvme/enroot
+    # chmod 1777 /opt/dlami/nvme/enroot
+
+fi
+
+# Use /fsx for enroot cache, if available. Let's be extra careful in the probe.
+if [[ $(mount | grep /fsx) ]]; then
+    sed -i -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/fsx/enroot|' /etc/enroot/enroot.conf
+    mkdir -p /fsx/enroot
+    chmod 1777 /fsx/enroot
+fi


### PR DESCRIPTION
Also increase apt timeout on these lcc scripts

*Issue #, if available:* #127, and hopefully #96

*Description of changes:* Docker and enroot to utilize `/opt/dlami/nvme` whenever possible. Also increase `apt` timeout on their LCC script as per [this comment on issue 96](https://github.com/aws-samples/awsome-distributed-training/issues/96#issuecomment-1890297370)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
