### PR TITLE
Restart slurm daemons after pyxis installed

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
@@ -87,3 +87,6 @@ if [[ $(mount | grep /fsx) ]]; then
     mkdir -p /fsx/enroot
     chmod 1777 /fsx/enroot
 fi
+
+systemctl is-active --quiet slurmctld && systemctl restart slurmctld || echo "This instance does not run slurmctld"
+systemctl is-active --quiet slurmd    && systemctl restart slurmd    || echo "This instance does not run slurmd"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* sometimes slurm daemons need to be restarted for pyxis plugin to be effective. I couldn't deterministically reproduce, it just happened sometimes, hence this PR proposes to always restart the Slurm daemons after pyxis is installed, to make sure the cluster is ready to run containerized jobs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
