### PR TITLE
Revert megatron-lm parent image to 23.09

### DIFF
--- a/3.test_cases/1.megatron-lm/0.distributed-training.Dockerfile
+++ b/3.test_cases/1.megatron-lm/0.distributed-training.Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-FROM nvcr.io/nvidia/pytorch:24.01-py3
+FROM nvcr.io/nvidia/pytorch:23.09-py3
 
 ARG EFA_INSTALLER_VERSION=1.30.0
 ARG AWS_OFI_NCCL_VERSION=v1.7.4-aws
@@ -16,7 +16,7 @@ RUN apt-get remove -y --allow-change-held-packages \
 
 RUN rm -rf /opt/hpcx/ompi \
     && rm -rf /usr/local/mpi \
-    && rm -rf /opt/hpcx/nccl_rdma_sharp_plugin \
+    && rm -rf /usr/local/ucx \
     && ldconfig
 
 RUN DEBIAN_FRONTEND=noninteractive apt install -y --allow-unauthenticated \


### PR DESCRIPTION
Undo the Docker image introduced by PR #133 (commit 25db42c)

*Issue #, if available:* N/A

*Description of changes:* Revert megatron-lm parent image from 24.01 back to 23.09.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
