### PR TITLE
Update 4.dl-ami.sbatch

### DIFF
--- a/4.validation_and_observability/0.nccl-tests/4.dl-ami.sbatch
+++ b/4.validation_and_observability/0.nccl-tests/4.dl-ami.sbatch
@@ -21,5 +21,5 @@ mpirun -n $((8 * SLURM_JOB_NUM_NODES)) -N 8 \
 	-x NCCL_DEBUG=INFO \
 	--mca pml ^cm \
 	--mca btl tcp,self \
-	--mca btl_tcp_if_exclude lo,docker0 \
+	--mca btl_tcp_if_exclude lo,docker0,veth_def_agent \
 	--bind-to none /usr/local/cuda-12.2/efa/test-cuda-12.2/all_reduce_perf -b 8 -e 2G -f 2 -g 1 -c 1 -n 100


### PR DESCRIPTION
The NCCL test fails when we run it with > 4 nodes. We need to exclude veth_def_agent in order for it to work.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
