### PR TITLE
Update 1.c4-preprocess.sbatch to change the log output location

### DIFF
--- a/3.test_cases/3.MPT/1.c4-preprocess.sbatch
+++ b/3.test_cases/3.MPT/1.c4-preprocess.sbatch
@@ -2,7 +2,8 @@
 
 #SBATCH -N 1 # number of nodes to use
 #SBATCH --job-name=c4-preprocess # name of your job
-#SBATCH --output=%x_%j.out # stdout output
+#SBATCH --output=logs/%x_%j.out # logfile for stdout
+#SBATCH --error=logs/%x_%j.err # logfile for stderr, remove it to merge both outputs
 #SBATCH --ntasks-per-node 8 # Number of processes per node
 #SBATCH --exclusive
 


### PR DESCRIPTION
This PR just moves output log destination of `1.c4-preprocess.sbatch` as the same location as `2.traini-mpt-manual-distributed.sbatch`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
