### PR TITLE
Enable sacct on login nodes

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/setup_mariadb_accounting.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/setup_mariadb_accounting.sh
@@ -68,12 +68,14 @@ create_slurmdbd_config() {
 # Append the accounting settings to accounting.conf, this file is empty by default and included into
 # slurm.conf. This is required for Slurm to enable accounting.
 add_accounting_to_slurm_config() {
-  cat >> $SLURM_ACCOUNTING_CONFIG_FILE << EOL
+    # `hostname -i` gave us "hostname: Name or service not known". So let's parse slurm.conf.
+    DBD_HOST=$(awk -F'[=(]' '/^SlurmctldHost=/ { print $NF }' /opt/slurm/etc/slurm.conf | tr -d ')')
+    cat >> $SLURM_ACCOUNTING_CONFIG_FILE << EOL
 # ACCOUNTING
 JobAcctGatherType=jobacct_gather/linux
 JobAcctGatherFrequency=30
 AccountingStorageType=accounting_storage/slurmdbd
-AccountingStorageHost=localhost
+AccountingStorageHost=$DBD_HOST
 AccountingStoragePort=6819
 EOL
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* `sacct` gives error on login nodes because `accounting.conf` set the dbd host to `localhost`. This PR sets the dbd host to the controller ip address.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
