### PR TITLE
pin container image version

### DIFF
--- a/3.test_cases/14.bionemo/README.md
+++ b/3.test_cases/14.bionemo/README.md
@@ -67,7 +67,7 @@ cp -r /apps/awsome-distributed-training/3.test_cases/14.bionemo/* ./apps/
 
 ```bash
 cd /apps/
-docker pull nvcr.io/nvidia/clara/bionemo-framework:latest
+docker pull nvcr.io/nvidia/clara/bionemo-framework:1.2
 ```
 
 ## 3. Create Conda env


### PR DESCRIPTION
Pull v1.2 image instead of `latest`. Broken in current README.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
