### PR TITLE
Bump dcgm exporter version to correctly capture GPU utilization

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_dcgm_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_dcgm_exporter.sh
@@ -4,14 +4,14 @@
 if nvidia-smi; then
     echo "NVIDIA GPU found. Proceeding with script..."
     # Set DCGM Exporter version
-    DCGM_EXPORTER_VERSION=2.1.4-2.3.1
+    DCGM_EXPORTER_VERSION=3.3.5-3.4.0-ubuntu22.04
 
     # Run the DCGM Exporter Docker container
     sudo docker run -d --rm \
        --gpus all \
        --net host \
        --cap-add SYS_ADMIN \
-       nvcr.io/nvidia/k8s/dcgm-exporter:${DCGM_EXPORTER_VERSION}-ubuntu20.04 \
+       nvcr.io/nvidia/k8s/dcgm-exporter:${DCGM_EXPORTER_VERSION} \
        -f /etc/dcgm-exporter/dcp-metrics-included.csv || { echo "Failed to run DCGM Exporter Docker container"; exit 1; }
 
     echo "Running DCGM exporter in a Docker container on port 9400..."


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* GPU utilization not shown in Grafana, because the dcgm exporter version is too old. This PR upgrades to the latest stable dcgm exporter image. The new image has larger size (700+MB) compared to the old version (200+ MB), however this is necessary for the GPU utilization metric to function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
