### PR TITLE
SMHP: Remove 14k log lines from efa exporter LCC

### DIFF
--- a/4.validation_and_observability/3.efa-node-exporter/Dockerfile
+++ b/4.validation_and_observability/3.efa-node-exporter/Dockerfile
@@ -8,7 +8,7 @@ ARG GOLANG_VERSION=1.21.5
 # install go
 RUN apt update && apt install curl git build-essential -y
 RUN curl -OL https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
-    tar -C /usr/local -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz
+    tar -C /usr/local -xf go${GOLANG_VERSION}.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install EFA


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* verbose untar go creates 14k+ log lines.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
