### PR TITLE
Change 10.FSDP/0.create_conda_env.sh to pytorch 2.1.0

### DIFF
--- a/3.test_cases/10.FSDP/0.create_conda_env.sh
+++ b/3.test_cases/10.FSDP/0.create_conda_env.sh
@@ -15,7 +15,7 @@ conda create -y -p ./pt_fsdp python=3.10
 source activate ./pt_fsdp/
 
 # Install AWS Pytorch, see https://aws-pytorch-doc.com/
-conda install -y pytorch=2.0.1 pytorch-cuda=12.2 torchvision torchaudio transformers datasets fsspec=2023.9.2 --strict-channel-priority --override-channels -c https://aws-ml-conda.s3.us-west-2.amazonaws.com -c nvidia -c conda-forge
+conda install -y pytorch=2.1.0 pytorch-cuda=12.1 torchvision torchaudio transformers datasets fsspec=2023.9.2 --strict-channel-priority --override-channels -c https://aws-ml-conda.s3.us-west-2.amazonaws.com -c nvidia -c conda-forge
 
 # Create checkpoint dir
 mkdir checkpoints


### PR DESCRIPTION
This fixes #219 

I'm not aware of the context what PyTorch version should be used, but to fix ""triu_tril_cuda_template" not implemented for 'BFloat16'" we need PyTorch 2.1.0+

Explanation:

""triu_tril_cuda_template" not implemented for 'BFloat16'" is fixed in this [PR](https://github.com/pytorch/pytorch/pull/101414) and this [commit](https://github.com/pytorch/pytorch/commit/c51dfbf5b41b1acdad798c10ef7bfb1ed58abc85)

```bash
git tag --contains c51dfbf5b41b1acdad798c10ef7bfb1ed58abc85 | grep "v2" | head -n 1
v2.1.0
```

@sean-smith @verdimrc