### PR TITLE
Enabled Prometheus agent mode

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_prometheus.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_prometheus.sh
@@ -110,7 +110,7 @@ Description=Prometheus Exporter
 
 [Service]
 Environment=PATH=/opt/slurm/bin:\$PATH
-ExecStart=/usr/bin/prometheus --config.file=/etc/prometheus/prometheus.yml
+ExecStart=/usr/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --enable-feature=agent --storage.agent.path="/opt/prometheus/data-agent"
 Restart=on-failure
 RestartSec=15
 Type=simple


### PR DESCRIPTION
*Issue #, if available:*
When running Prometheus server with the default configuration, a local time series database is created under `/data` on the root volume, even when Prometheus is configured to deliver metrics to a remote server (Amazon Managed Service for Prometheus - in this case). As a consequence, when working with large clusters, a large volume of metrics is stored locally and this can fill the root volume.

*Description of changes:*
With these changes, we enable Prometheus agent mode. When agent mode is enabled, no local time series database is created and Prometheus will only deliver the metrics to the remote server.
A minimal amount of local storage is still required for the WAL (write ahead log), which is configured through the `storage.agent.path` setting, but since this is a rotating log, it's OK to use the root volume as storage location.

References:
https://prometheus.io/blog/2021/11/16/agent/
https://prometheus.io/docs/prometheus/latest/feature_flags/#prometheus-agent
https://prometheus.io/docs/prometheus/latest/storage/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
