### PR TITLE
HyperPod - adding comment why we uninstall ec2-instance-connect for SSSD

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/setup_sssd.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/setup_sssd.py
@@ -27,6 +27,7 @@ packages_to_install = [
 ]
 
 packages_to_uninstall = [
+    # Uninstall ec2-instance-connect because it overrides AuthorizedKeysCommand in sshd_config.
     "ec2-instance-connect",
 ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding comment line to explain why we uninstall ec2-instance-connect for SSSD.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
