### PR TITLE
pcluster: add a small util script to fetch config from a running cluster

### DIFF
--- a/1.architectures/2.aws-parallelcluster/pcluster-fetch-config.sh
+++ b/1.architectures/2.aws-parallelcluster/pcluster-fetch-config.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Dependency: jq (required), bat or yq (optionals)
+
+declare -a HELP=(
+    "[-h|--help]"
+    "[-r|--region REGION]"
+    "CLUSTER_NAME"
+    "[-s|--syntax-highlighter <cat|bat|jq> (default: auto detect)]"
+)
+
+IS_SYNTAX_HIGHLIGHTER_ARGS=0
+region=""
+cluster_name=""
+declare -a pcluster_args=()
+declare -a syntax_highlighter=()
+parse_args() {
+    local key
+    while [[ $# -gt 0 ]]; do
+        key="$1"
+        case $key in
+        -h|--help)
+            echo "Get the cluster config YAML of a ParallelCluster cluster."
+            echo "Usage: $(basename ${BASH_SOURCE[0]}) ${HELP[@]}"
+            exit 0
+            ;;
+        -r|--region)
+            region="$2"
+            shift 2
+            ;;
+        -s|--syntax-highlighter)
+            syntax_highlighter=( "$2" )
+            shift 2
+            ;;
+        --)
+            SYNTAX_HIGHLIGHTER_ARGS=1
+            shift
+            ;;
+        *)
+            if [[ $IS_SYNTAX_HIGHLIGHTER_ARGS == 0 ]]; then
+                [[ "$cluster_name" == "" ]] \
+                    && cluster_name="$key" \
+                    || { echo "Must define one cluster name only" ; exit -1 ; }
+            else
+                syntax_highlighter_args+=($key)
+            fi
+            shift
+            ;;
+        esac
+    done
+
+    [[ "$cluster_name" != "" ]] || { echo "Must define a cluster name" ; exit -1 ; }
+    [[ "${region}" == "" ]] ||  { pcluster_args+=(--region $region) ; }
+}
+
+parse_args $@
+
+cluster_config_url=$(pcluster describe-cluster -n $cluster_name "${pcluster_args[@]}" | jq -r .clusterConfiguration.url)
+cluster_config=$(curl --silent "$cluster_config_url")
+
+# By default, auto-detect the syntax highlighter
+if [[ ${#syntax_highlighter[@]} -eq 0 ]]; then
+    if command -v bat &> /dev/null; then
+        syntax_highlighter=( bat -pp --language yaml )
+    elif command -v batcat &> /dev/null; then
+        syntax_highlighter=( batcat -pp --language yaml )
+    elif command -v yq &> /dev/null; then
+        syntax_highlighter=( yq )
+    else
+        syntax_highlighter=( cat )
+    fi
+fi
+
+echo "$cluster_config" | "${syntax_highlighter[@]}"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* pcluster: add a small util script to fetch config from a running cluster. Use-case: AWS account runs multiple clusters. We may not have the local, up-to-date .yaml config file anymore, and we want to quickly probe the config directly from the running cluster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
