### PR TITLE
pcluster-fetch-config: show error messages

### DIFF
--- a/1.architectures/2.aws-parallelcluster/pcluster-fetch-config.sh
+++ b/1.architectures/2.aws-parallelcluster/pcluster-fetch-config.sh
@@ -57,7 +57,9 @@ parse_args() {
 
 parse_args $@
 
-cluster_config_url=$(pcluster describe-cluster -n $cluster_name "${pcluster_args[@]}" | jq -r .clusterConfiguration.url)
+pcluster_response=$(pcluster describe-cluster -n $cluster_name "${pcluster_args[@]}" || true)
+cluster_config_url=$(echo "$pcluster_response" | jq -r .clusterConfiguration.url)
+[[ "$cluster_config_url" == "null" ]] && { echo "${pcluster_response}" | jq . ; exit 1 ; }
 cluster_config=$(curl --silent "$cluster_config_url")
 
 # By default, auto-detect the syntax highlighter


### PR DESCRIPTION
*Issue #, if available:* `pcluster-fetch-config.sh` silently aborts on error.

*Description of changes:* the script shows the underlying error messages from the `pcluster` cli.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
