### PR TITLE
Skip incomplete checkpoints in FSDP sample app

### DIFF
--- a/3.test_cases/10.FSDP/.gitignore
+++ b/3.test_cases/10.FSDP/.gitignore
@@ -1,0 +1,4 @@
+miniconda3
+pt_fsdp
+checkpoints
+Miniconda3-latest-Linux-x86_64.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changing the logic to find the latest checkpoint, to skip incomplete checkpoints.
When ".metadata" file doesn't exist, it means that the previous job got terminated during the checkpointing procedure, it causes FileNotFoundError. With this change, we skip such incomplete checkpoints.

Also, added conda environment files and checkpoint files in the FSDP sample local .gitignore file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
