### PR TITLE
mount additional fsx

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
@@ -149,7 +149,7 @@ def main(args):
     fsx_dns_name, fsx_mountname = params.fsx_settings
     if fsx_dns_name and fsx_mountname:
         print(f"Mount fsx: {fsx_dns_name}. Mount point: {fsx_mountname}")
-        ExecuteBashScript("./mount_fsx.sh").run(fsx_dns_name, fsx_mountname)
+        ExecuteBashScript("./mount_fsx.sh").run(fsx_dns_name, fsx_mountname, "/fsx")
 
     ExecuteBashScript("./add_users.sh").run()
 


### PR DESCRIPTION
This script allows mounting additional FSx Lustre filesystems from the `lifecycle_scrtipt.py`. These can be mounted by adding in lines on [lifecycle_script.py#L153](https://github.com/aws-samples/awsome-distributed-training/blob/78d906651b1de4fb5c068cd157c6d60331c44ad8/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py#L153) like so:

```bash
ExecuteBashScript("./mount_fsx.sh").run("fs-05dac34e835f2c48f.fsx.us-west-2.amazonaws.com", "4owupbev", "/fsx/home")
ExecuteBashScript("./mount_fsx.sh").run("fs-0972ef1ec89bcc14c.fsx.us-west-2.amazonaws.com", "6eoi7bev", "/fsx/mount2")
ExecuteBashScript("./mount_fsx.sh").run("fs-0da5542b6a0808375.fsx.us-west-2.amazonaws.com", "yioi7bev", "/fsx/mount3")
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
