### PR TITLE
Install aws-ofi-nccl version 1.7.4 specifically to FSDP app

### DIFF
--- a/3.test_cases/10.FSDP/0.create_conda_env.sh
+++ b/3.test_cases/10.FSDP/0.create_conda_env.sh
@@ -15,7 +15,7 @@ conda create -y -p ./pt_fsdp python=3.10
 source activate ./pt_fsdp/
 
 # Install AWS Pytorch, see https://aws-pytorch-doc.com/
-conda install -y pytorch=2.2.0 pytorch-cuda=12.1 torchvision torchaudio transformers datasets fsspec=2023.9.2 --strict-channel-priority --override-channels -c https://aws-ml-conda.s3.us-west-2.amazonaws.com -c nvidia -c conda-forge
+conda install -y pytorch=2.2.0 pytorch-cuda=12.1 aws-ofi-nccl=1.7.4 torchvision torchaudio transformers datasets fsspec=2023.9.2 --strict-channel-priority --override-channels -c https://aws-ml-conda.s3.us-west-2.amazonaws.com -c nvidia -c conda-forge
 
 # Create checkpoint dir
 mkdir checkpoints


### PR DESCRIPTION
*Description of changes:*

Install aws-ofi-nccl version 1.7.4 specifically to avoid binary package (1.9.0) incompatible with HyperPod AMI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
