### PR TITLE
Add files via upload

### DIFF
--- a/1.architectures/4.amazon-eks/eks-p5-odcr-vpc.yaml
+++ b/1.architectures/4.amazon-eks/eks-p5-odcr-vpc.yaml
@@ -1,0 +1,46 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: eks-p5-odcr-vpc
+  region: PLACEHOLDER_AWS_REGION
+  version: "1.29"
+
+# Substitute vpc and subnet ids below
+vpc:
+  id: PLACEHOLDER_VPC_ID
+  subnets:
+    private:
+      private-one:
+        id: PLACEHOLDER_SUBNET_PRIVATE_1
+      private-two:
+        id: PLACEHOLDER_SUBNET_PRIVATE_2
+    public:
+      public-one:
+        id: PLACEHOLDER_SUBNET_PUBLIC_1
+      public-two:
+        id: PLACEHOLDER_SUBNET_PUBLIC_2  
+
+# Fully-managed nodegroups     
+managedNodeGroups:
+
+    # GPU nodegroup
+    # Update capacityReservationID below
+  - name: p5-ocdr
+    instanceType: p5.48xlarge
+    instancePrefix: p5-odcr-nodes
+    privateNetworking: true
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 1
+    maxSize: 10
+    volumeSize: 500
+    capacityReservation:
+      capacityReservationTarget:
+        capacityReservationID: "cr-xxxxxxxxxx"
+    iam:
+      withAddonPolicies:
+        autoScaler: true
+        cloudWatch: true
+        ebs: true
+        fsx: true


### PR DESCRIPTION
Added yaml configuration file for p5 instances - eksctl, efaEnabled, ODCR

Cluster using an existing VPC with a nodegroup of 1 * p5.48xlarge instance. This instance type supports Elastic Fabric Adapter (EFA), requires a capacity reservation. To use this manifest, edit the vpc id, subnets, Capacity Reservation ID, and specify the desired private subnet for the nodes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
