### PR TITLE
Fix `easy-setup.sh` + make `region` and `profile` configurable in `validate-config.py`

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/easy-setup.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-setup.sh
@@ -25,7 +25,6 @@ declare -a HELP=(
     "[-s|--stack-id-vpc]"
     "[-i|--instance-type]"
     "[-c|--instance-count]"
-    "[-a|--availability-zone]"
     "[-d|--dry-run]"
     "CLUSTER_NAME"
 )
@@ -63,10 +62,6 @@ parse_args() {
             ;;
         -c|--instance-count)
             INSTANCE_COUNTS="$2"
-            shift 2
-            ;;
-        -i|--availability-zone)
-            AZ="$2"
             shift 2
             ;;
         -d|--dry-run)


### PR DESCRIPTION
This PR introduces:
1. arguments addition to `validate-config.py`. The current `validate-config.py`'s assumption prevent us from using the script with non-default profile. 
2. Changes making `easy-setup.sh` works with non-default profile. 
3. Refactoring