### PR TITLE
pytorch-screen.py: fix attribute error (backend einsum) on newer pytorch

### DIFF
--- a/4.validation_and_observability/1.pytorch-env-validation/pytorch-screen.py
+++ b/4.validation_and_observability/1.pytorch-env-validation/pytorch-screen.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError:
     pass
 
 print(f"{torch.cuda.is_available()=}")
+print(f"{torch.version.cuda=}")
 print(f"{torch.backends.cuda.is_built()=}")
 print(f"{torch.backends.cuda.matmul.allow_tf32=}")
 print(f"{torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction=}")
@@ -31,10 +32,13 @@ print(f"{torch.backends.mkl.is_available()=}")
 print(f"{torch.backends.mkldnn.is_available()=}")
 
 print(f"{torch.backends.openmp.is_available()=}")
-print(f"{torch.backends.opt_einsum.is_available()=}")
-print(f"{torch.backends.opt_einsum.get_opt_einsum()=}")
-print(f"{torch.backends.opt_einsum.enabled=}")
-print(f"{torch.backends.opt_einsum.strategy=}")
+try:
+    print(f"{torch.backends.opt_einsum.is_available()=}")
+    print(f"{torch.backends.opt_einsum.get_opt_einsum()=}")
+    print(f"{torch.backends.opt_einsum.enabled=}")
+    print(f"{torch.backends.opt_einsum.strategy=}")
+except AttributeError:
+    pass
 
 print(f"{torch.distributed.is_available()=}")
 print(f"{torch.distributed.is_mpi_available()=}")


### PR DESCRIPTION
*Issue #, if available:* `pytorch-screen.py` throws attribute error on newer PyTorch.

*Description of changes:* fix attribute error when running `pytorch-screen.py` on newer PyTorch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
