### PR TITLE
NCCL Tests for AWS ParallelCluster

### DIFF
--- a/micro-benchmarks/nccl-tests/slurm/nccl-tests-pcluster.sbatch
+++ b/micro-benchmarks/nccl-tests/slurm/nccl-tests-pcluster.sbatch
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+#SBATCH --job-name=nccl-all_reduce_perf # name of your job
+#SBATCH --nodes=2 # number of nodes to use, 24 p4d(e) = 192 A100 GPUs
+#SBATCH --ntasks-per-node 8 # Number of GPU per node
+#SBATCH --exclusive
+
+# This script is designed to run on the Deep Learning AMI, Ubuntu 20.04
+# See https://aws.amazon.com/releasenotes/aws-deep-learning-base-gpu-ami-ubuntu-20-04/
+set -ex
+
+# Get Hostname to Instance ID mapping
+mpirun -N 1 bash -c 'echo $(hostname) ➡️ $(cat /sys/devices/virtual/dmi/id/board_asset_tag | tr -d " ")'
+
+### NCCL_BUFFSIZE increase the send queue depth and can turn NCCL communications into non-blocking.
+### https://www.usenix.org/system/files/atc23-choi.pdf
+
+### NCCL_P2P_NET_CHUNKSIZE Improve performance by increasing buffer size for Send/Recv, Gather, Scatter and Alltoall communications
+### https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/p2p.html
+
+# run all_reduce test
+mpirun -n $((8 * SLURM_JOB_NUM_NODES)) -N 8 \
+        -x FI_PROVIDER=efa \
+	-x FI_EFA_USE_DEVICE_RDMA=1  \
+	-x FI_EFA_FORK_SAFE=1 \
+	-x LD_LIBRARY_PATH=/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/amazon/openmpi/lib:/opt/aws-ofi-nccl/lib:/usr/local/lib:/usr/lib:$LD_LIBRARY_PATH \
+	-x NCCL_DEBUG=INFO \
+	-x NCCL_BUFFSIZE=8388608 \
+	-x NCCL_P2P_NET_CHUNKSIZE=524288 \
+	--mca pml ^cm,ucx \
+	--mca btl tcp,self \
+	--mca btl_tcp_if_exclude lo,docker0,veth_def_agent \
+	--bind-to none /opt/nccl-tests/build/all_reduce_perf -b 8 -e 16G -f 2 -g 1 -c 1 -n 100


### PR DESCRIPTION
* This adds a nccl test script to accompany the workshop: https://catalog.us-east-1.prod.workshops.aws/workshops/6cbbf337-c498-4c6b-ad4f-99d22e03d8dc/en-US/05-nccl-tests

* It assumes NCCL is installed in `/opt/nccl` path and nccl tests are `/opt/nccl-tests`.

* By doing it this way instead of using a docker image it's significantly faster for users to get started

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
