### PR TITLE
EKS CB fix for un-managed Node group

### DIFF
--- a/1.architectures/4.amazon-eks/amazon-eks-nodegroup.yaml
+++ b/1.architectures/4.amazon-eks/amazon-eks-nodegroup.yaml
@@ -283,6 +283,8 @@ Resources:
     Condition: isP5
     Properties:
       LaunchTemplateData:
+        InstanceMarketOptions:
+          MarketType: "capacity-block"
         CapacityReservationSpecification:
           CapacityReservationTarget:
             CapacityReservationId: !Ref CapacityBlockId
@@ -530,6 +532,8 @@ Resources:
     Condition: isP4d
     Properties:
       LaunchTemplateData:
+        InstanceMarketOptions:
+          MarketType: "capacity-block"
         CapacityReservationSpecification:
           CapacityReservationTarget:
             CapacityReservationId: !Ref CapacityBlockId


### PR DESCRIPTION
This adds back the `MarketType` flag which is required for Capacity Blocks. See https://docs.aws.amazon.com/eks/latest/userguide/capacity-blocks.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
