### PR TITLE
Deleting --cpus-per-task in PyTorch DDP on CPU for Docker sample

### DIFF
--- a/3.test_cases/16.pytorch-cpu-ddp/3.container-train.sbatch
+++ b/3.test_cases/16.pytorch-cpu-ddp/3.container-train.sbatch
@@ -7,7 +7,6 @@
 #SBATCH --exclusive
 #SBATCH --wait-all-nodes=1
 #SBATCH --nodes 2
-#SBATCH --cpus-per-task=4
 #SBATCH --output=logs/%x_%j.out # logfile for stdout/stderr
 
 nodes=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )


### PR DESCRIPTION
*Description of changes:*

Deleting `--cpus-per-task` in PyTorch DDP on CPU for Docker sample - `3.container-train.sbatch`, as it is not compatible with HyperPod auto-resume option. 
Confirmed that this option is not used in `1.conda-train.sbatch`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
