### PR TITLE
Pcluster easy-ssh.sh

### DIFF
--- a/1.architectures/2.aws-parallelcluster/README.md
+++ b/1.architectures/2.aws-parallelcluster/README.md
@@ -28,7 +28,7 @@ pip3 install awscli # install the AWS CLI
 pip3 install aws-parallelcluster # then AWS ParallelCluster
 ```
 
-> **Note**: you can use virtual environments to test different versions of AWS ParallelCluster by setting the version during the installation. For example to use 3.7.1, change the command `pip3 install aws-parallelcluster==3.7.1`.
+> **Note**: you can use virtual environments to test different versions of AWS ParallelCluster by setting the version during the installation. For example to use 3.9.1, change the command `pip3 install aws-parallelcluster==3.9.1`.
 
 ### 2.2. Create your EC2 Keypair (if needed)
 
@@ -55,6 +55,62 @@ aws ec2 create-key-pair --key-name pcluster-workshop-key \
 # client refuses to use this private key to open an ssh connection.
 sudo chmod 600 $KEYPAIR_NAME.pem
 ```
+
+### 2.2 Connect to your cluster
+
+To easily login to your cluster via [AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html) we've included a script `easy-ssh.sh` that you can run like so, assuming `ml-cluster` is the name of your cluster:
+
+```bash
+./easy-ssh.sh ml-cluster
+```
+
+You'll need a few pre-requisites for this script:
+* JQ: `brew install jq`
+* aws cli
+* `pcluster` cli
+* [Session Manager Plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+
+Once you've run the script you'll see the following output:
+
+```
+Instance Id: i-0096542c11ccb02b5
+Os: ubuntu2004
+User: ubuntu
+Add the following to your ~/.ssh/config to easily connect:
+
+cat <<EOF >> ~/.ssh/config
+Host ml-cluster
+  User ubuntu
+  ProxyCommand sh -c "aws ssm start-session --target i-0095542c11ccb02b5 --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+EOF
+
+Add your ssh keypair and then you can do:
+
+$ ssh ml-cluster
+
+Connecting to ml-cluster...
+
+Starting session with SessionId: ...
+root@ip-10-0-24-126:~#
+```
+
+1. Add your public key to the file `~/.ssh/authorized_keys`
+
+2. Now paste in the lines from the output of to your terminal, this will add them to your `~/.ssh/config`.
+
+```
+cat <<EOF >> ~/.ssh/config
+Host ml-cluster
+  User ubuntu
+  ProxyCommand sh -c "aws ssm start-session --target i-0095542c11ccb02b5 --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+EOF
+```
+3. Now you ssh in, assuming `ml-cluster` is the name of your cluster with:
+
+```
+ssh ml-cluster
+```
+
 
 ## 3. Deploy a Cluster
 

--- a/1.architectures/2.aws-parallelcluster/easy-ssh.sh
+++ b/1.architectures/2.aws-parallelcluster/easy-ssh.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+
+cluster_name=${1:-ml-cluster}
+
+# grab head node instance id
+instance_id=$(pcluster describe-cluster -n ${cluster_name} | jq '.headNode.instanceId' | tr -d '"')
+os=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=parallelcluster:attributes" | jq '.Tags[0].Value' | tr -d '"' | awk -F ',' '{print $1}')
+
+if [ "$os" = 'ubuntu2004' ]; then 
+    user='ubuntu'
+elif [ "$os" = 'ubuntu2204' ]; then 
+    user='ubuntu'
+elif [ "$os" = 'alinux2' ]; then
+    user='XXXXXXXX'
+fi
+
+echo -e "Instance Id: $instance_id"
+echo -e "Os: $os"
+echo -e "User: $user"
+
+echo -e "Add the following to your ~/.ssh/config to easily connect:"
+echo "
+cat <<EOF >> ~/.ssh/config
+Host ${cluster_name}
+  User ${user}
+  ProxyCommand sh -c \"aws ssm start-session --target ${instance_id} --document-name AWS-StartSSHSession --parameters 'portNumber=%p'\"
+EOF
+
+Add your ssh keypair and then you can do:
+
+$ ssh ${cluster_name}
+"
+
+echo "Connecting to $cluster_name..."
+aws ssm start-session --target $instance_id

--- a/1.architectures/2.aws-parallelcluster/easy-ssh.sh
+++ b/1.architectures/2.aws-parallelcluster/easy-ssh.sh
@@ -15,7 +15,7 @@ if [ "$os" = 'ubuntu2004' ]; then
 elif [ "$os" = 'ubuntu2204' ]; then 
     user='ubuntu'
 elif [ "$os" = 'alinux2' ]; then
-    user='XXXXXXXX'
+    user='ec2-user'
 fi
 
 echo -e "Instance Id: $instance_id"


### PR DESCRIPTION
This adds a script `easy-ssh.sh` that makes it easy to connect to AWS ParallelCluster using SSM. 

```bash
$ ./easy-ssh.sh [cluster-name]
```

Which will output:
```
Instance Id: i-0096542c11ccb02b5
Os: ubuntu2004
User: ubuntu

Add the following to your ~/.ssh/config to easily connect:
cat <<EOF >> ~/.ssh/config
Host ml-cluster
  User ubuntu
  ProxyCommand sh -c "aws ssm start-session --target i-0095542c11ccb02b5 --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
EOF

Add your ssh keypair and then you can do:

$ ssh ml-cluster

Connecting to ml-cluster...
Starting session with SessionId: ...
root@ip-10-0-24-126:~#
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
