### PR TITLE
add metrics on the headnode

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
@@ -198,6 +198,7 @@ def main(args):
                 wait_for_scontrol()
                 ExecuteBashScript("./utils/install_docker.sh").run()
                 ExecuteBashScript("./utils/install_slurm_exporter.sh").run()
+                ExecuteBashScript("./utils/install_head_node_exporter.sh").run()
                 ExecuteBashScript("./utils/install_prometheus.sh").run()
 
         # Install and configure SSSD for ActiveDirectory/LDAP integration

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_head_node_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_head_node_exporter.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+
+# Run the Docker container with appropriate configurations
+sudo docker run -d --restart always \
+  --net="host" \
+  --pid="host" \
+  -v "/:/host:ro,rslave" \
+  public.ecr.aws/bitnami/node-exporter:latest \
+  --path.rootfs=/host && { echo "Successfully started Node Exporter on node"; exit 0; } || { echo "Failed to run Docker container"; exit 1; }

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_prometheus.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_prometheus.sh
@@ -79,6 +79,10 @@ global:
   scrape_timeout: 15s
 
 scrape_configs:
+  - job_name: 'head_node_metrics'
+    static_configs:
+      - targets:
+          - 'localhost:9100'
   - job_name: 'slurm_exporter'
     static_configs:
       - targets:


### PR DESCRIPTION
This commit adds `node_exporter` to the headnode so we can see metrics like root volume size. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
