### PR TITLE
Adding remote code trust flag for Dataloader

### DIFF
--- a/3.test_cases/10.FSDP/model_utils/train_utils.py
+++ b/3.test_cases/10.FSDP/model_utils/train_utils.py
@@ -456,7 +456,7 @@ def create_streaming_dataloader(dataset,
                       split=None):
     print(f"dataset={dataset}, name={name}")
     tokenizer = AutoTokenizer.from_pretrained(tokenizer)
-    data = load_dataset(dataset, name=name, streaming=True, split=split).shuffle(42+global_rank)
+    data = load_dataset(dataset, name=name, streaming=True, split=split, trust_remote_code=True).shuffle(42+global_rank)
     train_concat_dataset = ConcatTokensDataset(data, tokenizer, max_context_width, True)
     train_dataloader = DataLoader(train_concat_dataset,
                                        batch_size=batch_size,


### PR DESCRIPTION
HF requires the --trust-remote-code=True flag to be passed in to the Dataloader.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
