### PR TITLE
Change create_streaming_dataloader method's timeout

### DIFF
--- a/3.test_cases/10.FSDP/model_utils/train_utils.py
+++ b/3.test_cases/10.FSDP/model_utils/train_utils.py
@@ -462,5 +462,6 @@ def create_streaming_dataloader(dataset,
                                        batch_size=batch_size,
                                        num_workers=workers,
                                        pin_memory=True,
-                                       prefetch_factor=4)
+                                       prefetch_factor=4,
+                                       timeout=600)
     return train_dataloader


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The FSDP example (sometimes) broke with a HF Error that looked like:
```
raise ReadTimeoutError(
3: urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)
```
Upon digging, it seems like the current timeout is 10 seconds. So, the proposed change is to increase it (commit of 10 minutes seems to do the trick).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
