### PR TITLE
Fix device name for LDAP server.

### DIFF
--- a/1.architectures/6.ldap_server/cf_ldap_server.yaml
+++ b/1.architectures/6.ldap_server/cf_ldap_server.yaml
@@ -130,7 +130,7 @@ Resources:
               command: systemctl start cfn-hup.service
     Properties:
       BlockDeviceMappings:
-      - DeviceName: '/dev/xvda'
+      - DeviceName: '/dev/sda1'
         Ebs:
           DeleteOnTermination: false
           Encrypted: true


### PR DESCRIPTION
Currently, the LDAP server is created with a secondary volume instead of settings the root volume size.
This is due to Ubuntu uses `/dev/sda1` as root volume instead of `/dev/xvda`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
