### PR TITLE
Change NCCL Bench version to EFA Installer 1.34.0, NCCL:2.22.3, aws-ofi-plugin:1.10.0

### DIFF
--- a/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
+++ b/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
@@ -3,10 +3,10 @@
 FROM nvidia/cuda:12.2.2-devel-ubuntu22.04
 
 ARG GDRCOPY_VERSION=v2.4.1
-ARG EFA_INSTALLER_VERSION=1.33.0
-ARG AWS_OFI_NCCL_VERSION=v1.9.2-aws
-ARG NCCL_VERSION=v2.21.5-1
-ARG NCCL_TESTS_VERSION=v2.13.9
+ARG EFA_INSTALLER_VERSION=1.34.0
+ARG AWS_OFI_NCCL_VERSION=v1.10.0-aws
+ARG NCCL_VERSION=v2.22.3-1
+ARG NCCL_TESTS_VERSION=v2.13.10
 
 RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get remove -y --allow-change-held-packages \


### PR DESCRIPTION
Change EFA Installer 1.34.0
NCCL 2.22.3
AWS-OFI-Plugin 1.10.0
NCCL tests versions 2.13.10

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
