### PR TITLE
update TORCHRUN_ARGS to be able to auto-resume

### DIFF
--- a/3.test_cases/16.pytorch-cpu-ddp/slurm/1.conda-train.sbatch
+++ b/3.test_cases/16.pytorch-cpu-ddp/slurm/1.conda-train.sbatch
@@ -5,13 +5,15 @@
 #SBATCH --nodes 2
 #SBATCH --output=logs/%x_%j.out # logfile for stdout/stderr
 
-nodes=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
-nodes_array=($nodes)
-head_node=${nodes_array[0]}
-head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
-
-echo Node IP: $head_node_ip
 export LOGLEVEL=INFO
+
+declare -a TORCHRUN_ARGS=(
+    --nproc_per_node=4
+    --nnodes=$SLURM_JOB_NUM_NODES
+    --rdzv_id=$SLURM_JOB_ID
+    --rdzv_backend=c10d
+    --rdzv_endpoint=$(hostname)
+)
 
 AUTO_RESUME=""
 if [ -d "/opt/sagemaker_cluster" ]; then
@@ -20,9 +22,5 @@ if [ -d "/opt/sagemaker_cluster" ]; then
 fi
 
 srun ${AUTO_RESUME} ./pt_cpu/bin/torchrun \
---nnodes 2 \
---nproc_per_node 4 \
---rdzv_id $RANDOM \
---rdzv_backend c10d \
---rdzv_endpoint $head_node_ip:29500 \
-$(dirname "$PWD")/ddp.py 5000000 10
+    "${TORCHRUN_ARGS[@]}" \
+    $(dirname "$PWD")/ddp.py 5000000 10

--- a/3.test_cases/16.pytorch-cpu-ddp/slurm/3.container-train.sbatch
+++ b/3.test_cases/16.pytorch-cpu-ddp/slurm/3.container-train.sbatch
@@ -9,18 +9,20 @@
 #SBATCH --nodes 2
 #SBATCH --output=logs/%x_%j.out # logfile for stdout/stderr
 
-nodes=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
-nodes_array=($nodes)
-head_node=${nodes_array[0]}
-head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
-
-echo Node IP: $head_node_ip
 export LOGLEVEL=INFO
 export NVIDIA_VISIBLE_DEVICES=void
 
 declare -a ARGS=(
     --container-image ${PWD}/pytorch.sqsh
     --container-mounts $(dirname "$PWD")
+)
+
+declare -a TORCHRUN_ARGS=(
+    --nproc_per_node=4
+    --nnodes=$SLURM_JOB_NUM_NODES
+    --rdzv_id=$SLURM_JOB_ID
+    --rdzv_backend=c10d
+    --rdzv_endpoint=$(hostname)
 )
 
 AUTO_RESUME=""
@@ -30,9 +32,5 @@ if [ -d "/opt/sagemaker_cluster" ]; then
 fi
 
 srun ${AUTO_RESUME} -l "${ARGS[@]}" torchrun \
-    --nnodes 2 \
-    --nproc_per_node 4 \
-    --rdzv_id $RANDOM \
-    --rdzv_backend c10d \
-    --rdzv_endpoint $head_node_ip:29500 \
+    "${TORCHRUN_ARGS[@]}" \
     $(dirname "$PWD")/ddp.py 5000000 10


### PR DESCRIPTION
I have discovered that there is a problem on the CPU ddp job script. Specifically, how the `torchrun` arguments are specified prevents HyperPod auto-resume to function. 

```bash
srun ${AUTO_RESUME} ./pt_cpu/bin/torchrun \
--nnodes 2 \
--nproc_per_node 4 \
--rdzv_id $RANDOM \
--rdzv_backend c10d \
--rdzv_endpoint $head_node_ip:29500 \
$(dirname "$PWD")/ddp.py 5000000 10
```

Notice the `--rdzv_endpoint`  uses `head_node_ip`, this is the variable retrieved at the beginning of the script as follows:

```bash
head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
echo Node IP: $head_node_ip
```

When a node failure occurs in this `head_node` and Hyperpod's Auto-resume function is activated, `torchrun` will be re-executed with a non-existing (terminated) instance specified as the endpoint. 

This PR is proposing to use:
```bash
--rdzv_endpoint=$(hostname)
```
instead (cf. https://github.com/aws-samples/awsome-distributed-training/blob/4d16b6d77b7fe50c9e389c48e57d200687df57c8/3.test_cases/10.FSDP/1.distributed-training.sbatch#L47) to avoid the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
