### PR TITLE
Change slurm NCCL test to avoid mangled output.

### DIFF
--- a/micro-benchmarks/nccl-tests/slurm/nccl-tests-container.sbatch
+++ b/micro-benchmarks/nccl-tests/slurm/nccl-tests-container.sbatch
@@ -53,4 +53,4 @@ declare -a ARGS=(
 mpirun -N 1 bash -c 'echo $(hostname): $(cat /sys/devices/virtual/dmi/id/board_asset_tag | tr -d " ")'
 
 # Run NCCL test
-srun -u -l "${ARGS[@]}" --mpi=pmix --cpu-bind=none $NCCL_TESTS_PATH/all_reduce_perf -b 8 -e 16G -f 2 -g 1 -c 1 -n 100
+srun "${ARGS[@]}" --mpi=pmix --cpu-bind=none $NCCL_TESTS_PATH/all_reduce_perf -b 8 -e 16G -f 2 -g 1 -c 1 -n 100


### PR DESCRIPTION
This PR avoid rank mangled output for NCCL test by removing `-u` options