### PR TITLE
Allow FSxL metadata IOPS configuration update

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml
@@ -396,6 +396,8 @@ Resources:
         DataCompressionType: !Ref Compression
         DeploymentType: PERSISTENT_2
         PerUnitStorageThroughput: !Ref PerUnitStorageThroughput
+        MetadataConfiguration:
+          Mode: AUTOMATIC
 
   AmazonSagemakerClusterExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Description of changes:*

Adding FSxL MetadataConfiguration to allow customers to update FSx metadata IOPS.

* Specifying AUTOMATIC mode in the template, so the performance doesn't change until customer updates the setting to User-provisioned mode.
* Without MetadataConfiguration, FSx doesn't allow configuration change, so we need to include MetadataConfiguration in the LustreConfiguration even with AUTOMATIC mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
