### PR TITLE
Use secondary EBS volume for containerd data root if available

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
@@ -12,5 +12,11 @@ logger() {
 }
 
 logger "[start] on_create.sh"
+
+if [[ $(mount | grep /opt/sagemaker) ]]; then
+  logger "Found secondary EBS volume. Setting containerd data root to /opt/sagemaker/containerd/data-root"
+  sed -i -e "/^[# ]*root\s*=/c\root = \"/opt/sagemaker/containerd/data-root\"" /etc/eks/containerd/containerd-config.toml
+fi
+
 logger "no more steps to run"
 logger "[stop] on_create.sh"


### PR DESCRIPTION
*Description of changes:*

Use secondary EBS volume for containerd data root if available.
Tested cluster creation, job execution, auto-resume, and cluster deletion.
Tested image files are created under /opt/sagemaker/containerd/data-root. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
