### PR TITLE
Update FSDP conda env script to use newer version of PyTorch

### DIFF
--- a/3.test_cases/10.FSDP/0.create_conda_env.sh
+++ b/3.test_cases/10.FSDP/0.create_conda_env.sh
@@ -10,12 +10,19 @@ chmod +x Miniconda3-latest-Linux-x86_64.sh
 
 source ./miniconda3/bin/activate
 
-conda create -y -p ./pt_fsdp python=3.10
+conda create -y -p ./pt_fsdp python=3.11
 
 source activate ./pt_fsdp/
 
-# Install AWS Pytorch, see https://aws-pytorch-doc.com/
-conda install -y pytorch=2.2.0 pytorch-cuda=12.1 aws-ofi-nccl=1.7.4 torchvision torchaudio transformers datasets fsspec=2023.9.2 --strict-channel-priority --override-channels -c https://aws-ml-conda.s3.us-west-2.amazonaws.com -c nvidia -c conda-forge
+# Set true to install AWS Pytorch. see https://aws-pytorch-doc.com/
+use_aws_pytorch=true
+
+if $use_aws_pytorch; then
+    conda install -y pytorch=2.3.0 pytorch-cuda=12.1 aws-ofi-nccl torchvision torchaudio transformers datasets fsspec=2023.9.2 --strict-channel-priority --override-channels -c https://aws-ml-conda.s3.us-west-2.amazonaws.com -c nvidia -c conda-forge
+else
+    conda install -y pytorch=2.4.1 torchvision torchaudio transformers datasets fsspec=2023.9.2 pytorch-cuda=12.1 -c pytorch -c nvidia
+    conda install -y aws-ofi-nccl=1.9.1 -c https://aws-ml-conda.s3.us-west-2.amazonaws.com -c conda-forge
+fi
 
 # Create checkpoint dir
 mkdir checkpoints


### PR DESCRIPTION
*Description of changes:*

- Use latest AWS PyTorch 2.3.0
- Use Python3.11 (latest version AWS PyTorch supports)
- Add an option to use non-AWS PyTorch 2.4.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
