### PR TITLE
Improvements/#427

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
@@ -182,11 +182,6 @@ def main(args):
 
         ExecuteBashScript("./start_slurm.sh").run(node_type, ",".join(controllers))
 
-        # Install Docker/Enroot/Pyxis
-        if Config.enable_docker_enroot_pyxis:
-            ExecuteBashScript("./utils/install_docker.sh").run()
-            ExecuteBashScript("./utils/install_enroot_pyxis.sh").run(node_type)
-
         # Install metric exporting software and Prometheus for observability
         if Config.enable_observability:
             if node_type == SlurmNodeType.COMPUTE_NODE:
@@ -201,6 +196,11 @@ def main(args):
                 ExecuteBashScript("./utils/install_head_node_exporter.sh").run()
                 ExecuteBashScript("./utils/install_prometheus.sh").run()
         
+        # Install Docker/Enroot/Pyxis
+        if Config.enable_docker_enroot_pyxis:
+            ExecuteBashScript("./utils/install_docker.sh").run()
+            ExecuteBashScript("./utils/install_enroot_pyxis.sh").run(node_type)
+
         # Update Neuron SDK version to the version defined in update_neuron_sdk.sh
         if Config.enable_update_neuron_sdk:
             if node_type == SlurmNodeType.COMPUTE_NODE:

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
@@ -202,7 +202,7 @@ def main(args):
                 ExecuteBashScript("./utils/install_prometheus.sh").run()
         
         # Update Neuron SDK version to the version defined in update_neuron_sdk.sh
-        if Config.enable_observability:
+        if Config.enable_update_neuron_sdk:
             if node_type == SlurmNodeType.COMPUTE_NODE:
                 ExecuteBashScript("./utils/update_neuron_sdk.sh").run()
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/awsome-distributed-training/issues/427

*Description of changes:* This PR has 3 commits, each addressing separate issues.  

* [Commit 92d1b0c](https://github.com/aws-samples/awsome-distributed-training/commit/82d1b0c3e049a5d8afaae1620505b4d68676e8ef) to fix incorrect config param in config.py, previously undocumented issue. 

* [Commit abd677e](https://github.com/aws-samples/awsome-distributed-training/pull/438/commits/cec6633ab33e7c42629bfb5d4108ce000b66b717) to modify order which Docker / Enroot / Pyxis is called in lifecycle scripts, to mitigate chance of encountering race condition documented in issue 427

* [Commit 3c9a655](https://github.com/aws-samples/awsome-distributed-training/commit/3c9a65582b413771de17c4207983720f9c174a4d) to further address 427 by adding a while loop that will poll (max 120s) dlami-nvme.service for active and execStart messages. This provides assurance that /opt/dlami/nvme is mounted to node prior to executing enroot configuration which will use /opt/dlami/nvme. This commit also updates the order of if/elif statement to first try /opt/dlami/nvme before /opt/sagemaker. 

This PR has been tested successfully on a HyperPod cluster with 1 p5 and 4 c5.4xlarge to verify intended outcome and logs analyzed to confirm while loop functioning properly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
