### PR TITLE
Set HuggingFace metadata timeout for large clusters

### DIFF
--- a/3.test_cases/10.FSDP/1.distributed-training.sbatch
+++ b/3.test_cases/10.FSDP/1.distributed-training.sbatch
@@ -35,6 +35,9 @@ export NCCL_DEBUG=INFO
 ## https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__UNIFIED.html
 export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 
+## Set HuggingFace metadata timeout (in seconds) for large clusters
+export HF_HUB_ETAG_TIMEOUT=60
+
 ###########################
 ####### Torch Dist  #######
 ###########################


### PR DESCRIPTION
*Description of changes:*

Defining an environment variable HF_HUB_ETAG_TIMEOUT to 60 seconds (default 10 seconds) to avoid timeout issues in fetching HuggingFace metadata

If we don't define this variable, customers get this error in larger clusters (e.g., 16 x p5).
```
7: [rank80]: urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='[huggingface.co](http://huggingface.co/)', port=443): Read timed out. (read timeout=10)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
