### PR TITLE
fix nccl test eks

### DIFF
--- a/micro-benchmarks/nccl-tests/kubernetes/nccl-tests.yaml
+++ b/micro-benchmarks/nccl-tests/kubernetes/nccl-tests.yaml
@@ -12,11 +12,11 @@ spec:
       replicas: 1
       template:
          spec:
-          imagePullPolicy: IfNotPresent
           restartPolicy: OnFailure
-          containers:
+          containers: 
           - image: <account>.dkr.ecr.<region>.amazonaws.com/<image>:<tag>
             name: test-nccl-launcher
+            imagePullPolicy: IfNotPresent
             env:
              - name: LD_LIBRARY_PATH
                value: /opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/nvidia/lib:$LD_LIBRARY_PATH
@@ -38,10 +38,6 @@ spec:
             - LD_LIBRARY_PATH
             - -x
             - FI_PROVIDER=efa
-            - -x
-            - FI_EFA_USE_DEVICE_RDMA=1
-            - -x
-            - FI_EFA_FORK_SAFE=1
             - -x
             - NCCL_DEBUG=INFO
             - -x
@@ -78,10 +74,10 @@ spec:
         spec:
           nodeSelector:
             node.kubernetes.io/instance-type: "p5.48xlarge"
-          imagePullPolicy: IfNotPresent
           containers:
           - image: <account>.dkr.ecr.<region>.amazonaws.com/<image>:<tag>
             name: test-nccl-worker
+            imagePullPolicy: IfNotPresent
             volumeMounts:
             - name: shmem
               mountPath: /dev/shm


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Fixed image pull policy config, to resolve this error during deployment
```
Error from server (BadRequest): error when creating "nccl-tests.yaml": MPIJob in version "v2beta1" cannot be handled as a MPIJob: strict decoding error: unknown field "spec.mpiReplicaSpecs.Launcher.template.spec.imagePullPolicy", unknown field "spec.mpiReplicaSpecs.Worker.template.spec.imagePullPolicy"  yaml file apiVersion: 
```
2. removed unnecessary flags for EFA, these are auto-set in OFI plugin now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
