### PR TITLE
Install numpy v1 specifically for the FSDP sample app

### DIFF
--- a/3.test_cases/10.FSDP/0.create_conda_env.sh
+++ b/3.test_cases/10.FSDP/0.create_conda_env.sh
@@ -14,7 +14,7 @@ conda create -y -p ./pt_fsdp python=3.11
 
 source activate ./pt_fsdp/
 
-conda install -y pytorch=2.4.1 torchvision torchaudio transformers datasets fsspec=2023.9.2 pytorch-cuda=12.1 -c pytorch -c nvidia
+conda install -y pytorch=2.4.1 torchvision torchaudio transformers datasets fsspec=2023.9.2 pytorch-cuda=12.1 "numpy=1.*" -c pytorch -c nvidia
 
 # Create checkpoint dir
 mkdir checkpoints


### PR DESCRIPTION
*Description of changes:*

Installing numpy version 1 specifically, to avoid version incompatibility issues.
Without this change, there was a case where Numpy v2 is installed and training job fails with following error.

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.1.2 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
