### PR TITLE
Adding the CF template for FSx Lustre for HyperPod EKS workshop

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/fsx-lustre-stack.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/fsx-lustre-stack.yaml
@@ -1,0 +1,69 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: This template deploys an FSx for Luster File System
+
+Parameters:
+
+  LustreVersion:
+    Description: Lustre software version
+    Type: String
+    AllowedValues:
+      - "2.15"
+      - "2.12"
+    Default: "2.15"
+
+  Capacity:
+    Description: Storage capacity in GiB (1200 or increments of 2400)
+    Type: Number
+    Default: 1200
+
+  PerUnitStorageThroughput:
+    Description: Provisioned Read/Write (MB/s/TiB)
+    Type: Number
+    Default: 250
+    AllowedValues:
+      - 125
+      - 250
+      - 500
+      - 1000
+  
+  Compression:
+    Description: Data compression type
+    Type: String
+    AllowedValues:
+      - "LZ4"
+      - "NONE"
+    Default: "LZ4"
+
+Resources: 
+  FSxFileSystem:
+    Type: AWS::FSx::FileSystem
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      FileSystemType: LUSTRE
+      StorageType: SSD
+      FileSystemTypeVersion: !Ref LustreVersion
+      StorageCapacity: !Ref Capacity
+      LustreConfiguration:
+        DataCompressionType: !Ref Compression
+        DeploymentType: PERSISTENT_2
+        PerUnitStorageThroughput: !Ref PerUnitStorageThroughput
+      SubnetIds:
+        - !ImportValue PrivateSubnet1 # Import
+      SecurityGroupIds:
+        - !ImportValue NoIngressSecurityGroup # Import
+      MetadataConfiguration:
+          Mode: AUTOMATIC
+
+Outputs:
+  FSxLustreFilesystemId:
+    Description: The ID of the FSxL filesystem
+    Value: !Ref FSxFileSystem
+
+  FSxLustreFilesystemDNSname:
+    Description: The DNS of the FSxL filesystem 
+    Value: !GetAtt FSxFileSystem.DNSName
+
+  FSxLustreFilesystemMountname:
+    Description: The mount name of the FSxL filesystem 
+    Value: !GetAtt FSxFileSystem.LustreMountName


### PR DESCRIPTION
*Description of changes:*

Starting to maintain the CloudFormation template for FSx Lustre in this repository.
This template is used in the HyperPod EKS workshop - FSxL static provisioning section (https://catalog.workshops.aws/sagemaker-hyperpod-eks/en-US/01-cluster/06-fsx-for-lustre#static-provisioning-(optional)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
