### PR TITLE
HyperPod Mountpoint for s3 Lifecycle Script

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/config.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/config.py
@@ -2,7 +2,7 @@
 # Basic configuration parameters
 class Config:
 
-    # Set true if you want to install Docker/Enroot/Pyxis.
+    # Default is true to install Docker/Enroot/Pyxis.
     enable_docker_enroot_pyxis = True
 
     # Set true if you want to install metric exporter software and Prometheus for observability
@@ -26,6 +26,17 @@ class Config:
 
     # Set true to install quality-of-live improvements
     enable_initsmhp = False
+
+    # Set true if you want to use mountpoint for s3 on cluster nodes. 
+    # If enabled, a systemctl mount-s3.service file will be writen that will mount at /mnt/<BucketName>.
+    # requires s3 permissions to be added to cluster execution role. 
+    enable_mount_s3 = False
+
+    s3_bucket = "" # required when enable_mount_s3 = True, replace with your actual data bucket name in quotes, ie. "my-dataset-bucket"
+
+    if enable_mount_s3 and not s3_bucket:
+        raise ValueError("Error: A bucket name must be specified when enable_mount_s3 is True")
+
 
 # Configuration parameters for ActiveDirectory/LDAP/SSSD
 class SssdConfig:

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
@@ -179,7 +179,6 @@ def main(args):
         ExecuteBashScript("./apply_hotfix.sh").run(node_type)
         ExecuteBashScript("./utils/motd.sh").run(node_type)
         ExecuteBashScript("./utils/fsx_ubuntu.sh").run()
-
         ExecuteBashScript("./start_slurm.sh").run(node_type, ",".join(controllers))
 
         # Install metric exporting software and Prometheus for observability
@@ -205,7 +204,7 @@ def main(args):
         if Config.enable_update_neuron_sdk:
             if node_type == SlurmNodeType.COMPUTE_NODE:
                 ExecuteBashScript("./utils/update_neuron_sdk.sh").run()
-
+        
         # Install and configure SSSD for ActiveDirectory/LDAP integration
         if Config.enable_sssd:
             subprocess.run(["python3", "-u", "setup_sssd.py", "--node-type", node_type], check=True)
@@ -216,6 +215,9 @@ def main(args):
         if Config.enable_pam_slurm_adopt:
             ExecuteBashScript("./utils/slurm_fix_plugstackconf.sh").run()
             ExecuteBashScript("./utils/pam_adopt_cgroup_wheel.sh").run()
+
+        if Config.enable_mount_s3:
+            ExecuteBashScript("./utils/mount-s3.sh").run(Config.s3_bucket)
 
     print("[INFO]: Success: All provisioning scripts completed")
 

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/mount-s3.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/mount-s3.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Check if a bucket name is provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <bucketname>"
+    exit 1
+fi
+
+# Define variables
+bucketname="$1"
+mount_dir="/mnt/$bucketname"
+mountpoint_install_dir="/opt/mountpoint-s3"
+bash_script="/usr/local/bin/mount-s3.sh"
+systemd_service="/etc/systemd/system/mount-s3.service"
+
+# Step 1: Create the bash script for mounting the S3 bucket
+sudo tee $bash_script > /dev/null <<EOF
+#!/bin/bash
+
+bucketname="$bucketname"
+mount_dir="$mount_dir"
+mountpoint_install_dir="$mountpoint_install_dir"
+
+# Ensure mountpoint directory exists
+[ ! -d "\$mountpoint_install_dir" ] && sudo mkdir -p "\$mountpoint_install_dir"
+
+# Install mount-s3 if not installed
+if ! command -v mount-s3 &> /dev/null; then
+    sudo wget -q -P "\$mountpoint_install_dir" https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
+    sudo apt-get install -y "\$mountpoint_install_dir/mount-s3.deb"
+fi
+
+# Enable user_allow_other in /etc/fuse.conf if needed
+sudo sed -i 's/^#user_allow_other/user_allow_other/' /etc/fuse.conf
+
+# Create mount directory
+[ ! -d "\$mount_dir" ] && sudo mkdir -p "\$mount_dir"
+
+# Mount S3 bucket
+sudo mount-s3 --allow-other "\$bucketname" "\$mount_dir" 2>&1 | tee /var/log/mount-s3.log
+
+# Verify mount success
+if mountpoint -q "\$mount_dir"; then
+    echo "Successfully mounted \$bucketname to \$mount_dir"
+else
+    echo "Failed to mount \$bucketname"
+    exit 1
+fi
+EOF
+
+# Make the bash script executable
+sudo chmod +x $bash_script
+echo "Created and set executable permissions for $bash_script"
+
+# Step 2: Create the systemd service file
+sudo tee $systemd_service > /dev/null <<EOF
+[Unit]
+Description=Mount S3 Bucket using mount-s3 (fuse)
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=$bash_script
+RemainAfterExit=true
+ExecStop=/bin/fusermount -u $mount_dir
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "Created systemd service at $systemd_service"
+
+# # Step 3: Reload systemd to pick up the new service
+sudo systemctl daemon-reload
+echo "Reloaded systemd"
+
+# Step 4: Start the service
+sudo systemctl start mount-s3.service
+echo "Started the mount-s3 service"
+
+# Step 5: Enable the service to start at boot
+sudo systemctl enable mount-s3.service
+echo "Enabled the mount-s3 service to start on boot"


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Opt-In lifeycle script that has 2 parameters in configy.py. When set to true, a s3 bucket is defined, and the cluster execution role has sufficient permission, `mount-s3.sh` file will create a systemd service called mount-s3.service on each of the nodes, which will run the mount script that is cat'ed in the LCS script. 

I have confirmed the script works as intended, when run via lifecycle on 4 node cluster:

config.py:

```
    enable_mount_s3 = True

    data_bucket = "synth-tar-data" # when enable_mount_s3 = True, replace with your actual data bucket name

```

and confirming fuse is mounted correctly:

```
 srun -N 4 mount | grep '/mnt/synth'
mountpoint-s3 on /mnt/synth-tar-data type fuse (rw,nosuid,nodev,noatime,user_id=0,group_id=0,default_permissions,allow_other)
mountpoint-s3 on /mnt/synth-tar-data type fuse (rw,nosuid,nodev,noatime,user_id=0,group_id=0,default_permissions,allow_other)
mountpoint-s3 on /mnt/synth-tar-data type fuse (rw,nosuid,nodev,noatime,user_id=0,group_id=0,default_permissions,allow_other)
mountpoint-s3 on /mnt/synth-tar-data type fuse (rw,nosuid,nodev,noatime,user_id=0,group_id=0,default_permissions,allow_other)
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
