### PR TITLE
don't display login in motd if no login node

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/motd.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/motd.sh
@@ -10,5 +10,5 @@ GREEN="\e[32m"
 ENDCOLOR="\e[0m"
 echo -e "You're on the ${GREEN}$1${ENDCOLOR}" | sudo tee -a /etc/motd
 echo -e "Controller Node IP: ${GREEN}$2${ENDCOLOR}" | sudo tee -a /etc/motd
-echo -e "Login Node IP: ${GREEN}$3${ENDCOLOR}" | sudo tee -a /etc/motd
+[ ! -z "$3" ] && echo -e "Login Node IP: ${GREEN}$3${ENDCOLOR}" | sudo tee -a /etc/motd
 echo -e "Instance Type: ${GREEN}ml.${instance_type}${ENDCOLOR}" | sudo tee -a /etc/motd


### PR DESCRIPTION
Prevent this from happening:
<img width="872" alt="image" src="https://github.com/user-attachments/assets/aec8ad0d-c4ba-41b8-9f40-68fae3076fed">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
