### PR TITLE
easy-ssh.sh switch to default (ubuntu) user

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
@@ -108,10 +108,10 @@ echo -e "Cluster id: ${GREEN}${cluster_id}${NC}"
 echo -e "Instance id: ${GREEN}${instance_id}${NC}"
 echo -e "Node Group: ${GREEN}${node_group}${NC}"
 
-echo -e "\naws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}\n"
+echo -e "\naws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document SSM-SessionManagerRunShellAsUbuntu\n"
 
 check_ssh_config
 
 [[ DRY_RUN -eq 1 ]] && exit 0
 
-aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}
+aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document SSM-SessionManagerRunShellAsUbuntu

--- a/1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml
@@ -443,6 +443,29 @@ Resources:
           - '${S3Bucket}-${RandomGUID}'
           - { RandomGUID: !Select [0, !Split ["-", !Select [2, !Split ["/", !Ref AWS::StackId ]]]] }
 
+  SSMSessionManagerRunShellAsUbuntu:
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentType: "Session"
+      Content:
+        schemaVersion: "1.0"
+        description: "Document to hold regional settings for Session Manager"
+        sessionType: "Standard_Stream"
+        inputs:
+          s3BucketName: ""
+          s3KeyPrefix: ""
+          s3EncryptionEnabled: true
+          cloudWatchLogGroupName: ""
+          cloudWatchEncryptionEnabled: true
+          cloudWatchStreamingEnabled: true
+          idleSessionTimeout: "20"
+          maxSessionDuration: ""
+          kmsKeyId: ""
+          runAsEnabled: true
+          runAsDefaultUser: "ubuntu"
+          shellProfile:
+            windows: ""
+            linux: "/bin/bash"
 
 #############
 ## Outputs ##


### PR DESCRIPTION
Creates a custom SSM document `SSM-SessionManagerRunShellAsUbuntu` to connect as `ubuntu` user by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
