### PR TITLE
Raising the default Kubernetes version in HyperPod EKS template to 1.30

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/hyperpod-eks-full-stack.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/hyperpod-eks-full-stack.yaml
@@ -118,7 +118,7 @@ Parameters:
   KubernetesVersion:
     Description: Kubernetes version to use for EKS cluster
     Type: String
-    Default: '1.29'
+    Default: '1.30'
 
   EKSPrivateSubnet1CIDR:
     Description: Please enter the IP range (CIDR notation) for the EKS private subnet in the first Availability Zone. EKS will use this subnet to deploy cross-account ENIs.


### PR DESCRIPTION
*Description of changes:*

Raising the default Kubernetes version in HyperPod EKS template to 1.30.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
