### PR TITLE
pin prometheus to version 2.55.1

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_prometheus.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_prometheus.sh
@@ -32,8 +32,11 @@ generate_targets() {
 }
 
 # Retrieve the latest Prometheus version from GitHub releases
-echo "Retrieving the latest Prometheus version..."
-LATEST_VERSION=$(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | grep -oP '"tag_name": "\K(.*?)(?=")' | sed 's/^v//')
+#echo "Retrieving the latest Prometheus version..."
+#LATEST_VERSION=$(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | grep -oP '"tag_name": "\K(.*?)(?=")' | sed 's/^v//')
+
+echo "Using pinned Prometheus version 2.55.1"
+LATEST_VERSION=2.55.1
 
 # Check if the latest version retrieval was successful
 if [ -z "$LATEST_VERSION" ]; then

--- a/4.validation_and_observability/4.prometheus-grafana/update-prometheus.sh
+++ b/4.validation_and_observability/4.prometheus-grafana/update-prometheus.sh
@@ -37,8 +37,11 @@ if command -v prometheus &>/dev/null; then
     echo "Prometheus is already installed. Skipping installation."
 else
     # Retrieve the latest Prometheus version from GitHub releases
-    echo "Retrieving the latest Prometheus version..."
-    LATEST_VERSION=$(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | grep -oP '"tag_name": "\K(.*?)(?=")' | sed 's/^v//')
+    # echo "Retrieving the latest Prometheus version..."
+    # LATEST_VERSION=$(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | grep -oP '"tag_name": "\K(.*?)(?=")' | sed 's/^v//')
+    
+    echo "Using pinned Prometheus version 2.55.1"
+    LATEST_VERSION=2.55.1 
 
     # Check if the latest version retrieval was successful
     if [ -z "$LATEST_VERSION" ]; then


### PR DESCRIPTION
*Issue #, if available:* Prometheus 3.0, released 11/14, removes the ability to use `--enable-feature=agent --storage.agent.path="/opt/prometheus/data-agent` flag which is implemented in the `prometheus.service` file when installing prometheus on the controller node.

This leads error when the latest prometheus 3.0.0 version is pulled in the install-prometheus.sh script

2 Alternatives explored, going with the lower risk option 2 until option 1 can be better understood. 

**1/** continuing to pull latest version and replacing with `--storage.tsdb.path="/opt/prometheus/data"` confirmed to work and successfully install prometheus correctly, however removing the [remote-agent](https://prometheus.io/blog/#prometheus-agent-mode)  leads to risk of disk space filling up on controller. Until the risks of this new behavior are better understood, this option leads to too much risk.

**2/** Pin the prometheus version to 2.55.1, which is known to work at x1000 node cluster scale. 

Both options have been validated, but 2 is less risky. 

*Description of changes:*
pin prometheus version to 2.55.1 instead of pulling latest. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
