### PR TITLE
fix: Updating Dockerfile to pin versions and fix the exampel

### DIFF
--- a/3.test_cases/10.FSDP/Dockerfile
+++ b/3.test_cases/10.FSDP/Dockerfile
@@ -3,8 +3,8 @@ FROM public.ecr.aws/hpc-cloud/nccl-tests:latest
 
 RUN apt update && apt install -y nvtop
 
-RUN pip install torchvision torchaudio transformers datasets fsspec==2023.9.2 python-etcd numpy==1.*
-RUN pip install torch==2.2.0+cu121 --index-url https://download.pytorch.org/whl/cu121
+RUN pip install torchvision torchaudio transformers==4.46.1 datasets fsspec==2023.9.2 python-etcd numpy==1.*
+RUN pip install torch==2.5.1+cu121 --index-url https://download.pytorch.org/whl/cu121
 
 RUN mkdir /checkpoints
 


### PR DESCRIPTION
*Issue #:* [491](https://github.com/aws-samples/awsome-distributed-training/issues/491)

*Description of changes:*
Updating the Dockerfile of test case number 10 FSDP to work after a new version of transformers was introduced.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
