### PR TITLE
add an option to pull image

### DIFF
--- a/micro-benchmarks/nccl-tests/README.md
+++ b/micro-benchmarks/nccl-tests/README.md
@@ -41,7 +41,8 @@ The NCCL tests are packaged in a container.
 > |`NCCL_VERSION`         | `v2.23.4-1` | [link](https://github.com/NVIDIA/nccl)                                                      |
 > |`NCCL_TESTS_VERSION`   | `v2.13.10`   | [link](https://github.com/NVIDIA/nccl-tests)                                                |
 
-### Build the container
+### Prepare the container
+
 1. Build the container image with the command below:
    ```bash
    EFA_INSTALLER_VERSION=1.36.0
@@ -57,7 +58,14 @@ The NCCL tests are packaged in a container.
           .
    ```
 
-1. Once the container image is built, you can check if it is present with `docker images`. You should see an output similar to this one:
+   or alternatively pull the image from public ECR repository:
+   ```bash
+   docker pull public.ecr.aws/hpc-cloud/nccl-tests:${EFA_INSTALLER_VERSION}-${AWS_OFI_NCCL_VERSION}-${NCCL_VERSION}-${NCCL_TESTS_VERSION}
+   # or
+   docker pull public.ecr.aws/hpc-cloud/nccl-tests:latest
+   ```
+ 
+1. Once the container image is prepared, you can check if it is present with `docker images`. You should see an output similar to this one:
    ```
    REPOSITORY               TAG                        IMAGE ID       CREATED         SIZE
    nccl                     latest                     6e981e5cf6a5   5 hours ago     8.61GB

--- a/micro-benchmarks/nccl-tests/buildspec.yaml
+++ b/micro-benchmarks/nccl-tests/buildspec.yaml
@@ -16,7 +16,7 @@ env:
 phases:
   pre_build:
     commands:
-      - export TAG="efa${EFA_INSTALLER_VERSION}-ofi${AWS_OFI_NCCL_VERSION}-nccl${NCCL_VERSION}-tests${NCCL_TESTS_VERSION}"
+      - export TAG="${EFA_INSTALLER_VERSION}-${AWS_OFI_NCCL_VERSION}-${NCCL_VERSION}-${NCCL_TESTS_VERSION}"
       - echo "TAG=$TAG"
       - export REPO_COUNT="$(aws ecr describe-repositories | grep repositoryName | grep \"${ECR_REPOSITORY_NAME}\" | wc -l)"
       - if [ "$REPO_COUNT" == 0 ]; then aws ecr create-repository --repository-name ${ECR_REPOSITORY_NAME}; else echo "Repository ${ECR_REPOSITORY_NAME} already exists"; fi


### PR DESCRIPTION
This PR is suggesting to introduce following two changes:

1. Add nccl-tests image pull guidance in README.md.
2. Update `buildsepc.yaml` to create `public.ecr.aws/hpc-cloud/nccl-tests` image with the same tag name convention as README. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
