### PR TITLE
Update gen-keypair-ubuntu.sh to update authorized_keys

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/gen-keypair-ubuntu.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/gen-keypair-ubuntu.sh
@@ -17,7 +17,7 @@ else
 fi
 if [[ $GENERATE_KEYPAIR == 1 ]]; then
     echo Generate a new keypair...
-    ssh-keygen -t rsa -q -f id_rsa -N ""
+    ssh-keygen -t rsa  -b 4096 -q -f id_rsa -N ""
     cat id_rsa.pub >> authorized_keys
     # Set permissions for the ssh keypair
     chmod 600 id_rsa

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/gen-keypair-ubuntu.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/gen-keypair-ubuntu.sh
@@ -4,7 +4,17 @@ set -exuo pipefail
 
 mkdir -p /fsx/ubuntu/.ssh
 cd /fsx/ubuntu/.ssh
-{ test -f id_rsa && grep "^$(cat id_rsa.pub)$" authorized_keys &> /dev/null ; } && GENERATE_KEYPAIR=0 || GENERATE_KEYPAIR=1
+
+# Check if id_rsa exists
+if [ ! -f id_rsa ]; then
+    GENERATE_KEYPAIR=1
+else
+    GENERATE_KEYPAIR=0
+    # Check if id_rsa.pub exists in authorized_keys
+    if ! grep -qF "$(cat id_rsa.pub)" authorized_keys 2>/dev/null; then
+        # If not, add the public key to authorized_keys
+        cat id_rsa.pub >> authorized_keys
+fi
 if [[ $GENERATE_KEYPAIR == 1 ]]; then
     echo Generate a new keypair...
     ssh-keygen -t rsa -q -f id_rsa -N ""


### PR DESCRIPTION
IHAC who accidentally remove contents in `authorized_keys` after cluster setup. That caused
```
2024-12-26T09:09:03.929Z
Generate a new keypair...
2024-12-26T09:09:04.180Z
+ ssh-keygen -t rsa -q -f id_rsa -N ‘’
2024-12-26T09:09:04.180Z
id_rsa already exists.
2024-12-26T09:09:04.430Z
Overwrite (y/n)? Traceback (most recent call last): File “lifecycle_script.py”, line 232, in <module> main(args) File “lifecycle_script.py”, line 185, in main ExecuteBashScript(“./utils/gen-keypair-ubuntu.sh”).run() File “lifecycle_script.py”, line 31, in run result.check_returncode() File “/usr/lib/python3.8/subprocess.py”, line 448, in check_returncode raise CalledProcessError(self.returncode, self.args, self.stdout,
2024-12-26T09:09:08.979Z
subprocess.CalledProcessError: Command ’[’sudo’, ‘bash’, ‘./utils/gen-keypair-ubuntu.sh’]' returned non-zero
```
when they tried to add a new node as `GENERATE_KEYPAIR=1` when we don't have the contents of `id_rsa.pub` in `authorized_keys`, even when the key pair does exist.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
