### PR TITLE
Adding examples for SMHP EKS task governance

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/task-governance/1-imagenet-gpu-team-a.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/task-governance/1-imagenet-gpu-team-a.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-gpu
+  namespace: hyperpod-ns-team-a
+  labels:
+      kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+spec:
+  ports:
+    - name: etcd-client-port
+      port: 2379
+      protocol: TCP
+      targetPort: 2379
+  selector:
+    app: etcd-gpu
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: etcd-gpu
+    kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+  name: etcd-gpu
+  namespace: hyperpod-ns-team-a
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etcd-gpu
+  template:
+    metadata:
+      labels:
+        app: etcd-gpu
+        kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: ml.g5.8xlarge
+      containers:
+        - name: etcd
+          command: ["/usr/local/bin/etcd"]
+          args:
+            - "--data-dir"
+            - "/var/lib/etcd"
+            - "--enable-v2"
+            - "--listen-client-urls"
+            - "http://0.0.0.0:2379"
+            - "--advertise-client-urls"
+            - "http://0.0.0.0:2379"
+            - "--initial-cluster-state"
+            - "new"
+          image: quay.io/coreos/etcd:latest
+          ports:
+            - containerPort: 2379
+              name: client
+              protocol: TCP
+            - containerPort: 2380
+              name: server
+              protocol: TCP
+      restartPolicy: Always
+---
+# Example from: https://github.com/kubeflow/training-operator/tree/master/examples/pytorch/elastic/imagenet
+apiVersion: "kubeflow.org/v1"
+kind: PyTorchJob
+metadata:
+  name: imagenet-gpu-team-a-1
+  namespace: hyperpod-ns-team-a
+  labels:
+      kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+  annotations: {
+    sagemaker.amazonaws.com/enable-job-auto-resume: "true",
+    sagemaker.amazonaws.com/job-max-retry-count: "2"
+  }
+spec:
+  elasticPolicy:
+    rdzvBackend: etcd
+    rdzvHost: etcd-gpu
+    rdzvPort: 2379
+    minReplicas: 1
+    maxReplicas: 36
+    maxRestarts: 200
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 3
+      restartPolicy: OnFailure
+      template:
+        metadata:
+          labels:
+            app: imagenet
+            kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+        spec:
+          nodeSelector:
+            node.kubernetes.io/instance-type: "ml.g5.8xlarge"
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - imagenet
+                topologyKey: "topology.kubernetes.io/zone"
+          containers:
+            - name: pytorch
+              image: kubeflow/pytorch-elastic-example-imagenet:latest
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  nvidia.com/gpu: 1
+                limits:
+                  nvidia.com/gpu: 1
+              env:
+              - name: LOGLEVEL
+                value: DEBUG
+              command:
+                - bash
+                - -c
+                - "wget https://raw.githubusercontent.com/pytorch/elastic/master/examples/imagenet/main.py -O /workspace/examples/imagenet.py; /usr/local/bin/torchrun --nproc_per_node=1 --nnodes=3 /workspace/examples/imagenet.py --arch=resnet18 --epochs=50 --batch-size=32 --workers=0 --checkpoint-file=/workspace/checkpoint.pth.tar /workspace/data/tiny-imagenet-200"
+

--- a/1.architectures/7.sagemaker-hyperpod-eks/task-governance/1-imagenet-gpu-team-a.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/task-governance/1-imagenet-gpu-team-a.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: hyperpod-ns-team-a
   labels:
       kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+      kueue.x-k8s.io/priority-class: training-priority
 spec:
   ports:
     - name: etcd-client-port
@@ -21,6 +22,7 @@ metadata:
   labels:
     app: etcd-gpu
     kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+    kueue.x-k8s.io/priority-class: training-priority
   name: etcd-gpu
   namespace: hyperpod-ns-team-a
 spec:
@@ -33,6 +35,7 @@ spec:
       labels:
         app: etcd-gpu
         kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+        kueue.x-k8s.io/priority-class: training-priority
     spec:
       nodeSelector:
         node.kubernetes.io/instance-type: ml.g5.8xlarge
@@ -67,6 +70,7 @@ metadata:
   namespace: hyperpod-ns-team-a
   labels:
       kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+      kueue.x-k8s.io/priority-class: training-priority
   annotations: {
     sagemaker.amazonaws.com/enable-job-auto-resume: "true",
     sagemaker.amazonaws.com/job-max-retry-count: "2"
@@ -95,6 +99,7 @@ spec:
           labels:
             app: imagenet
             kueue.x-k8s.io/queue-name: hyperpod-ns-team-a-localqueue
+            kueue.x-k8s.io/priority-class: training-priority
         spec:
           nodeSelector:
             node.kubernetes.io/instance-type: "ml.g5.8xlarge"

--- a/1.architectures/7.sagemaker-hyperpod-eks/task-governance/2-hyperpod-cli-example-team-b.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/task-governance/2-hyperpod-cli-example-team-b.yaml
@@ -1,0 +1,32 @@
+defaults:
+  - override hydra/job_logging: stdout
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+training_cfg:
+  entry_script: /opt/pytorch-mnist/mnist.py
+  script_args: []
+  run:
+    name: hyperpod-cli-mnist-team-b
+    nodes: 2
+    ntasks_per_node: 1
+cluster:
+  cluster_type: k8s
+  instance_type: ml.g5.8xlarge
+  cluster_config:
+    namespace: hyperpod-ns-team-b
+    label_selector:
+      required:
+        sagemaker.amazonaws.com/node-health-status:
+          - Schedulable
+      preferred:
+        sagemaker.amazonaws.com/deep-health-check-status:
+          - Passed
+      weights:
+        - 100
+    pullPolicy: IfNotPresent
+base_results_dir: ./result
+container: docker.io/kubeflowkatib/pytorch-mnist-cpu:v1beta1-bc09cfd
+env_vars:
+  NCCL_DEBUG: INFO

--- a/1.architectures/7.sagemaker-hyperpod-eks/task-governance/2-hyperpod-cli-example-team-b.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/task-governance/2-hyperpod-cli-example-team-b.yaml
@@ -14,6 +14,8 @@ training_cfg:
 cluster:
   cluster_type: k8s
   instance_type: ml.g5.8xlarge
+  custom_labels:
+    kueue.x-k8s.io/priority-class: training-priority
   cluster_config:
     namespace: hyperpod-ns-team-b
     label_selector:

--- a/1.architectures/7.sagemaker-hyperpod-eks/task-governance/3-imagenet-gpu-team-b-higher-prio.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/task-governance/3-imagenet-gpu-team-b-higher-prio.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-gpu
+  namespace: hyperpod-ns-team-b
+  labels:
+      kueue.x-k8s.io/queue-name: hyperpod-ns-team-b-localqueue
+      kueue.x-k8s.io/priority-class: experimentation-priority
+spec:
+  ports:
+    - name: etcd-client-port
+      port: 2379
+      protocol: TCP
+      targetPort: 2379
+  selector:
+    app: etcd-gpu
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: etcd-gpu
+    kueue.x-k8s.io/queue-name: hyperpod-ns-team-b-localqueue
+    kueue.x-k8s.io/priority-class: experimentation-priority
+  name: etcd-gpu
+  namespace: hyperpod-ns-team-b
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etcd-gpu
+  template:
+    metadata:
+      labels:
+        app: etcd-gpu
+        kueue.x-k8s.io/queue-name: hyperpod-ns-team-b-localqueue
+        kueue.x-k8s.io/priority-class: experimentation-priority
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: ml.g5.8xlarge
+      containers:
+        - name: etcd
+          command: ["/usr/local/bin/etcd"]
+          args:
+            - "--data-dir"
+            - "/var/lib/etcd"
+            - "--enable-v2"
+            - "--listen-client-urls"
+            - "http://0.0.0.0:2379"
+            - "--advertise-client-urls"
+            - "http://0.0.0.0:2379"
+            - "--initial-cluster-state"
+            - "new"
+          image: quay.io/coreos/etcd:latest
+          ports:
+            - containerPort: 2379
+              name: client
+              protocol: TCP
+            - containerPort: 2380
+              name: server
+              protocol: TCP
+      restartPolicy: Always
+---
+# Example from: https://github.com/kubeflow/training-operator/tree/master/examples/pytorch/elastic/imagenet
+apiVersion: "kubeflow.org/v1"
+kind: PyTorchJob
+metadata:
+  name: imagenet-gpu-team-b-2
+  namespace: hyperpod-ns-team-b
+  labels:
+      kueue.x-k8s.io/queue-name: hyperpod-ns-team-b-localqueue
+      kueue.x-k8s.io/priority-class: experimentation-priority
+  annotations: {
+    sagemaker.amazonaws.com/enable-job-auto-resume: "true",
+    sagemaker.amazonaws.com/job-max-retry-count: "2"
+  }
+spec:
+  elasticPolicy:
+    rdzvBackend: etcd
+    rdzvHost: etcd-gpu
+    rdzvPort: 2379
+    minReplicas: 1
+    maxReplicas: 36
+    maxRestarts: 200
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 2
+      restartPolicy: OnFailure
+      template:
+        metadata:
+          labels:
+            app: imagenet
+            kueue.x-k8s.io/queue-name: hyperpod-ns-team-b-localqueue
+            kueue.x-k8s.io/priority-class: experimentation-priority
+        spec:
+          nodeSelector:
+            node.kubernetes.io/instance-type: "ml.g5.8xlarge"
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - imagenet
+                topologyKey: "topology.kubernetes.io/zone"
+          containers:
+            - name: pytorch
+              image: kubeflow/pytorch-elastic-example-imagenet:latest
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  nvidia.com/gpu: 1
+                limits:
+                  nvidia.com/gpu: 1
+              env:
+              - name: LOGLEVEL
+                value: DEBUG
+              command:
+                - bash
+                - -c
+                - "wget https://raw.githubusercontent.com/pytorch/elastic/master/examples/imagenet/main.py -O /workspace/examples/imagenet.py; /usr/local/bin/torchrun --nproc_per_node=1 --nnodes=3 /workspace/examples/imagenet.py --arch=resnet18 --epochs=50 --batch-size=32 --workers=0 --checkpoint-file=/workspace/checkpoint.pth.tar /workspace/data/tiny-imagenet-200"
+

--- a/1.architectures/7.sagemaker-hyperpod-eks/task-governance/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/task-governance/README.md
@@ -1,0 +1,203 @@
+# SageMaker HyperPod Task Governance
+
+SageMaker HyperPod task governance is a management system designed to streamline resource allocation and ensure efficient utilization of compute resources across teams and projects for your Amazon EKS clusters. It provides administrators with the capability to set priority levels for various tasks, allocate compute resources for each team, determine how idle compute is borrowed and lent between teams, and configure whether a team can preempt its own tasks.
+
+HyperPod task governance leverages Kueue for Kubernetes-native job queueing, scheduling, and quota management and is installed using the HyperPod task governance EKS add-on. When installed, HyperPod creates and modifies SageMaker AI-managed Kubernetes resources such as:
+- KueueManagerConfig
+- ClusterQueues
+- LocalQueues
+- WorkloadPriorityClasses
+- ResourceFlavors
+- ValidatingAdmissionPolicies
+
+While Kubernetes administrators have the flexibility to modify the state of these resources, any changes made to a SageMaker AI-managed resource may be updated and overwritten by the service.
+
+## Enable Task Governance
+
+### Prerequisites
+
+- Amazon EKS cluster running Kubernetes version 1.30 or greater
+
+- No existing installations of Kueue (it must be removed before installing the add-on)
+
+### Installation Steps
+
+To install the **SageMaker HyperPod task governance EKS add-on**, run the following command:
+
+```
+aws eks create-addon --region $REGION --cluster-name $EKS_CLUSTER_NAME --addon-name amazon-sagemaker-hyperpod-taskgovernance
+```
+
+Verify successful installation with:
+
+```
+aws eks describe-addon --region $REGION --cluster-name $EKS_CLUSTER_NAME --addon-name amazon-sagemaker-hyperpod-taskgovernance
+```
+
+If the installation was successful, you should see details about the installed add-on in the output.
+
+## Setup for running the examples
+
+### Cluster Policy and Compute Allocation Setup
+
+Before running the examples, you need to set up a Cluster Policy and define Compute Allocations for the teams.
+
+This example assumes a cluster with **4 g5.8xlarge instances** and two teams (Team A and Team B). The Cluster Policy will use task ranking instead of the default FIFO (First-In-First-Out) behavior, allowing tasks with higher priorities to preempt lower-priority tasks.
+
+#### Create a Cluster Policy
+
+To update how tasks are prioritized and how idle compute is allocated, apply a Cluster Policy using the following placeholder configuration:
+
+```
+aws sagemaker \
+    --region $REGION \
+    create-cluster-scheduler-config \
+    --name "example-cluster-scheduler-config" \
+    --cluster-arn "<Enter HyperPod ClusterArn>" \
+    --scheduler-config "PriorityClasses=[{Name=inference,Weight=90},{Name=experimentation,Weight=80},{Name=fine-tuning,Weight=50},{Name=training,Weight=70}],FairShare=Enabled"
+```
+
+#### Create Compute Allocations
+
+Each team requires a Compute Allocation to manage their compute capacity. Both teams will have 2 instances allocated, 100 fair-share weight, and 50% borrowing capability.
+
+```
+aws sagemaker \
+    --region $REGION \
+    create-compute-quota \
+    --name "Team-A-Quota-Allocation" \
+    --cluster-arn "<Enter HyperPod ClusterArn>" \
+    --compute-quota-config "ComputeQuotaResources=[{InstanceType=ml.g5.8xlarge,Count=2}],ResourceSharingConfig={Strategy=LendAndBorrow,BorrowLimit=50},PreemptTeamTasks=LowerPriority" \
+    --activation-state "Enabled" \
+    --compute-quota-target "TeamName=team-a,FairShareWeight=0"
+```
+
+```
+aws sagemaker \
+    --region $REGION \
+    create-compute-quota \
+    --name "Team-B-Quota-Allocation" \
+    --cluster-arn "<Enter HyperPod ClusterArn>" \
+    --compute-quota-config "ComputeQuotaResources=[{InstanceType=ml.g5.8xlarge,Count=2}],ResourceSharingConfig={Strategy=LendAndBorrow,BorrowLimit=50},PreemptTeamTasks=LowerPriority" \
+    --activation-state "Enabled" \
+    --compute-quota-target "TeamName=team-b,FairShareWeight=0"
+```
+
+If using a different cluster size, adjust the CLI commands and job submission configurations accordingly.
+
+## Running the examples
+
+Once the cluster policy and compute allocations are configured, you can run the following examples demonstrating various aspects of HyperPod task governance:
+
+### Job 1: Idle Compute Usage
+
+**Scenario:** Team A submits a PyTorch job that requires **3 instances** but only has **2 allocated**. The system allows Team A to **borrow** 1 instance from Team B's idle capacity.
+
+```
+kubectl apply -f 1-imagenet-gpu-team-a.yaml --namespace hyperpod-ns-team-a
+```
+
+Verify the job is running (pulling the container image might take a moment):
+```
+kubectl get pods -n hyperpod-ns-team-a
+```
+
+Once the pods are running, you can check the output of logs to identify the elected master:
+```
+kubectl logs imagenet-gpu-team-a-1-worker-0 --namespace hyperpod-ns-team-a | grep master_addr=
+```
+```
+[2025-02-04 18:58:08,460] torch.distributed.elastic.agent.server.api: [INFO]   master_addr=imagenet-gpu-team-a-1-worker-2
+```
+You can then use the pod referenced in the `master_addr` to look at the current training progress:
+```
+kubectl logs imagenet-gpu-team-a-1-worker-2 --namespace hyperpod-ns-team-a
+```
+
+### Job 2: Guaranteed Compute
+
+**Scenario:** Team B needs to reclaim its compute resources. By submitting a job requiring **2 instances**, Team B's job is **prioritized**, and Job 1 is **suspended** due to resource unavailability.
+
+In this example, we'll be using the hyperpod CLI, but we could also use kubectl and have identical behavior.
+
+```
+hyperpod start-job --config-file 2-hyperpod-cli-example-team-b.yaml
+```
+
+After the job has been submitted, you can see that the workers from Job 1 have been preempted, and only the workers in Team B's namespace are running.
+```
+kubectl get pods -n hyperpod-ns-team-a
+```
+Check running pods for Team B:
+```
+kubectl get pods -n hyperpod-ns-team-b
+```
+
+### Job 3: Preemption by Priorities
+
+**Scenario:** Team B submits a **high-priority job** requiring **2 instances**. Since high-priority jobs take precedence, **Job 2 is suspended**, ensuring Team B’s critical workload runs first.
+
+
+```
+kubectl apply -f 3-imagenet-gpu-team-b-higher-prio.yaml --namespace hyperpod-ns-team-b
+```
+
+Since this job uses a **priority-class**, the lower-priority Job 2 is preempted:
+
+```
+kubectl get pods -n hyperpod-ns-team-b
+```
+### Inspecting workloads
+
+We can also inspect the workloads on a particular namespace:
+```
+kubectl get workloads -n hyperpod-ns-team-b
+```
+This is an example output of the command after running all 3 scenarios:
+
+```
+NAME                                         QUEUE                           RESERVED IN                       ADMITTED   FINISHED   AGE
+pod-etcd-gpu-6584d647d4-sp6xx-bb3f9          hyperpod-ns-team-b-localqueue   hyperpod-ns-team-b-clusterqueue   True                  11s
+pytorchjob-hyperpod-cli-mnist-team-b-2c720   hyperpod-ns-team-b-localqueue                                     False                 45s
+pytorchjob-imagenet-gpu-team-b-2-ef5c0       hyperpod-ns-team-b-localqueue   hyperpod-ns-team-b-clusterqueue   True                  11s
+```
+We can see that the workload for Job 2 has been set to `ADMITTED: False` because the newly submitted workload took precedence.
+
+When we describe the suspended workload, we can see the reason it was preempted.
+```
+kubectl describe workload pytorchjob-hyperpod-cli-mnist-team-b-2c720 -n hyperpod-ns-team-b
+```
+
+```
+Status:
+  Conditions:
+    Last Transition Time:  2025-02-04T19:06:25Z
+    Message:               couldn't assign flavors to pod set worker: borrowing limit for nvidia.com/gpu in flavor ml.g5.8xlarge exceeded
+    Observed Generation:   1
+    Reason:                Pending
+    Status:                False
+    Type:                  QuotaReserved
+    Last Transition Time:  2025-02-04T19:06:25Z
+    Message:               Preempted to accommodate a workload (UID: d34468c2-1ce5-47cd-a61d-689be78b6121) due to prioritization in the ClusterQueue
+    Observed Generation:   1
+    Reason:                Preempted
+    Status:                True
+    Type:                  Evicted
+    Last Transition Time:  2025-02-04T19:06:25Z
+    Message:               The workload has no reservation
+    Observed Generation:   1
+    Reason:                NoReservation
+    Status:                False
+    Type:                  Admitted
+    Last Transition Time:  2025-02-04T19:06:25Z
+    Message:               Preempted to accommodate a workload (UID: d34468c2-1ce5-47cd-a61d-689be78b6121) due to prioritization in the ClusterQueue
+    Reason:                InClusterQueue
+    Status:                True
+    Type:                  Preempted
+    Last Transition Time:  2025-02-04T19:06:25Z
+    Message:               Preempted to accommodate a workload (UID: d34468c2-1ce5-47cd-a61d-689be78b6121) due to prioritization in the ClusterQueue
+    Observed Generation:   1
+    Reason:                Preempted
+    Status:                True
+    Type:                  Requeued
+```

--- a/1.architectures/7.sagemaker-hyperpod-eks/task-governance/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/task-governance/README.md
@@ -142,7 +142,7 @@ kubectl get pods -n hyperpod-ns-team-b
 kubectl apply -f 3-imagenet-gpu-team-b-higher-prio.yaml --namespace hyperpod-ns-team-b
 ```
 
-Since this job uses a **priority-class**, the lower-priority Job 2 is preempted:
+Since this job uses a **priority-class** with a higher weight than the other jobs, the lower-priority Job 2 is preempted:
 
 ```
 kubectl get pods -n hyperpod-ns-team-b


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added a new section on Task Governance for SageMaker HyperPod on EKS, including setup instructions for cluster policies and compute allocations, along with examples demonstrating resource borrowing, guaranteed compute, and priority-based preemption.