### PR TITLE
Fixing FSDP app's Dockerfile

### DIFF
--- a/3.test_cases/10.FSDP/Dockerfile
+++ b/3.test_cases/10.FSDP/Dockerfile
@@ -3,8 +3,8 @@ FROM public.ecr.aws/hpc-cloud/nccl-tests:latest
 
 RUN apt update && apt install -y nvtop
 
-RUN pip install torchvision torchaudio transformers==4.46.1 datasets fsspec==2023.9.2 python-etcd numpy==1.*
-RUN pip install torch==2.5.1+cu121 --index-url https://download.pytorch.org/whl/cu121
+RUN pip install transformers==4.46.1 datasets fsspec==2023.9.2 python-etcd numpy==1.*
+RUN pip install torch==2.5.1+cu121 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
 
 RUN mkdir /checkpoints
 


### PR DESCRIPTION
*Description of changes:*

Fixing Dockerfile of the FSDP sample app to install the versions of torchvision and torchaudio that match the version of torch.

Before this fix, the app fails with following error:
```
operator torchvision::nms does not exist
```

This is because torch/torchaudio/torchvision are inconsistent and incompatible.
```
torch                    2.5.1+cu121
torchaudio               2.6.0
torchvision              0.21.0
```

By applying this fix, these package versions will be
```
torch                    2.5.1+cu121
torchaudio               2.5.1+cu121
torchvision              0.20.1+cu121
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
