### PR TITLE
Minor change to OS cluster observability CF stack description

### DIFF
--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: CloudFormation template to monitor SageMaker Hyperpod - launches a t2.medium instance with 30GB of storage, security group, IAM role for Prometheus access, Grafana setup, and a Prometheus workspace.
+Description: Setup to monitor sagemaker hyperpod clusters on AWS. CloudFormation template to monitor SageMaker Hyperpod - launches a t2.medium instance with 30GB of storage, security group, IAM role for Prometheus access, Grafana setup, and a Prometheus workspace.
 
 Parameters:
   LatestAmiId:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Minor change to `cluster-observability-os-grafana.yaml`: Added line 'Setup to monitor sagemaker hyperpod clusters on AWS' to description (from [here](https://github.com/aws-samples/awsome-distributed-training/blob/main/4.validation_and_observability/4.prometheus-grafana/cluster-observability.yaml#L2C15-L2C66))

Reason: The `install_prometheus.sh` [LCS](https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_prometheus.sh#L9-L13) uses the following login to get the `AMPRemoteWriteURL`:
```
aws cloudformation describe-stacks \
--region $REGION \
--query "Stacks[?Description != null && contains(Description, 'monitor sagemaker hyperpod')][].Outputs[?OutputKey=='AMPRemoteWriteURL'].OutputValue" \
--output text
```

This will be a catchall way for the `--query` to get the right observability stack and get the `AMPRemoteWriteURL` for the prometheus config. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
