### PR TITLE
Changed docker run command for os observability stack to use IMDSv2

### DIFF
--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: CloudFormation template to monitor SageMaker Hyperpod - launches a t2.medium instance with 30GB of storage, security group, IAM role for Prometheus access, Grafana setup, and a Prometheus workspace.
+Description: Setup to monitor sagemaker hyperpod clusters on AWS. CloudFormation template to monitor SageMaker Hyperpod - launches a t2.medium instance with 30GB of storage, security group, IAM role for Prometheus access, Grafana setup, and a Prometheus workspace.
 
 Parameters:
   LatestAmiId:

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -93,7 +93,6 @@ Resources:
 
           # Run Grafana container with automatic restart
           echo "Starting Grafana container with restart policy..."
-          # New: Editing docker run command to use "--network host" and "--env AWS_EC2_METADATA_DISABLED=false"
           docker run --network host --env GF_AUTH_SIGV4_AUTH_ENABLED=true --env AWS_SDK_LOAD_CONFIG=true --env AWS_EC2_METADATA_DISABLED=false -d --name=grafana --restart always grafana/grafana:10.4.14-ubuntu
 
           # Print Grafana access info

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -94,7 +94,7 @@ Resources:
 
             # Run Grafana container with automatic restart
             echo "Starting Grafana container with restart policy..."
-            docker run --network host --env GF_AUTH_SIGV4_AUTH_ENABLED=true --env AWS_SDK_LOAD_CONFIG=true --env AWS_EC2_METADATA_DISABLED=false -d --name=grafana --restart always grafana/grafana:10.4.14-ubuntu
+            docker run -p 3000:3000 --add-host=metadata.aws:169.254.169.254 --env GF_AUTH_SIGV4_AUTH_ENABLED=true --env AWS_SDK_LOAD_CONFIG=true --env AWS_EC2_METADATA_DISABLED=false -d --name=grafana --restart always grafana/grafana:10.4.14-ubuntu
 
             # Print Grafana access info
             echo "Docker and Grafana setup complete."

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -49,59 +49,68 @@ Resources:
       Tags:
         - Key: "Name"
           Value: "SageMaker Hyperpod PrometheusMetrics"
+  
+  GrafanaLaunchTemplate:
+    Type: "AWS::EC2::LaunchTemplate"
+    Properties:
+      LaunchTemplateData:
+        ImageId: !Ref LatestAmiId
+        InstanceType: "t2.medium"
+        IamInstanceProfile: 
+          Name: !Ref MyInstanceProfile
+        MetadataOptions:
+          HttpTokens: optional
+          HttpEndpoint: enabled
+          HttpPutResponseHopLimit: 2
+        BlockDeviceMappings:
+          - DeviceName: "/dev/xvda"
+            Ebs:
+              VolumeSize: 30
+        UserData:
+          Fn::Base64: !Sub |
+            #!/bin/bash
+
+            # Update system packages
+            sudo yum update -y
+
+            # Install Docker
+            echo "Installing Docker..."
+            sudo amazon-linux-extras install docker -y
+
+            # Start Docker service
+            echo "Starting Docker service..."
+            sudo systemctl start docker
+
+            # Enable Docker to start on boot
+            sudo systemctl enable docker
+
+            # Add the current user (ec2-user) to the Docker group to run Docker commands without sudo
+            echo "Adding ec2-user to Docker group..."
+            sudo usermod -aG docker ec2-user
+
+            # Pull the latest Grafana image
+            echo "Pulling the latest Grafana Docker image..."
+            docker pull grafana/grafana:10.4.14-ubuntu
+
+            # Run Grafana container with automatic restart
+            echo "Starting Grafana container with restart policy..."
+            docker run --network host --env GF_AUTH_SIGV4_AUTH_ENABLED=true --env AWS_SDK_LOAD_CONFIG=true --env AWS_EC2_METADATA_DISABLED=false -d --name=grafana --restart always grafana/grafana:10.4.14-ubuntu
+
+            # Print Grafana access info
+            echo "Docker and Grafana setup complete."
+            TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+            echo "Grafana is running at http://$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/public-ipv4):3000"
+            echo "Default Grafana login credentials are admin/admin. Please change the password after the first login."
+
+            # Note: Log out and log back in for Docker permissions to take effect
+            echo "Please log out and back in for Docker group permissions to apply."
 
   MyInstance:
     Type: "AWS::EC2::Instance"
     Properties:
-      InstanceType: "t2.medium"
-      ImageId: !Ref LatestAmiId
-      IamInstanceProfile: !Ref MyInstanceProfile
-      MetaDataOptions:
-        HttpTokens: optional
-        HttpEndpoint: enabled
-        HttpPutResponseHopLimit: 2
-      BlockDeviceMappings:
-        - DeviceName: "/dev/xvda"
-          Ebs:
-            VolumeSize: 30
-      UserData:
-        Fn::Base64: !Sub |
-          #!/bin/bash
-
-          # Update system packages
-          sudo yum update -y
-
-          # Install Docker
-          echo "Installing Docker..."
-          sudo amazon-linux-extras install docker -y
-
-          # Start Docker service
-          echo "Starting Docker service..."
-          sudo systemctl start docker
-
-          # Enable Docker to start on boot
-          sudo systemctl enable docker
-
-          # Add the current user (ec2-user) to the Docker group to run Docker commands without sudo
-          echo "Adding ec2-user to Docker group..."
-          sudo usermod -aG docker ec2-user
-
-          # Pull the latest Grafana image
-          echo "Pulling the latest Grafana Docker image..."
-          docker pull grafana/grafana:10.4.14-ubuntu
-
-          # Run Grafana container with automatic restart
-          echo "Starting Grafana container with restart policy..."
-          docker run --network host --env GF_AUTH_SIGV4_AUTH_ENABLED=true --env AWS_SDK_LOAD_CONFIG=true --env AWS_EC2_METADATA_DISABLED=false -d --name=grafana --restart always grafana/grafana:10.4.14-ubuntu
-
-          # Print Grafana access info
-          echo "Docker and Grafana setup complete."
-          TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-          echo "Grafana is running at http://$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/public-ipv4):3000"
-          echo "Default Grafana login credentials are admin/admin. Please change the password after the first login."
-
-          # Note: Log out and log back in for Docker permissions to take effect
-          echo "Please log out and back in for Docker group permissions to apply."
+      LaunchTemplate:
+        LaunchTemplateId: !Ref GrafanaLaunchTemplate
+        Version: !GetAtt GrafanaLaunchTemplate.DefaultVersionNumber
       Tags:
         - Key: "Name"
           Value: "OS-Grafana"

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -82,7 +82,7 @@ Resources:
             sudo systemctl start docker
 
             # Enable Docker to start on boot
-            sudo systemctl enable docker
+            sudo systemctl enable --now docker
 
             # Add the current user (ec2-user) to the Docker group to run Docker commands without sudo
             echo "Adding ec2-user to Docker group..."

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -77,10 +77,6 @@ Resources:
             echo "Installing Docker..."
             sudo amazon-linux-extras install docker -y
 
-            # Start Docker service
-            echo "Starting Docker service..."
-            sudo systemctl start docker
-
             # Enable Docker to start on boot
             sudo systemctl enable --now docker
 

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -59,7 +59,7 @@ Resources:
         IamInstanceProfile: 
           Name: !Ref MyInstanceProfile
         MetadataOptions:
-          HttpTokens: optional
+          HttpTokens: required
           HttpEndpoint: enabled
           HttpPutResponseHopLimit: 2
         BlockDeviceMappings:

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Setup to monitor sagemaker hyperpod clusters on AWS. CloudFormation template to monitor SageMaker Hyperpod - launches a t2.medium instance with 30GB of storage, security group, IAM role for Prometheus access, Grafana setup, and a Prometheus workspace.
+Description: CloudFormation template to monitor SageMaker Hyperpod - launches a t2.medium instance with 30GB of storage, security group, IAM role for Prometheus access, Grafana setup, and a Prometheus workspace.
 
 Parameters:
   LatestAmiId:
@@ -56,6 +56,11 @@ Resources:
       InstanceType: "t2.medium"
       ImageId: !Ref LatestAmiId
       IamInstanceProfile: !Ref MyInstanceProfile
+      # New: Configuring MDS
+      MetaDataOptions:
+        HttpTokens: optional
+        HttpEndpoint: enabled
+        HttpPutResponseHopLimit: 2
       BlockDeviceMappings:
         - DeviceName: "/dev/xvda"
           Ebs:
@@ -88,11 +93,14 @@ Resources:
 
           # Run Grafana container with automatic restart
           echo "Starting Grafana container with restart policy..."
-          docker run --env GF_AUTH_SIGV4_AUTH_ENABLED=true --env AWS_SDK_LOAD_CONFIG=true -d -p 3000:3000 --name=grafana --restart always grafana/grafana:10.4.14-ubuntu
+          # New: Editing docker run command to use "--network host" and "--env AWS_EC2_METADATA_DISABLED=false"
+          docker run --network host --env GF_AUTH_SIGV4_AUTH_ENABLED=true --env AWS_SDK_LOAD_CONFIG=true --env AWS_EC2_METADATA_DISABLED=false -d --name=grafana --restart always grafana/grafana:10.4.14-ubuntu
 
           # Print Grafana access info
           echo "Docker and Grafana setup complete."
-          echo "Grafana is running at http://$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4):3000"
+          # New: Changing to IMDSv2
+          TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+          echo "Grafana is running at http://$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/public-ipv4):3000"
           echo "Default Grafana login credentials are admin/admin. Please change the password after the first login."
 
           # Note: Log out and log back in for Docker permissions to take effect

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -56,7 +56,6 @@ Resources:
       InstanceType: "t2.medium"
       ImageId: !Ref LatestAmiId
       IamInstanceProfile: !Ref MyInstanceProfile
-      # New: Configuring MDS
       MetaDataOptions:
         HttpTokens: optional
         HttpEndpoint: enabled

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability-os-grafana.yaml
@@ -97,7 +97,6 @@ Resources:
 
           # Print Grafana access info
           echo "Docker and Grafana setup complete."
-          # New: Changing to IMDSv2
           TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
           echo "Grafana is running at http://$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/public-ipv4):3000"
           echo "Default Grafana login credentials are admin/admin. Please change the password after the first login."


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
IMDS v2 (used by all new EC2 instances) requires a token to be set before being able to query 169.254.169.254

```
TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
```


Running `curl http://169.254.169.254/latest/meta-data` on the Grafana instance by itself doesn't return anything, but running 
```
curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/ 
```

returns actual metadata! 

Also, here's the log from current instance init:
```
Grafana is running at http://:3000
```

**The CF template itself is not yet tested. I have tested the `docker run` command changes directly on the Grafana instance. We should test the CF stack changes before merging.**

![image](https://github.com/user-attachments/assets/27c07747-55eb-46d5-a034-59a90a92d128)
![image](https://github.com/user-attachments/assets/c382a076-3d0f-4924-ba6d-3107769398c6)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
