### PR TITLE
exit when targeted instance unreachable

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
@@ -131,6 +131,12 @@ print_header "🚀 HyperPod Cluster Easy SSH Script! 🚀"
 cluster_id=$(aws sagemaker describe-cluster "${aws_cli_args[@]}" --cluster-name $cluster_name | jq '.ClusterArn' | awk -F/ '{gsub(/"/, "", $NF); print $NF}')
 instance_id=$(aws sagemaker list-cluster-nodes "${aws_cli_args[@]}" --cluster-name $cluster_name --instance-group-name-contains ${node_group} | jq '.ClusterNodeSummaries[0].InstanceId' | tr -d '"')
 
+# Exit immediately if cluster or instance ID is not found.
+if [[ -z "$cluster_id" || -z "$instance_id" ]]; then
+    echo "Error: Cluster or instance not found for the specified cluster name (${cluster_name}). Exiting."
+    exit 1
+fi
+
 # print_header
 echo -e "Cluster id: ${GREEN}${cluster_id}${NC}"
 echo -e "Instance id: ${GREEN}${instance_id}${NC}"


### PR DESCRIPTION
This PR proposes `easy-ssh.sh` script to exit with error when targeted instance is unreachable.

Before:

```
❯ ./easy-ssh.sh -c controller-machine --region us-east-2 "ml-cluster-p5en"

=================================================

==== 🚀 HyperPod Cluster Easy SSH Script! 🚀 ====


=================================================

An error occurred (ResourceNotFound) when calling the DescribeCluster operation: Cluster with name ml-cluster-p5en not found

An error occurred (ResourceNotFound) when calling the ListClusterNodes operation: Cluster with name ml-cluster-p5en not found
Cluster id: 
Instance id: 
Node Group: controller-machine
Would you like to add ml-cluster-p5en to  ~/.ssh/config (yes/no)?
> 
```

After:

```
 ./easy-ssh.sh -c controller-machine --region us-east-2 "ml-cluster-p5en"

=================================================

==== 🚀 HyperPod Cluster Easy SSH Script! 🚀 ====


=================================================

An error occurred (ResourceNotFound) when calling the DescribeCluster operation: Cluster with name ml-cluster-p5en not found

An error occurred (ResourceNotFound) when calling the ListClusterNodes operation: Cluster with name ml-cluster-p5en not found
Error: Cluster or instance not found for the specified cluster name (ml-cluster-p5en). Exiting.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
