### PR TITLE
add auto-resume flag automatically when job executed on HP

### DIFF
--- a/3.test_cases/22.nemo-run/slurm/run.py
+++ b/3.test_cases/22.nemo-run/slurm/run.py
@@ -77,6 +77,10 @@ def slurm_executor(
 
 
    local_tunnel = run.LocalTunnel(job_dir="")
+
+   if os.path.isdir("/opt/sagemaker_cluster"):
+       print("Detected Hyperpod cluster.. enabling --auto-resume=1")
+       srun_args = ["--auto-resume=1"]
   
    # This defines the slurm executor.
    # We connect to the executor via the tunnel defined by user, host and remote_job_dir.
@@ -91,6 +95,7 @@ def slurm_executor(
        mem="0",
        exclusive=True,
        packager=packager,
+       srun_args=srun_args,
    )
 
 


### PR DESCRIPTION
*Issue #, if available:*

This PR suggest to add flag `--auto-resume=1` flag when nemo run test case is executed on HP.

```python
   if os.path.isdir("/opt/sagemaker_cluster"):
       print("Detected Hyperpod cluster.. enabling --auto-resume=1")
       srun_args = ["--auto-resume=1"]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Log:

```
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 0 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 1 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 2 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 3 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 4 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 5 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 6 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 7 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 8 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 9 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 10 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 11 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 12 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 13 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 14 process_task_init
[Auto Resume] Info: JobID: 42 StepID: 1 TaskID: 15 process_task_init
[NeMo W 2025-03-20 22:30:42 nemo_logging:361] /usr/local/lib/python3.10/dist-packages/pyannote/core/notebook.py:134: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed in 3.11. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap()`` or ``pyplot.get_cmap()`` instead.
...
````
