### PR TITLE
Reduce efa exporter container images

### DIFF
--- a/4.validation_and_observability/3.efa-node-exporter/Dockerfile
+++ b/4.validation_and_observability/3.efa-node-exporter/Dockerfile
@@ -1,14 +1,7 @@
-FROM public.ecr.aws/docker/library/ubuntu:22.04
+FROM public.ecr.aws/docker/library/golang:1.24.1-bookworm AS build
 
 ARG NODE_EXPORTER_VERSION=v1.9.0
 ARG PROCFS_EXPORTER_VERSION=v0.16.0
-ARG GOLANG_VERSION=1.24.1
-
-# install go
-RUN apt update && apt install curl git build-essential -y
-RUN curl -OL https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
-    tar -C /usr/local -xf go${GOLANG_VERSION}.linux-amd64.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
 
 # Install ProcFS
 RUN git clone -b $PROCFS_EXPORTER_VERSION https://github.com/prometheus/procfs.git /workspace/procfs
@@ -21,5 +14,9 @@ COPY amazon_efa_linux.go /workspace/node_exporter/collector/
 
 WORKDIR /workspace/node_exporter
 RUN  go mod edit --replace=github.com/prometheus/procfs=/workspace/procfs
-RUN  go mod tidy && go build -o node_exporter
+RUN  go mod tidy && CGO_ENABLE=0 go build -o /go/bin/node_exporter
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /go/bin/node_exporter /workspace/
+WORKDIR /workspace
 ENTRYPOINT ["./node_exporter"]

--- a/4.validation_and_observability/3.efa-node-exporter/buildspec.yaml
+++ b/4.validation_and_observability/3.efa-node-exporter/buildspec.yaml
@@ -4,7 +4,6 @@ env:
   variables:
     NODE_EXPORTER_VERSION: "v1.9.0"
     PROCFS_EXPORTER_VERSION: "v0.16.0"
-    GOLANG_VERSION: "1.24.1"
   exported-variables:
     - NODE_EXPORTER_VERSION
     - PROCFS_EXPORTER_VERSION
@@ -21,7 +20,7 @@ phases:
       - export REPO_URI="$(aws ecr describe-repositories | grep repositoryUri | grep /${ECR_REPOSITORY_NAME}\" | cut -d '"' -f 4)"
       - echo "REPO_URI=$REPO_URI"
       - echo "Building ${REPO_URI}:${TAG} ..."
-      - cd 4.validation_and_observability/3.efa-node-exporter && docker image build --build-arg NODE_EXPORTER_VERSION=$NODE_EXPORTER_VERSION --build-arg PROCFS_EXPORTER_VERSION=$PROCFS_EXPORTER_VERSION --build-arg GOLANG_VERSION=$GOLANG_VERSION -t ${REPO_URI}:${TAG} -f ./Dockerfile .
+      - cd 4.validation_and_observability/3.efa-node-exporter && docker image build --build-arg NODE_EXPORTER_VERSION=$NODE_EXPORTER_VERSION --build-arg PROCFS_EXPORTER_VERSION=$PROCFS_EXPORTER_VERSION -t ${REPO_URI}:${TAG} -f ./Dockerfile .
   post_build:
     commands:
       - export ECR_URI=${REPO_URI%"/${ECR_REPOSITORY_NAME}"}


### PR DESCRIPTION
This PR changes the container file for efa node exporter to be distroless.
It allows to reduce container image size from ~1.3GB to ~25.5MB.
