### PR TITLE
Add EKS node autorepair example cluster manifest

### DIFF
--- a/1.architectures/4.amazon-eks/README.md
+++ b/1.architectures/4.amazon-eks/README.md
@@ -30,6 +30,11 @@ The following example cluster configurations for distributed training are provid
 * [**`eks-p4de-odcr.yaml`**](./eks-p4de-odcr.yaml): Cluster with 2 * `p4de.24xlarge` instances from an existing ODCR. A new VPC will be created for this cluster. This configuration is useful for distributed training when no VPC is already available. Note that you would have to match the AZ of your ODCR in the nodegroup section of the manifest. Nodegroups in this and previous examples are fully-managed and can be accessed via the EKS console. If you are using an instance type that is not yet supported in managed nodegroups by EKS, you can define a nodegroup in a self-manged nodegroup section as shown at the end of this example.
 * [**`eks-p5-odcr.yaml`**](./eks-p5-odcr.yaml): Cluster with 1 * `p5.48xlarge` instances from an existing ODCR and an existing VPC. Note that you would have to match the AZ of your ODCR in the nodegroup section of the manifest. Nodegroups in this and previous examples are fully-managed and can be accessed via the EKS console. If you are using an instance type that is not yet supported in managed nodegroups by EKS, you can define a nodegroup in a self-manged nodegroup by using the `eks-p5-capacity-block.yaml` template.
 * [**`eks-p5-capacity-block.yaml`**](./eks-p5-capacity-block.yaml): Cluster with 1 * `p5.48xlarge` instances from an existing ML CBR and an existing VPC. Note that you would have to match the AZ of your ML CBR in the node group section of the manifest. Node groups in this and previous examples are fully-managed and can be accessed via the EKS console.
+* [**`eks-g5-node-autorepair.yaml`**](./eks-g5-node-autorepair.yaml): Cluster with 2 * `g5.8xlarge` instances with [node autorepair](https://docs.aws.amazon.com/eks/latest/userguide/node-health.html) enabled, node monitoring agent and cloudwatch observability add-on deployed. You may view enhanced node status using the following command:
+
+```sh
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,CONDITIONS:.status.conditions[*].type,STATUS:.status.conditions[*].status'
+```
 
 ## 3. Cluster creation
 

--- a/1.architectures/4.amazon-eks/eks-g5-node-autorepair.yaml
+++ b/1.architectures/4.amazon-eks/eks-g5-node-autorepair.yaml
@@ -1,0 +1,65 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: eks-g5-autorepair
+  region: PLACEHOLDER_AWS_REGION
+  version: "1.32"
+
+# List availability zones where cluster subnets will be created
+availabilityZones:
+  - PLACEHOLDER_AZ_1
+  - PLACEHOLDER_AZ_2
+
+iam:
+  withOIDC: true
+
+# EKS-managed node group(s)
+managedNodeGroups:
+  # Nodegroup for system pods
+  - name: sys
+    instanceType: c5.2xlarge
+    desiredCapacity: 1
+    iam:
+      withAddonPolicies:
+        autoScaler: true
+        cloudWatch: true
+    nodeRepairConfig:
+      enabled: true
+
+  # GPU nodegroup
+  # List availability zones where instances in from this nodegroup will be launched
+  - name: g5
+    instanceType: g5.8xlarge
+    instancePrefix: g5
+    privateNetworking: true
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 2
+    maxSize: 10
+    availabilityZones: ["PLACEHOLDER_AZ_2"]
+    # Utilize the local instance store volume(s)
+    overrideBootstrapCommand: |
+      apiVersion: node.eks.aws/v1alpha1
+      kind: NodeConfig
+      spec:
+        instance:
+          localStorage:
+            strategy: RAID0
+    iam:
+      withAddonPolicies:
+        autoScaler: true
+        cloudWatch: true
+        ebs: true
+        fsx: true
+    nodeRepairConfig:
+      enabled: true
+
+addons:
+  - name: eks-node-monitoring-agent
+    resolveConflicts: overwrite
+  - name: amazon-cloudwatch-observability
+    resolveConflicts: overwrite
+    attachPolicyARNs:
+      - arn:aws:iam::aws:policy/CloudWatchFullAccess
+


### PR DESCRIPTION
*Issue #585 

*Description of changes:*
Add example manifest with node autorepair, node monitoring and observability add-on enbled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
