### PR TITLE
Fix cloudwatch access from Grafana

### DIFF
--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability.yaml
@@ -15,6 +15,8 @@ Resources:
                 - grafana.amazonaws.com
             Action:
               - 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonGrafanaCloudWatchAccess
       RoleName: !Sub ${AWS::StackName}-Grafana-Role
   
   AmazonGrafanaPrometheusPolicy:


### PR DESCRIPTION
*Issue #, if available:*
Amazon managed grafana lack access to cloudwatch to setup datasource.
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
