### PR TITLE
updated fsx_ubuntu.sh script with wait loop

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/fsx_ubuntu.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/fsx_ubuntu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Wait for FSx to be properly mounted (timeout after 30 seconds)
+# Wait for FSx to be properly mounted (timeout after 60 seconds)
 ATTEMPTS=6
 WAIT=10
 for ((i=1; i<=ATTEMPTS; i++)); do

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/fsx_ubuntu.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/fsx_ubuntu.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Wait for FSx to be properly mounted (timeout after 30 seconds)
+ATTEMPTS=6
+WAIT=10
+for ((i=1; i<=ATTEMPTS; i++)); do
+    if mountpoint -q "/fsx" && touch /fsx/.test_write 2>/dev/null; then
+        rm -f /fsx/.test_write
+        break
+    fi
+    if [ $i -eq $ATTEMPTS ]; then
+        echo "FSx mount not ready after $((ATTEMPTS * WAIT)) seconds"
+        exit 1
+    fi
+    sleep $WAIT
+done
+
 # move the ubuntu user to the shared /fsx filesystem
 if [ -d "/fsx/ubuntu" ]; then
     sudo usermod -d /fsx/ubuntu ubuntu


### PR DESCRIPTION
*Issue #, if available:*
#632 

*Description of changes:*
I've added a wait loop to [fsx_ubuntu.sh](https://github.com/aws-samples/awsome-distributed-training/blob/fix/fsx_ubuntu/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/fsx_ubuntu.sh) that checks the mounted filesystem for write capability every 10 seconds for 60 seconds. 
I've tested this change, and it seems to resolve the transient race condition with [mount_fsx.sh](https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
