### PR TITLE
Fixing recently raised Studio Issues

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/slurm-studio/slurm_lifecycle.sh
+++ b/1.architectures/5.sagemaker-hyperpod/slurm-studio/slurm_lifecycle.sh
@@ -315,7 +315,7 @@ TEMP_FILE_2=$(mktemp)
 sleep 5
 
 # Same MUNGE Keys
-CONTROLLER_ID=${CONTROLLER_IDS[1]}
+CONTROLLER_ID=${CONTROLLER_IDS[0]}
 
 MUNGE_KEY_SIZE=$(aws ssm start-session \
    --target "sagemaker-cluster:${CLUSTER_ID}_${HEAD_NODE_NAME}-${CONTROLLER_ID}" \

--- a/1.architectures/5.sagemaker-hyperpod/slurm-studio/slurm_lifecycle.sh
+++ b/1.architectures/5.sagemaker-hyperpod/slurm-studio/slurm_lifecycle.sh
@@ -240,7 +240,7 @@ ClusterName=${CLUSTER_NAME}
 EOF
 
 # Add controllers 
-for ((i=1; i<=${#CONTROLLER_HOSTNAMES[@]}; i++)); do
+for ((i=0; i<${#CONTROLLER_HOSTNAMES[@]}; i++)); do
     echo "SlurmctldHost=${CONTROLLER_HOSTNAMES[i]}(${CONTROLLER_IPS[i]})" | sudo tee -a /usr/local/etc/slurm.conf
 done
 


### PR DESCRIPTION
*Issue #, if available:* #639

*Description of changes:*
The issue was an incorrect index (1 used instead of 0), which was causing the controller node to not be detected (i.e., it only worked if >1 controller node existed). This PR fixes that issue and always grabs the MUNGE key from the controller node at index 0 (same MUNGE key on all controller nodes). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
