### PR TITLE
Update 0.distributed-training.Dockerfile

### DIFF
--- a/3.test_cases/pytorch/megatron-lm/0.distributed-training.Dockerfile
+++ b/3.test_cases/pytorch/megatron-lm/0.distributed-training.Dockerfile
@@ -124,7 +124,7 @@ RUN pip install transformers==${TRANSFORMERS_VERSION} sentencepiece python-etcd
 #####################
 # Install megatron-lm
 #####################
-RUN pip install -U setuptools==75.1.0
+RUN pip install -U setuptools
 RUN cd /workspace && git clone --depth 1 --branch ${MEGATRON_LM_VERSION} https://github.com/NVIDIA/Megatron-LM.git \
     && cd Megatron-LM \
     && python3 -m pip install nltk  \


### PR DESCRIPTION
75.1.0 is too old and you get this error message:  ERROR [17/19] RUN pip install -U setuptools==75.1.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
