### PR TITLE
Upgrade pinned version of Ansible

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx_openzfs.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx_openzfs.sh
@@ -11,7 +11,7 @@ OPENZFS_MOUNT_POINT="$2"
 NFS_VERSION=4.2
 
 # Ansible Version
-ANSIBLE_VERSION="6.7.0"
+ANSIBLE_VERSION="10.7.0"
 
 # Function for error handling
 handle_error()


### PR DESCRIPTION
FSx OZFS was not able to mount with Ubuntu 22.04 upgrade (original problem in #677)

Tested with upgraded ansible version. FSx OZFS successfully mounts.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
