### PR TITLE
Nghtm patch 2

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh
@@ -1,108 +1,144 @@
 #!/bin/bash
 
-# must be run a sudo
-
-set -x
-set -e
+#set -x  # Debug output
 
 # FSx Lustre Endpoints
 FSX_DNS_NAME="$1"
 FSX_MOUNTNAME="$2"
 MOUNT_POINT="$3"
 
+# Cleanup function
+cleanup() {
+    if [ $? -ne 0 ]; then
+        echo "Script failed, checking logs..."
+        sudo dmesg | tail -n 20
+        echo "Mount status:"
+        mount | grep lustre || true
+        echo "LNet status:"
+        sudo lctl list_nids || true
+    fi
+}
+
+trap cleanup EXIT
+
 is_mounted() {
-  mountpoint -q "$1"
-  return $?
+    sudo mountpoint -q "$1"
+    return $?
 }
 
 check_already_mounted() {
-  # Check if FSx is already mounted to $MOUNT_POINT
-  if is_mounted $MOUNT_POINT; then
-    if grep -qs "$FSX_MOUNTNAME $MOUNT_POINT lustre" /proc/mounts; then
-      echo "FSx Lustre already mounted to $MOUNT_POINT. Exiting."
-      exit 0
-    else
-      echo "$MOUNT_POINT is mounted, but not to mountname: $FSX_MOUNTNAME from provisioning_parameters.json. Exiting."
-      exit 1
+    if is_mounted "$MOUNT_POINT"; then
+        if sudo grep -qs "${FSX_DNS_NAME}@tcp:/${FSX_MOUNTNAME}" /proc/mounts; then
+            echo "FSx Lustre already mounted to $MOUNT_POINT. Exiting."
+            exit 0
+        else
+            echo "Warning: $MOUNT_POINT is mounted with different filesystem:"
+            sudo grep "$MOUNT_POINT" /proc/mounts
+            exit 1
+        fi
     fi
-  fi
 }
 
 is_fsx_reachable() {
-  if lctl ping "$FSX_DNS_NAME"; then
-    echo "FSx is reachable"
-  else
-    echo "FSx is not reachable, Trying to mount system anyway"
-  fi
+    echo "Checking FSx reachability..."
+    if sudo lctl ping "$FSX_DNS_NAME"; then
+        echo "FSx is reachable"
+        return 0
+    else
+        echo "FSx is not reachable. Will try mounting anyway."
+        return 1
+    fi
 }
 
 add_to_fstab() {
-  # Add FSx to /etc/fstab
-  echo "$FSX_DNS_NAME@tcp:/$FSX_MOUNTNAME $MOUNT_POINT lustre defaults,noatime,flock,_netdev 0 0" | tee -a /etc/fstab  
+    echo "Adding mount entry to /etc/fstab..."
+    # Backup existing fstab
+    sudo cp /etc/fstab /etc/fstab.backup.$(date +%Y%m%d_%H%M%S)
+    
+    # Remove any existing entries for this mount point
+    sudo sed -i "\|${MOUNT_POINT}|d" /etc/fstab
+    
+    # Add new entry
+    echo "$FSX_DNS_NAME@tcp:/$FSX_MOUNTNAME $MOUNT_POINT lustre defaults,noatime,flock,_netdev 0 0" | sudo tee -a /etc/fstab
 }
 
 mount_fs() {
-  if [[ ! -d $MOUNT_POINT ]]; then
-    mkdir -p $MOUNT_POINT
-    chmod 644 $MOUNT_POINT
-  fi
-
-  if mount -t lustre -o noatime,flock "$FSX_DNS_NAME"@tcp:/"$FSX_MOUNTNAME" "$MOUNT_POINT"; then
-    if ! is_mounted $MOUNT_POINT ;then
-      echo "Mounting FSx to $MOUNT_POINT directory successful, but mountpoint was not detected. Exiting."
-      exit 1
+    echo "Preparing to mount FSx..."
+    
+    if [[ ! -d $MOUNT_POINT ]]; then
+        sudo mkdir -p "$MOUNT_POINT" || { echo "Failed to create mount point"; exit 1; }
+        sudo chmod 755 "$MOUNT_POINT"
     fi
-  else
-    echo "FAILED to mount, FSX to $MOUNT_POINT directory. Exiting."
-    exit 1
-  fi
-}
 
+    echo "Attempting to mount FSx..."
+    if sudo mount -t lustre -o noatime,flock "${FSX_DNS_NAME}@tcp:/${FSX_MOUNTNAME}" "$MOUNT_POINT"; then
+        if is_mounted "$MOUNT_POINT"; then
+            echo "Mount successful:"
+            df -h "$MOUNT_POINT"
+            return 0
+        else
+            echo "Error: Mount command succeeded but mountpoint check failed"
+            sudo dmesg | tail -n 10
+            exit 1
+        fi
+    else
+        echo "Error: Mount failed"
+        sudo dmesg | tail -n 10
+        exit 1
+    fi
+}
 
 load_lnet_modules() {
-  modprobe -v lnet
+    echo "Loading kernel modules..."
+    sudo modprobe lustre || echo "Warning: loading lustre module failed"
+    sudo modprobe lnet || { echo "Error: Failed to load LNet module"; exit 1; }
+    sudo lctl network up || { echo "Error: Failed to bring up LNet network"; exit 1; }
 }
 
-# create a systemd service to check mount periodically and remount FSx if necessary
-# To stop the service, run: 
-# `systemctl stop check_mount.service`
-# To disable the service, run:
-# `systemctl disable check_mount.service`
 install_remount_service() {
-  
-  if [[ ! -d /opt/ml/scripts ]]; then
-    mkdir -p /opt/ml/scripts
-    chmod 644 /opt/ml/scripts
-    echo "Created dir /opt/ml/scripts"
-  fi
+    echo "Installing remount service..."
+    if [[ ! -d /opt/ml/scripts ]]; then
+        sudo mkdir -p /opt/ml/scripts
+        sudo chmod 755 /opt/ml/scripts
+    fi
 
-  CHECK_MOUNT_FILE=/opt/ml/scripts/check_mount_$FSX_MOUNTNAME.sh
+    CHECK_MOUNT_FILE=/opt/ml/scripts/check_mount_${FSX_MOUNTNAME//\//_}.sh
 
-  cat > $CHECK_MOUNT_FILE << EOF
+    sudo tee "$CHECK_MOUNT_FILE" > /dev/null << EOF
 #!/bin/bash
 MOUNT_POINT=$MOUNT_POINT
-if ! grep -qs "$MOUNT_POINT" /proc/mounts; then
-  mount -t lustre -o noatime,flock "$FSX_DNS_NAME"@tcp:/"$FSX_MOUNTNAME" "$MOUNT_POINT"
-  echo "Mounted FSx to $MOUNT_POINT"
+
+if ! grep -qs "\$MOUNT_POINT" /proc/mounts; then
+    modprobe lustre
+    modprobe lnet
+    lctl network up
+    mount -t lustre -o noatime,flock "$FSX_DNS_NAME@tcp:/$FSX_MOUNTNAME" "\$MOUNT_POINT"
+    echo "Mounted FSx to \$MOUNT_POINT"
 else
-  echo "FSx Lustre already mounted to $MOUNT_POINT. Stopping services check_fsx_mount_$FSX_MOUNTNAME.timer and check_fsx_mount_$FSX_MOUNTNAME.service"
-  systemctl stop check_fsx_mount_$FSX_MOUNTNAME.timer
+    echo "FSx Lustre already mounted to \$MOUNT_POINT"
 fi
 EOF
 
-  chmod +x $CHECK_MOUNT_FILE
+    sudo chmod +x "$CHECK_MOUNT_FILE"
 
-  cat > /etc/systemd/system/check_fsx_mount_$FSX_MOUNTNAME.service << EOF
+    sudo tee "/etc/systemd/system/check_fsx_mount_${FSX_MOUNTNAME//\//_}.service" > /dev/null << EOF
 [Unit]
 Description=Check and remount FSx Lustre filesystems if necessary
+After=network-online.target
+Wants=network-online.target
 
 [Service]
+Type=oneshot
 ExecStart=$CHECK_MOUNT_FILE
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
 EOF
 
-  cat > /etc/systemd/system/check_fsx_mount_$FSX_MOUNTNAME.timer << EOF
+    sudo tee "/etc/systemd/system/check_fsx_mount_${FSX_MOUNTNAME//\//_}.timer" > /dev/null << EOF
 [Unit]
-Description=Run check_fsx_mount_$FSX_MOUNTNAME.service every minute
+Description=Run check_fsx_mount_${FSX_MOUNTNAME//\//_}.service every minute
 
 [Timer]
 OnBootSec=1min
@@ -112,21 +148,26 @@ OnUnitActiveSec=1min
 WantedBy=timers.target
 EOF
 
-  systemctl daemon-reload
-  systemctl enable --now check_fsx_mount_$FSX_MOUNTNAME.timer
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now "check_fsx_mount_${FSX_MOUNTNAME//\//_}.timer"
 }
 
 main() {
-  echo "Mount_fsx called fsx_dns_name: $FSX_DNS_NAME, fsx_mountname: $FSX_MOUNTNAME"
-  echo "Using mount_point: $MOUNT_POINT"
-  load_lnet_modules
-  check_already_mounted
-  is_fsx_reachable
-  add_to_fstab
-  mount_fs
-  install_remount_service
-  echo "FSx Lustre mounted successfully to $MOUNT_POINT"
+    echo "Starting FSx mount process..."
+    echo "Parameters:"
+    echo "  FSX_DNS_NAME: $FSX_DNS_NAME"
+    echo "  FSX_MOUNTNAME: $FSX_MOUNTNAME"
+    echo "  MOUNT_POINT: $MOUNT_POINT"
+    
+    load_lnet_modules
+    check_already_mounted
+    is_fsx_reachable
+    add_to_fstab
+    mount_fs
+    install_remount_service
+    
+    echo "FSx Lustre mount process completed successfully"
+    df -h "$MOUNT_POINT"
 }
 
 main "$@"
-

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx_openzfs.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx_openzfs.sh
@@ -13,11 +13,42 @@ NFS_VERSION=4.2
 # Ansible Version
 ANSIBLE_VERSION="10.7.0"
 
+# Retry settings
+MAX_ATTEMPTS=5
+INITIAL_BACKOFF=1
+
+# Function for exponential backoff
+retry_with_backoff() {
+    local max_attempts=$1
+    local initial_backoff=$2
+    local cmd="${@:3}"
+    local attempt=1
+    local backoff=$initial_backoff
+
+    while [ $attempt -le $max_attempts ]; do
+        if eval "$cmd"; then
+            return 0
+        fi
+        
+        if [ $attempt -eq $max_attempts ]; then
+            echo "Failed after $attempt attempts"
+            return 1
+        fi
+        
+        echo "Attempt $attempt failed. Retrying in $backoff seconds..."
+        sleep $backoff
+        
+        # Exponential backoff with jitter
+        backoff=$(( backoff * 2 + (RANDOM % 3) ))
+        attempt=$((attempt + 1))
+    done
+}
+
 # Function for error handling
 handle_error()
 {
     local exit_code=$?
-    echo "Error occured in command: $BASH_COMMAND"
+    echo "Error occurred in command: $BASH_COMMAND"
     echo "Exit code: $exit_code"
     exit $exit_code
 }
@@ -33,14 +64,13 @@ verify_parameters()
     fi
 }
 
-# Install Ansible and collections: Move to higher LCS once others start using Ansible too.
+# Install Ansible and collections
 install_ansible()
 {
-    apt-get update
-    # apt-get install -y ansible=$ANSIBLE_VERSION
-    apt-get install -y python3-pip
-    python3 -m pip install "ansible==${ANSIBLE_VERSION}"
-    ansible-galaxy collection install ansible.posix
+    retry_with_backoff $MAX_ATTEMPTS $INITIAL_BACKOFF "apt-get update"
+    retry_with_backoff $MAX_ATTEMPTS $INITIAL_BACKOFF "apt-get install -y python3-pip"
+    retry_with_backoff $MAX_ATTEMPTS $INITIAL_BACKOFF "python3 -m pip install 'ansible==${ANSIBLE_VERSION}'"
+    retry_with_backoff $MAX_ATTEMPTS $INITIAL_BACKOFF "ansible-galaxy collection install ansible.posix"
 }
 
 # Install NFS Client based on OS
@@ -48,17 +78,31 @@ install_nfs_client()
 {
     if [ -f /etc/lsb-release ]; then
         # Ubuntu
-        ansible localhost -b -m ansible.builtin.apt -a "name=nfs-common state=present update_cache=yes"
+        retry_with_backoff $MAX_ATTEMPTS $INITIAL_BACKOFF "ansible ********* -b -m ansible.builtin.apt -a 'name=nfs-common state=present update_cache=yes'"
     elif [ -f /etc/redhat-release ]; then
         # CentOS/RHEL
-        ansible localhost -b -m ansible.builtin.yum -a "name=nfs-utils state=present"
+        retry_with_backoff $MAX_ATTEMPTS $INITIAL_BACKOFF "ansible ********* -b -m ansible.builtin.yum -a 'name=nfs-utils state=present'"
     fi
 }
 
 # Mount the FSx OpenZFS file system
 mount_fs()
 {
-    ansible localhost -b -m ansible.posix.mount -a "path=$OPENZFS_MOUNT_POINT src=$FSX_OPENZFS_DNS_NAME:/fsx fstype=nfs opts=nfsvers=$NFS_VERSION,_netdev,nconnect=16,x-systemd.automount,x-systemd.requires=network-online.target dump=0 passno=0 state=mounted"
+    # Create mount point directory if it doesn't exist
+    if [ ! -d "$OPENZFS_MOUNT_POINT" ]; then
+        mkdir -p "$OPENZFS_MOUNT_POINT"
+    fi
+
+    retry_with_backoff $MAX_ATTEMPTS $INITIAL_BACKOFF "ansible ********* -b -m ansible.posix.mount -a \"path=$OPENZFS_MOUNT_POINT src=$FSX_OPENZFS_DNS_NAME:/fsx fstype=nfs opts=nfsvers=$NFS_VERSION,_netdev,nconnect=16,x-systemd.automount,x-systemd.requires=network-online.target dump=0 passno=0 state=mounted\""
+}
+
+# Verify mount was successful
+verify_mount()
+{
+    if ! mountpoint -q "$OPENZFS_MOUNT_POINT"; then
+        echo "Failed to verify mount point $OPENZFS_MOUNT_POINT"
+        exit 1
+    fi
 }
 
 main() 
@@ -69,6 +113,7 @@ main()
     install_ansible
     install_nfs_client
     mount_fs
+    verify_mount
     echo "FSx OpenZFS mounted successfully to $OPENZFS_MOUNT_POINT"
 }
 

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_dcgm_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_dcgm_exporter.sh
@@ -2,12 +2,38 @@
 
 # Define the container name and image version
 CONTAINER_NAME="dcgm-exporter"
-DCGM_EXPORTER_VERSION=3.3.8-3.6.0-ubuntu22.04
+DCGM_EXPORTER_VERSION=4.2.3-4.1.1-ubuntu22.04
 IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:${DCGM_EXPORTER_VERSION}"
+METRICS_CSV_URL="https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/refs/heads/main/4.validation_and_observability/4.prometheus-grafana/dcgm-metrics.csv"
+METRICS_CSV_PATH="/tmp/dcgm-metrics.csv"
 
 # Maximum number of retries
 MAX_RETRIES=5
 RETRY_DELAY=5  # Initial delay in seconds
+
+# Function to download file with exponential backoff
+download_with_retry() {
+    local attempt=0
+    local delay=$RETRY_DELAY
+
+    while [ $attempt -lt $MAX_RETRIES ]; do
+        echo "Attempting to download metrics CSV (attempt $((attempt + 1))/$MAX_RETRIES)..."
+        if curl -s -f -o "$METRICS_CSV_PATH" "$METRICS_CSV_URL"; then
+            echo "Successfully downloaded metrics CSV."
+            return 0
+        else
+            attempt=$((attempt + 1))
+            if [ $attempt -lt $MAX_RETRIES ]; then
+                echo "Download failed. Retrying in $delay seconds..."
+                sleep $delay
+                delay=$((delay * 2))  # Exponential backoff
+            else
+                echo "Failed to download metrics CSV after $MAX_RETRIES attempts. Exiting..."
+                return 1
+            fi
+        fi
+    done
+}
 
 # Check if the container exists and is running
 if docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" | grep -q "$CONTAINER_NAME"; then
@@ -30,19 +56,26 @@ if nvidia-smi > /dev/null 2>&1; then
 
     echo "Instance Type is recognized as $INSTANCE_TYPE, setting DCGM_EXPORTER_VERSION to $DCGM_EXPORTER_VERSION"
 
+    # Download metrics CSV with retry
+    if ! download_with_retry; then
+        echo "Failed to download metrics CSV. Exiting..."
+        exit 1
+    fi
+
     # Retry logic for pulling the image
     attempt=0
+    delay=$RETRY_DELAY
     while [ $attempt -lt $MAX_RETRIES ]; do
-        echo "Attempting to pull image ($attempt/$MAX_RETRIES)..."
+        echo "Attempting to pull image ($((attempt + 1))/$MAX_RETRIES)..."
         if sudo docker pull "$IMAGE"; then
             echo "Successfully pulled image."
             break
         else
             attempt=$((attempt + 1))
             if [ $attempt -lt $MAX_RETRIES ]; then
-                echo "Pull failed. Retrying in $RETRY_DELAY seconds..."
-                sleep $RETRY_DELAY
-                RETRY_DELAY=$((RETRY_DELAY * 2))  # Exponential backoff
+                echo "Pull failed. Retrying in $delay seconds..."
+                sleep $delay
+                delay=$((delay * 2))  # Exponential backoff
             else
                 echo "Failed to pull Docker image after $MAX_RETRIES attempts. Exiting..."
                 exit 1
@@ -50,14 +83,18 @@ if nvidia-smi > /dev/null 2>&1; then
         fi
     done
 
-    # Run the DCGM Exporter Docker container
+    # Create a volume mount point for the metrics file
+    METRICS_MOUNT="/etc/dcgm-exporter/custom-metrics.csv"
+
+    # Run the DCGM Exporter Docker container with the custom metrics
     if sudo docker run -d --restart always \
         --name $CONTAINER_NAME \
         --gpus all \
         --net host \
         --cap-add SYS_ADMIN \
+        -v "$METRICS_CSV_PATH:$METRICS_MOUNT" \
         $IMAGE \
-        -f /etc/dcgm-exporter/dcp-metrics-included.csv; then
+        -f "$METRICS_MOUNT"; then
         echo "Running DCGM exporter in a Docker container on port 9400..."
     else
         echo "Failed to run DCGM Exporter Docker container"

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
@@ -33,7 +33,7 @@ systemctl enable docker.service
 systemctl start docker.service
 
 # install nvidia docker toolkit
-curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
     sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
@@ -71,3 +71,110 @@ fi
 
 systemctl daemon-reload
 systemctl restart docker
+
+
+
+
+#!/bin/bash
+
+set -exo pipefail
+
+# Define exponential backoff function
+function retry_with_backoff() {
+    local max_attempts=$1
+    local initial_wait=$2
+    local max_wait=$3
+    local command="${@:4}"
+    local attempt=1
+    local wait_time=$initial_wait
+
+    while true; do
+        echo "Attempt $attempt of $max_attempts: $command"
+        if eval "$command"; then
+            return 0
+        fi
+
+        if (( attempt == max_attempts )); then
+            echo "Command failed after $max_attempts attempts: $command"
+            return 1
+        fi
+
+        echo "Command failed. Retrying in $wait_time seconds..."
+        sleep $wait_time
+
+        attempt=$(( attempt + 1 ))
+        wait_time=$(( wait_time * 2 ))
+        if (( wait_time > max_wait )); then
+            wait_time=$max_wait
+        fi
+    done
+}
+
+# If docker is already installed, skip installing again
+if command -v docker &> /dev/null; then
+    echo "Docker is already installed and in the PATH."
+    exit 0
+fi
+
+echo "
+###################################
+# BEGIN: install docker
+###################################
+"
+
+apt-get -y -o DPkg::Lock::Timeout=120 update
+apt-get -y -o DPkg::Lock::Timeout=120 install \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+mkdir -m 0755 -p /etc/apt/keyrings
+
+# Docker GPG key download with retry
+retry_with_backoff 5 5 60 "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg"
+
+echo \
+"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+$(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get -y -o DPkg::Lock::Timeout=120 update
+apt-get -y -o DPkg::Lock::Timeout=120 install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+chgrp docker $(which docker)
+chmod g+s $(which docker)
+systemctl enable docker.service
+systemctl start docker.service
+
+# Install nvidia docker toolkit with retry
+retry_with_backoff 5 5 60 "curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+retry_with_backoff 5 5 60 "curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list"
+sudo apt-get install -y -o DPkg::Lock::Timeout=120 nvidia-container-toolkit
+
+# add user to docker group
+sudo usermod -aG docker ubuntu
+
+# Opportunistically use /opt/sagemaker or /opt/dlami/nvme if present
+if [[ $(mount | grep /opt/sagemaker) ]]; then
+    cat <<EOL >> /etc/docker/daemon.json
+{
+    "data-root": "/opt/sagemaker/docker/data-root"
+}
+EOL
+
+    sed -i \
+        's|^\[Service\]$|[Service]\nEnvironment="DOCKER_TMPDIR=/opt/sagemaker/docker/tmp"|' \
+        /usr/lib/systemd/system/docker.service
+elif [[ $(mount | grep /opt/dlami/nvme) ]]; then
+    cat <<EOL >> /etc/docker/daemon.json
+{
+    "data-root": "/opt/dlami/nvme/docker/data-root"
+}
+EOL
+
+    sed -i \
+        's|^\[Service\]$|[Service]\nEnvironment="DOCKER_TMPDIR=/opt/dlami/nvme/docker/tmp"|' \
+        /usr/lib/systemd/system/docker.service
+fi
+
+systemctl daemon-reload
+systemctl restart docker

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
@@ -4,25 +4,63 @@ set -e
 
 BIN_DIR=$(dirname $(readlink -e ${BASH_SOURCE[0]}))
 
+# Exponential backoff function
+function retry_with_backoff() {
+    local max_attempts=$1
+    local initial_wait=$2
+    local max_wait=$3
+    local command="${@:4}"
+    local attempt=1
+    local wait_time=$initial_wait
+
+    while true; do
+        echo "Attempt $attempt of $max_attempts: $command"
+        if eval "$command"; then
+            return 0
+        fi
+
+        if (( attempt == max_attempts )); then
+            echo "Command failed after $max_attempts attempts: $command"
+            return 1
+        fi
+
+        echo "Command failed. Retrying in $wait_time seconds..."
+        sleep $wait_time
+
+        attempt=$(( attempt + 1 ))
+        wait_time=$(( wait_time * 2 ))
+        if (( wait_time > max_wait )); then
+            wait_time=$max_wait
+        fi
+    done
+}
+
+# Function for apt operations with retry
+function apt_install_with_retry() {
+    local package=$1
+    retry_with_backoff 5 5 60 "apt-get -y -o DPkg::Lock::Timeout=120 install $package"
+}
+
 ################################################################################
 # Install enroot & pyxis
 ################################################################################
 # Modify cgroup.conf to avoid runtime error due to incorrect GPU ID mapping
 # https://github.com/NVIDIA/pyxis/issues/47#issuecomment-842065289
 if [[ -f /opt/slurm/etc/cgroup.conf ]]; then
-  grep ^ConstrainDevices /opt/slurm/etc/cgroup.conf &> /dev/null \
-	  || echo "ConstrainDevices=yes" >> /opt/slurm/etc/cgroup.conf
+    grep ^ConstrainDevices /opt/slurm/etc/cgroup.conf &> /dev/null \
+        || echo "ConstrainDevices=yes" >> /opt/slurm/etc/cgroup.conf
 fi
 
-apt-get -y -o DPkg::Lock::Timeout=120 install squashfs-tools parallel libnvidia-container-tools
-apt-get -y -o DPkg::Lock::Timeout=120 install fuse-overlayfs squashfuse
+# Install packages with retry
+apt_install_with_retry "squashfs-tools parallel libnvidia-container-tools"
+apt_install_with_retry "fuse-overlayfs squashfuse"
 
 SLURM_INSTALL_DIR='/opt/slurm'
 PYXIS_TMP_DIR='/tmp/pyxis'
 
 if [ ! -d $SLURM_INSTALL_DIR ]; then
-  echo "Slurm installation not found. Skipping pyxis and enroot installation.\n"
-  exit 1
+    echo "Slurm installation not found. Skipping pyxis and enroot installation.\n"
+    exit 1
 fi
 
 rm -fr $SLURM_INSTALL_DIR/pyxis
@@ -32,13 +70,18 @@ PYXIS_VERSION=v0.19.0
 ENROOT_VERSION=3.4.1
 arch=$(dpkg --print-architecture)
 cd $PYXIS_TMP_DIR
-curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${arch}.deb
-curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_${arch}.deb # optional
-apt install -y -o DPkg::Lock::Timeout=120 ./enroot_${ENROOT_VERSION}-1_${arch}.deb
-apt install -y -o DPkg::Lock::Timeout=120 ./enroot+caps_${ENROOT_VERSION}-1_${arch}.deb
+
+# Download enroot packages with retry
+retry_with_backoff 5 5 60 "curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${arch}.deb"
+retry_with_backoff 5 5 60 "curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_${arch}.deb"
+
+# Install enroot packages with retry
+retry_with_backoff 5 5 60 "apt install -y -o DPkg::Lock::Timeout=120 ./enroot_${ENROOT_VERSION}-1_${arch}.deb"
+retry_with_backoff 5 5 60 "apt install -y -o DPkg::Lock::Timeout=120 ./enroot+caps_${ENROOT_VERSION}-1_${arch}.deb"
 cp $BIN_DIR/enroot.conf /etc/enroot/enroot.conf
 
-git clone --depth 1 --branch $PYXIS_VERSION https://github.com/NVIDIA/pyxis.git $SLURM_INSTALL_DIR/pyxis
+# Clone pyxis with retry
+retry_with_backoff 5 5 60 "git clone --depth 1 --branch $PYXIS_VERSION https://github.com/NVIDIA/pyxis.git $SLURM_INSTALL_DIR/pyxis"
 cd $SLURM_INSTALL_DIR/pyxis/
 CPPFLAGS='-I /opt/slurm/include/' make -j $(nproc)
 CPPFLAGS='-I /opt/slurm/include/' make install
@@ -51,15 +94,11 @@ ln -fs /usr/local/share/pyxis/pyxis.conf $SLURM_INSTALL_DIR/etc/plugstack.conf.d
 
 mkdir -p /run/pyxis/ /tmp/enroot/data /opt/enroot/
 chmod 777 -R /tmp/enroot /opt/enroot
+
 ################################################################################
-# Below while loop instituted to combat race condition when mapping enroot path to /opt/dlami/nvme described in https://github.com/aws-samples/awsome-distributed-training/issues/427
-# Maximum time to wait in seconds (2 minutes = 120 seconds)
+# Below while loop instituted to combat race condition when mapping enroot path to /opt/dlami/nvme
 MAX_WAIT_TIME=120
-
-# Initialize the elapsed time
 ELAPSED_TIME=0
-
-# Interval to wait between each check (in seconds)
 CHECK_INTERVAL=5
 
 while true; do
@@ -68,32 +107,27 @@ while true; do
     # Check the ExecMainStatus of the lib/systemd/system/dlami-nvme.service
     RESULT_STATE=$(systemctl show dlami-nvme | grep "ExecMainStatus" | cut -d '=' -f 2)
 
-    # Print the current states of /lib/systemd/system/dlami-nvme.service (for debugging purposes)
     echo "dlami-nvme.service ActiveState: $ACTIVE_STATE"
     echo "dlami-nvme.service ExecMainStatus: $RESULT_STATE"
 
-    # Break the loop if service == active and ExecMainStatus == 0 (which means success)
     if [[ "$ACTIVE_STATE" == "active" && "$RESULT_STATE" == "0" ]]; then
         echo "dlami-nvme.service is active and successful. Proceeding with Enroot configuration on /opt/dlami/nvme if available"
         break
     fi
 
-    # Increment the elapsed time
     ELAPSED_TIME=$((ELAPSED_TIME + CHECK_INTERVAL))
 
-    # Break the loop if the elapsed time exceeds the maximum wait time
     if [[ $ELAPSED_TIME -ge $MAX_WAIT_TIME ]]; then
         echo "WARN: Timeout reached: dlami-nvme.service did not become active and successful, it is possible enroot default path is /opt/sagemaker. When training larger models, dragons be here. See https://github.com/aws-samples/awsome-distributed-training/issues/427 for corrective actions"
         break
     fi
 
-    # Wait for the specified interval before checking again
     sleep $CHECK_INTERVAL
 done
 
 ####################################################################################################
 
-# Opportunistically use /opt/dlami/nvme (takes precedent) or /opt/sagemaker (secondary) if present. Let's be extra careful in the probe.
+# Configure enroot paths based on available mounts
 if [[ $(mount | grep /opt/dlami/nvme) ]]; then
     sed -i \
         -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/user-$(id -u)|' \
@@ -109,8 +143,8 @@ if [[ $(mount | grep /opt/dlami/nvme) ]]; then
     mkdir -p /opt/dlami/nvme/tmp/enroot/data/
     chmod 1777 /opt/dlami/nvme/tmp/enroot/data/
 
-     mkdir -p /opt/dlami/nvme/enroot
-     chmod 1777 /opt/dlami/nvme/enroot
+    mkdir -p /opt/dlami/nvme/enroot
+    chmod 1777 /opt/dlami/nvme/enroot
 
 elif [[ $(mount | grep /opt/sagemaker) ]]; then
     sed -i \
@@ -127,17 +161,17 @@ elif [[ $(mount | grep /opt/sagemaker) ]]; then
     mkdir -p /opt/sagemaker/tmp/enroot/data/
     chmod 1777 /opt/sagemaker/tmp/enroot/data/
 
-     mkdir -p /opt/sagemaker/enroot
-     chmod 1777 /opt/sagemaker/enroot
-     
+    mkdir -p /opt/sagemaker/enroot
+    chmod 1777 /opt/sagemaker/enroot
 fi
 
-# Use /fsx for enroot cache, if available. Let's be extra careful in the probe.
+# Configure FSX for enroot cache if available
 if [[ $(mount | grep /fsx) ]]; then
     sed -i -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/fsx/enroot|' /etc/enroot/enroot.conf
     mkdir -p /fsx/enroot
     chmod 1777 /fsx/enroot
 fi
 
-systemctl is-active --quiet slurmctld && systemctl restart slurmctld || echo "This instance does not run slurmctld"
-systemctl is-active --quiet slurmd    && systemctl restart slurmd    || echo "This instance does not run slurmd"
+# Restart Slurm services if they're running
+retry_with_backoff 5 5 60 "systemctl is-active --quiet slurmctld && systemctl restart slurmctld || echo 'This instance does not run slurmctld'"
+retry_with_backoff 5 5 60 "systemctl is-active --quiet slurmd && systemctl restart slurmd || echo 'This instance does not run slurmd'"


### PR DESCRIPTION
*Issue #, if available:* 

https://github.com/aws-samples/awsome-distributed-training/issues/678
https://github.com/aws-samples/awsome-distributed-training/issues/679
https://github.com/aws-samples/awsome-distributed-training/issues/680

*Description of changes:*
Update several lifecycle scripts for SageMaker HyperPod Slurm U22.04 following internal testing today. This commit adds exponetial backoff/retry logic to the following scripts, to help gracefully fail and retry in the event of network connectivity issues observed in issues 678,679,680:

M       1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx_openzfs.sh
M       1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
M       1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh

This PR also adds custom metrics for `install_dcgm_exporter.sh` and upgrades dcgm exporter container from `3.3.8-3.6.0-ubuntu22.04` to `4.2.3-4.1.1-ubuntu22.04`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
