### PR TITLE
Fix minor spelling mistake in start_slurm.sh

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/start_slurm.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/start_slurm.sh
@@ -30,7 +30,7 @@ main() {
     systemctl enable --now slurmd
 
     mv /etc/systemd/system/slurmctld{,_DO_NOT_START_ON_CONTROLLER}.service \
-        || { echo "Failed to mask slurmctldd, perhaps the AMI already masked it?" ; }
+        || { echo "Failed to mask slurmctld, perhaps the AMI already masked it?" ; }
   fi
 
   echo "[INFO] Start Slurm Script completed"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fix minor spelling mistake in start_slurm.sh
`slurmctldd` -> `slurmctld`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
