### PR TITLE
Skip fsx_ubuntu.sh execution when no FSx parameters are provided in the provisioning parameters

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
@@ -203,7 +203,11 @@ def main(args):
 
         ExecuteBashScript("./apply_hotfix.sh").run(node_type)
         ExecuteBashScript("./utils/motd.sh").run(node_type, ",".join(head_node_ip), ",".join(login_node_ip))
-        ExecuteBashScript("./utils/fsx_ubuntu.sh").run()
+
+        # Only configure home directory on FSx if either FSx Lustre or FSx OpenZFS is configured and provided in the provisioning params
+        if (fsx_dns_name and fsx_mountname) or (Config.enable_fsx_openzfs and fsx_openzfs_dns_name):
+            ExecuteBashScript("./utils/fsx_ubuntu.sh").run()
+
         ExecuteBashScript("./start_slurm.sh").run(node_type, ",".join(controllers))
         ExecuteBashScript("./utils/gen-keypair-ubuntu.sh").run()
         ExecuteBashScript("./utils/ssh-to-compute.sh").run()


### PR DESCRIPTION
This PR fixes an issue where the lifecycle script fails when no FSx parameters are provided in the provisioning configuration. The script was attempting to execute `fsx_ubuntu.sh` which was failing with a non-zero exit code when no FSx mounts were available.
```
Execute script: ./utils/fsx_ubuntu.sh 
sudo: unable to resolve host ip-10-2-44-125: Name or service not known
Waiting for FSx mount: /home to be ready... (attempt 1/6)
Waiting for FSx mount: /home to be ready... (attempt 2/6)
Waiting for FSx mount: /home to be ready... (attempt 3/6)
Waiting for FSx mount: /home to be ready... (attempt 4/6)
Waiting for FSx mount: /home to be ready... (attempt 5/6)
Mount not ready after 60 seconds
OpenZFS is not mounted. Using FSxL file system as home
Waiting for FSx mount: /fsx to be ready... (attempt 1/6)
Waiting for FSx mount: /fsx to be ready... (attempt 2/6)
Waiting for FSx mount: /fsx to be ready... (attempt 3/6)
Waiting for FSx mount: /fsx to be ready... (attempt 4/6)
Waiting for FSx mount: /fsx to be ready... (attempt 5/6)
Mount not ready after 60 seconds
Warning: FSx mount not available. Exiting.
Traceback (most recent call last):
  File "/tmp/sagemaker-hyperpod-slurm-test-bucket-390403902333/lifecycle_script.py", line 255, in <module>
    main(args)
  File "/tmp/sagemaker-hyperpod-slurm-test-bucket-390403902333/lifecycle_script.py", line 206, in main
    ExecuteBashScript("./utils/fsx_ubuntu.sh").run()
  File "/tmp/sagemaker-hyperpod-slurm-test-bucket-390403902333/lifecycle_script.py", line 31, in run
    result.check_returncode()
  File "/usr/lib/python3.10/subprocess.py", line 457, in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
subprocess.CalledProcessError: Command '['sudo', 'bash', './utils/fsx_ubuntu.sh']' returned non-zero exit status 1.
```