### PR TITLE
Updating venv test case for FSDP to point to correct `train.py`

### DIFF
--- a/.github/workflows/fsdp-regression-test-venv.yml
+++ b/.github/workflows/fsdp-regression-test-venv.yml
@@ -77,7 +77,7 @@ jobs:
           sed -i "s|--checkpoint_dir=./checkpoints|--checkpoint_dir=${{ env.CHECKPOINT_DIR }}|g" "$TMP_SBATCH"
 
           echo "Submitting Slurm job..."
-          sbatch --wait $TMP_SBATCH
+          pushd src && sbatch --wait ../${TMP_SBATCH} && popd
           exit_code=$?
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
           echo "Slurm job completed with exit code: $exit_code"


### PR DESCRIPTION
Currently, the venv sample errors out with
```
can't open file '/home/github/actions-runner/_work/awsome-distributed-training/awsome-distributed-training/15538433720/3.test_cases/pytorch/FSDP/./train.py': [Errno 2] No such file or directory
```

Example run: https://github.com/aws-samples/awsome-distributed-training/actions/runs/15538433720/job/43743048173?pr=706

Creating this PR to update the venv regression test to point to the right `./train.py` by updating dir (not directly changing sbatch files, since those are used by container sample too).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
