### PR TITLE
Change FSDP PyTorch to 2.7.1

### DIFF
--- a/3.test_cases/pytorch/FSDP/slurm/llama2_13b-training.sbatch
+++ b/3.test_cases/pytorch/FSDP/slurm/llama2_13b-training.sbatch
@@ -43,7 +43,7 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 # LD_PRELOAD is required for PyTorch to find the NCCL library
 # This path assumes you are using the Deep Learning AMI
 # If you are not using the DLAMI, you may need to update this path
-export LD_PRELOAD=/usr/local/cuda-12.4/lib/libnccl.so
+export LD_PRELOAD=/usr/local/cuda-12.8/lib/libnccl.so
 export NCCL_SOCKET_IFNAME=^docker,lo,veth,eth
 
 ## Set HuggingFace metadata timeout (in seconds) for large clusters

--- a/3.test_cases/pytorch/FSDP/slurm/llama2_70b-training.sbatch
+++ b/3.test_cases/pytorch/FSDP/slurm/llama2_70b-training.sbatch
@@ -43,7 +43,7 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 # LD_PRELOAD is required for PyTorch to find the NCCL library
 # This path assumes you are using the Deep Learning AMI
 # If you are not using the DLAMI, you may need to update this path
-export LD_PRELOAD=/usr/local/cuda-12.4/lib/libnccl.so
+export LD_PRELOAD=/usr/local/cuda-12.8/lib/libnccl.so
 export NCCL_SOCKET_IFNAME=^docker,lo,veth,eth
 
 ## Set HuggingFace metadata timeout (in seconds) for large clusters

--- a/3.test_cases/pytorch/FSDP/slurm/llama2_7b-training.sbatch
+++ b/3.test_cases/pytorch/FSDP/slurm/llama2_7b-training.sbatch
@@ -43,7 +43,7 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 # LD_PRELOAD is required for PyTorch to find the NCCL library
 # This path assumes you are using the Deep Learning AMI
 # If you are not using the DLAMI, you may need to update this path
-export LD_PRELOAD=/usr/local/cuda-12.4/lib/libnccl.so
+export LD_PRELOAD=/usr/local/cuda-12.8/lib/libnccl.so
 export NCCL_SOCKET_IFNAME=^docker,lo,veth,eth
 
 ## Set HuggingFace metadata timeout (in seconds) for large clusters

--- a/3.test_cases/pytorch/FSDP/slurm/mathstral_7b-training.sbatch
+++ b/3.test_cases/pytorch/FSDP/slurm/mathstral_7b-training.sbatch
@@ -43,7 +43,7 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 # LD_PRELOAD is required for PyTorch to find the NCCL library
 # This path assumes you are using the Deep Learning AMI
 # If you are not using the DLAMI, you may need to update this path
-export LD_PRELOAD=/usr/local/cuda-12.4/lib/libnccl.so
+export LD_PRELOAD=/usr/local/cuda-12.8/lib/libnccl.so
 export NCCL_SOCKET_IFNAME=^docker,lo,veth,eth
 
 ## Set HuggingFace metadata timeout (in seconds) for large clusters

--- a/3.test_cases/pytorch/FSDP/slurm/mistral_8x7b-training.sbatch
+++ b/3.test_cases/pytorch/FSDP/slurm/mistral_8x7b-training.sbatch
@@ -43,7 +43,7 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 # LD_PRELOAD is required for PyTorch to find the NCCL library
 # This path assumes you are using the Deep Learning AMI
 # If you are not using the DLAMI, you may need to update this path
-export LD_PRELOAD=/usr/local/cuda-12.4/lib/libnccl.so
+export LD_PRELOAD=/usr/local/cuda-12.8/lib/libnccl.so
 export NCCL_SOCKET_IFNAME=^docker,lo,veth,eth
 
 ## Set HuggingFace metadata timeout (in seconds) for large clusters

--- a/3.test_cases/pytorch/FSDP/slurm/training-sub.template
+++ b/3.test_cases/pytorch/FSDP/slurm/training-sub.template
@@ -43,7 +43,7 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 # LD_PRELOAD is required for PyTorch to find the NCCL library
 # This path assumes you are using the Deep Learning AMI
 # If you are not using the DLAMI, you may need to update this path
-export LD_PRELOAD=/usr/local/cuda-12.4/lib/libnccl.so
+export LD_PRELOAD=/usr/local/cuda-12.8/lib/libnccl.so
 export NCCL_SOCKET_IFNAME=^docker,lo,veth,eth
 
 ## Set HuggingFace metadata timeout (in seconds) for large clusters

--- a/3.test_cases/pytorch/FSDP/src/requirements.txt
+++ b/3.test_cases/pytorch/FSDP/src/requirements.txt
@@ -1,8 +1,5 @@
 datasets
-fsspec==2023.9.2
-numpy==1.*
-python-etcd
-torch==2.5.1 --index-url https://download.pytorch.org/whl/cu124
-torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu124
-torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu124
-transformers==4.50.3
+torch==2.7.1 --index-url https://download.pytorch.org/whl/cu128
+torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu128
+torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu128
+transformers==4.52.4


### PR DESCRIPTION
Close #738

*Description of changes:*
Moving to PyTorch 2.7.1 and cuda 12.8


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
