### PR TITLE
docker library version on eks

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/sagemaker-studio-stack.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/sagemaker-studio-stack.yaml
@@ -903,7 +903,7 @@ Resources:
                 if [ -n "$VERSION_CODENAME" ]; then
                   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $VERSION_CODENAME stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
                   sudo apt update -qq
-                  sudo apt install -y -qq docker-ce docker-ce-cli docker-buildx-plugin docker-compose-plugin
+                  sudo apt install -y -qq docker-ce=5:20.10.24~3-0~ubuntu-jammy docker-ce-cli=5:20.10.24~3-0~ubuntu-jammy docker-buildx-plugin=0.17.1-1~ubuntu.22.04~jammy docker-compose-plugin=2.29.7-1~ubuntu.22.04~jammy
                 else
                   echo "Could not determine OS version codename, skipping Docker installation"
                 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
to address error:
```
sagemaker-user@default:~$ docker build --network sagemaker -t ${REGISTRY}${IMAGE}${TAG
} .
[+] Building 0.3s (1/1) FINISHED                             docker-container:default
 => ERROR [internal] booting buildkit                                            0.3s
 => => pulling image moby/buildkit:buildx-stable-1                               0.3s
 => => creating container buildx_buildkit_default                                0.0s
------
 > [internal] booting buildkit:
------
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
ERROR: Error response from daemon: {"message":"Forbidden. Reason: [ContainerCreate] SageMaker Studio Docker Usage does not allow privileged mode execution"}
sagemaker-user@default:~$ 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
