### PR TITLE
Update push.sh - remove extra double quote

### DIFF
--- a/3.test_cases/megatron/nemo/kubernetes/push.sh
+++ b/3.test_cases/megatron/nemo/kubernetes/push.sh
@@ -37,7 +37,7 @@ docker tag "${IMAGE_NAME}:${TAG}" "${ECR_IMAGE}"
 
 # Push the image
 echo "Pushing image to ECR..."
-CMD="docker push "${ECR_IMAGE}"
+CMD="docker push ${ECR_IMAGE}"
 if [ ! "$verbose" == "false" ]; then echo -e "\n${CMD}\n"; fi
 eval "$CMD"
 


### PR DESCRIPTION
CMD="docker push "${ECR_IMAGE}" -> CMD="docker push ${ECR_IMAGE}"

remove the extra double quotes to correct syntax

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
