### PR TITLE
Update README.md

### DIFF
--- a/1.architectures/2.aws-parallelcluster/README.md
+++ b/1.architectures/2.aws-parallelcluster/README.md
@@ -374,7 +374,7 @@ cat cluster-templates/cluster-vanilla.yaml | envsubst > ${CONFIG_DIR}/cluster.ya
 > [!IMPORTANT]  
 > The default configuration has `PlacementGroup` set to `False`. This is recommended when using AWS-provided ODCR or Capacity Blocks, as enabling placement groups may conflict with the placement group assigned to your ODCR/CB and cause *Insufficient Capacity Error* (ICE). 
 >
-> However, when using user-procured Capacity Reservations (CR) for distributed training workloads, you should set `PlacementGroup` to `True` and specify a cluster placement group name. This ensures optimal network performance between instances. Configure it like this:
+> However, when using user-procured On-demand Capacity Reservations (ODCR) for distributed training workloads, you should set `PlacementGroup` to `True` and specify a cluster placement group name. This ensures optimal network performance between instances. Configure it like this:
 >
 > ```yaml
 > PlacementGroup:


### PR DESCRIPTION
The term "CR" is used for both ODCR and CBML [[docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-reservation-overview.html)]. To avoid ambiguity, it is referred as **OD**CR explicitly as "user-procured **On-demand** Capacity Reservations (**OD**CR)" when the `PlacementGroup` should be set to `True`. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
