### PR TITLE
feat: Update LCS of hyperpod eks to support AL2023 OS

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
@@ -4,18 +4,67 @@ set -ex
 
 LOG_FILE="/var/log/provision/provisioning.log"
 mkdir -p "/var/log/provision"
-touch $LOG_FILE
+touch "$LOG_FILE"
 
-# Function to log messages
 logger() {
-  echo "$@" | tee -a $LOG_FILE
+  echo "$@" | tee -a "$LOG_FILE"
 }
 
 logger "[start] on_create.sh"
 
-if [[ $(mount | grep /opt/sagemaker) ]]; then
+# Wait for /opt/sagemaker to be mounted (max 60s)
+for i in {1..12}; do
+  if mount | grep -q "/opt/sagemaker"; then
+    logger "/opt/sagemaker is mounted"
+    break
+  else
+    logger "Waiting for /opt/sagemaker to be mounted..."
+    sleep 5
+  fi
+done
+
+if mount | grep -q "/opt/sagemaker"; then
   logger "Found secondary EBS volume. Setting containerd data root to /opt/sagemaker/containerd/data-root"
-  sed -i -e "/^[# ]*root\s*=/c\root = \"/opt/sagemaker/containerd/data-root\"" /etc/eks/containerd/containerd-config.toml
+
+  # Detect OS version reliably
+  source /etc/os-release
+  os_version="$VERSION_ID"
+  logger "Detected OS version: $os_version"
+
+  if [[ "$os_version" == "2" ]]; then
+    # Amazon Linux 2 logic
+    CONFIG_FILE="/etc/eks/containerd/containerd-config.toml"
+    if [[ -f "$CONFIG_FILE" ]]; then
+      logger "Amazon Linux 2 detected. Modifying $CONFIG_FILE using sed"
+      sed -i -e "/^[# ]*root\s*=/c\root = \"/opt/sagemaker/containerd/data-root\"" "$CONFIG_FILE"
+    else
+      logger "Amazon Linux 2 detected, but $CONFIG_FILE not found!"
+    fi
+
+  elif [[ "$os_version" == "2023" ]]; then
+    # Amazon Linux 2023 logic (systemd override)
+    logger "Amazon Linux 2023 detected. Writing systemd override for containerd"
+
+    mkdir -p /etc/systemd/system/containerd.service.d
+
+    cat <<EOF | tee /etc/systemd/system/containerd.service.d/override.conf
+[Service]
+Environment="CONTAINERD_CONFIG=/etc/containerd/config.toml"
+ExecStart=
+ExecStart=/usr/bin/containerd --root /opt/sagemaker/containerd/data-root --config \$CONTAINERD_CONFIG
+EOF
+
+    logger "Reloading and restarting containerd"
+    systemctl daemon-reexec
+    systemctl daemon-reload
+    systemctl restart containerd
+
+  else
+    logger "Unsupported OS version: $os_version. Skipping containerd configuration."
+  fi
+
+else
+  logger "/opt/sagemaker not mounted. Skipping containerd configuration"
 fi
 
 logger "no more steps to run"


### PR DESCRIPTION
 **Lifecycle Script Issue in AL2023**
 While running a SageMaker lifecycle script on Amazon Linux 2023 (AL2023)-based clusters, the script failed during containerd configuration with:

    `sed: can't read /etc/eks/containerd/containerd-config.toml: No such file or directory`

This happened because the script was trying to modify the containerd config file at a path (`/etc/eks/containerd/containerd-config.toml`) that does not exist on AL2023.

Attempts to use nodeadm config containerd also failed because the version of nodeadm in AL2023 only supports config check, and does not include a containerd configuration subcommand.

Root Cause

  - AL2 uses /etc/eks/containerd/containerd-config.toml, which can be edited directly with sed.
  - AL2023 uses a systemd-based override model instead of static config files.
  - The lifecycle script lacked OS detection and attempted AL2-style edits on AL2023, causing lifecycle failure.

**Resolution:**

Updated the lifecycle script to:
* Detect OS version by sourcing /etc/os-release: 

        VERSION_ID="2" → Amazon Linux 2

        VERSION_ID="2023" → Amazon Linux 2023
* Apply containerd config changes conditionally:
  * For AL2: Use sed to update /etc/eks/containerd/containerd-config.toml
  * For AL2023: Write a systemd override file at /etc/systemd/system/containerd.service.d/override.conf with:

```
[Service]
Environment="CONTAINERD_CONFIG=/etc/containerd/config.toml"
ExecStart=
ExecStart=/usr/bin/containerd --root /opt/sagemaker/containerd/data-root --config $CONTAINERD_CONFIG
```

Then reload and restart containerd:
```
systemctl daemon-reexec
systemctl daemon-reload
systemctl restart containerd
```

* Wait up to 60 seconds for /opt/sagemaker to mount before applying configuration

**Outcome**
* Lifecycle script now runs successfully on both AL2 and AL2023.
* containerd data root is correctly set to /opt/sagemaker/containerd/data-root based on OS.
* Logs confirm successful execution, and SageMaker node provisioning completes without error.

