### PR TITLE
Resolving error message for HF trust remote code

### DIFF
--- a/3.test_cases/pytorch/FSDP/src/model_utils/train_utils.py
+++ b/3.test_cases/pytorch/FSDP/src/model_utils/train_utils.py
@@ -506,7 +506,7 @@ def create_streaming_dataloader(dataset,
                       split=None):
     print(f"dataset={dataset}, name={name}")
     tokenizer = AutoTokenizer.from_pretrained(tokenizer,legacy=False)
-    data = load_dataset(dataset, name=name, streaming=True, split=split, trust_remote_code=True).shuffle(42+global_rank)
+    data = load_dataset(dataset, name=name, streaming=True, split=split).shuffle(42+global_rank)
     train_concat_dataset = ConcatTokensDataset(data, tokenizer, max_context_width, True)
     train_dataloader = DataLoader(train_concat_dataset,
                                        batch_size=batch_size,


### PR DESCRIPTION
On 07/15, I started seeing errors while calling the load function:
```
[ERROR] datasets.load: trust_remote_code is not supported anymore.
```

Removing it just seems to work now.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
