### PR TITLE
Resolving "Unsupported block type" error in Terraform

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/custom.tfvars
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/custom.tfvars
@@ -1,0 +1,16 @@
+kubernetes_version = "1.32"
+eks_cluster_name = "tf-eks-cluster"
+hyperpod_cluster_name = "tf-hp-cluster"
+resource_name_prefix = "tf-eks-test"
+availability_zone_id  = "usw2-az2"
+instance_groups = {
+    accelerated-instance-group-1 = {
+        instance_type = "ml.c5.2xlarge",
+        instance_count = 1,
+        ebs_volume_size = 100,
+        threads_per_core = 1,
+        enable_stress_check = false,
+        enable_connectivity_check = false,
+        lifecycle_script = "on_create.sh"
+    }
+}

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/hyperpod_cluster/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/hyperpod_cluster/main.tf
@@ -47,7 +47,7 @@ resource "awscc_sagemaker_cluster" "hyperpod_cluster" {
 
   orchestrator = {
     eks = {
-      cluster_arn = "arn:${data.aws_partition.current.partition}:eks:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${var.eks_cluster_name}"
+      cluster_arn = "arn:${data.aws_partition.current.partition}:eks:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:cluster/${var.eks_cluster_name}"
     }
   }
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/s3_bucket/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/s3_bucket/main.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${var.resource_name_prefix}-bucket-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+  bucket = "${var.resource_name_prefix}-bucket-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.id}"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption" {

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/s3_endpoint/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/s3_endpoint/main.tf
@@ -1,6 +1,6 @@
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = var.vpc_id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.id}.s3"
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/sagemaker_iam_role/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/sagemaker_iam_role/main.tf
@@ -1,6 +1,6 @@
 # IAM Role
 resource "aws_iam_role" "sagemaker_execution_role" {
-  name = "${var.resource_name_prefix}-SMHP-Exec-Role-${data.aws_region.current.name}"
+  name = "${var.resource_name_prefix}-SMHP-Exec-Role-${data.aws_region.current.id}"
   path = "/"
 
   assume_role_policy = jsonencode({
@@ -33,7 +33,7 @@ resource "aws_iam_role_policy_attachment" "eks_cni_policy_attachment" {
 
 # Custom IAM Policy
 resource "aws_iam_policy" "sagemaker_execution_policy" {
-  name = "${var.resource_name_prefix}-ExecutionRolePolicy-${data.aws_region.current.name}"
+  name = "${var.resource_name_prefix}-ExecutionRolePolicy-${data.aws_region.current.id}"
   path = "/"
 
   policy = jsonencode({

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/outputs.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/outputs.tf
@@ -121,5 +121,5 @@ output "hyperpod_cluster_status" {
 # Region Output
 output "aws_region" {
   description = "AWS region"
-  value       = data.aws_region.current.name
+  value       = data.aws_region.current.id
 }

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/providers.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/providers.tf
@@ -7,10 +7,10 @@ provider "awscc" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = var.create_eks_module ? module.eks_cluster[0].eks_cluster_endpoint : data.aws_eks_cluster.existing_eks_cluster[0].endpoint
     cluster_ca_certificate = base64decode(var.create_eks_module ? module.eks_cluster[0].eks_cluster_certificate_authority : data.aws_eks_cluster.existing_eks_cluster[0].certificate_authority[0].data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", var.create_eks_module ? module.eks_cluster[0].eks_cluster_name : var.existing_eks_cluster_name]
       command     = "aws"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

-Fixed Helm provider configuration by changing the `kubernetes` block to use attribute syntax with = sign instead of block syntax, resolving the "Unsupported block type" error. 

- Updated all instances of the deprecated `data.aws_region.current.name` attribute to use `data.aws_region.current.id` to address the deprecation warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
