### PR TITLE
Upgrading helm provider to v3.0.0 to support blocks to nested objects

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/versions.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.0.0"
+      version = ">= 3.0.0"
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The syntax for the helm provider was updated to use nested objects in https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/providers.tf

To support this change, the helm provider version needs to be updated to v3.0.0 in https://github.com/aws-samples/awsome-distributed-training/blob/945fe5c0a259dd542b0cd72a6175a5923a3b07f8/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/versions.tf#L13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
