### PR TITLE
Adding Region to HMA Helm chart for Nova customization with Restricted Instance Group 

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/helm-chart-injector/lambda_function/lambda_function.py
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/helm-chart-injector/lambda_function/lambda_function.py
@@ -165,7 +165,8 @@ def on_create():
             'helm', 'install',
             os.environ['RELEASE_NAME'],
             f"/tmp/helm-charts/{os.environ['CHART_PATH']}",
-            '--namespace', os.environ['NAMESPACE']
+            '--namespace', os.environ['NAMESPACE'],
+            '--set', f"health-monitoring-agent.region={os.environ['AWS_REGION']}"
         ]
         subprocess.run(install_cmd, check=True)
 
@@ -234,7 +235,8 @@ def on_update():
         upgrade_cmd = [
             'helm', 'upgrade',
             os.environ['RELEASE_NAME'],
-            f"/tmp/helm-charts/{os.environ['CHART_PATH']}"
+            f"/tmp/helm-charts/{os.environ['CHART_PATH']}",
+            '--set', f"health-monitoring-agent.region={os.environ['AWS_REGION']}"
         ]
         subprocess.run(upgrade_cmd, check=True)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding `'--set', f"health-monitoring-agent.region={os.environ['AWS_REGION']}"` to `on_create` and `on_update` functions. 

PR related to recent updates to HyperPod Helm Charts here: 
https://github.com/aws/sagemaker-hyperpod-cli/pull/141

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
