### PR TITLE
Updating EFA validation script CUDA version and OFI NCCL path

### DIFF
--- a/4.validation_and_observability/efa-versions.py
+++ b/4.validation_and_observability/efa-versions.py
@@ -33,7 +33,7 @@ def get_nccl_version(container=[]):
         version = subprocess.check_output(container + ['locate', 'nccl'])
         version = version.decode('utf-8')
         print(version)
-        version = re.search(r'/usr/local/cuda-12.2/lib/libnccl.so.(\d+\.\d+\.\d+)', version).group(1)
+        version = re.search(r'/usr/local/cuda-12.8/lib/libnccl.so.(\d+\.\d+\.\d+)', version).group(1)
         return version
     except Exception as e:
         print(f'Error: {e}')
@@ -41,9 +41,9 @@ def get_nccl_version(container=[]):
 
 def get_aws_ofi_nccl_version(container=[]):
     try:
-        version = subprocess.check_output(container + ['strings', '/opt/aws-ofi-nccl/lib/libnccl-net.so'])
+        version = subprocess.check_output(container + ['strings', '/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-net.so'])
         version = version.decode('utf-8')
-        version = re.search(r'NET/OFI Initializing aws-ofi-nccl (\d+\.\d+\.\d+-aws)', version).group(1)
+        version = re.search(r'NET/OFI Initializing aws-ofi-nccl (\d+\.\d+\.\d+)', version).group(1)
         return version
     except Exception as e:
         


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated path for `get_nccl_version` to `/usr/local/cuda-12.8/lib/libnccl.so` 
Updated path for `get_aws_ofi_nccl _version` to `/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-net.so`
Updated regex for `get_aws_ofi_nccl_version` to `\d+\.\d+\.\d+`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
