### PR TITLE
Add note to OpenZFS for Slinky and modify config

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/README.md
@@ -23,7 +23,7 @@ The diagram above depicts the resulting proof-of-concept deployment outlined in 
 
 The login LoadBalancer type service is annotated to dynamically create an AWS Network Load Balancer using the [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller), allowing ML scientists to SSH into their login pods without interfacing with the Kubernetes API server via kubectl. 
 
-The login and compute node pods also have FSx for Lustre and FSx for OpenZFS shared filesystems mounted. Having containerized compute node pods allows many dependencies that would traditionally be installed manually using Conda or a Python virtual environment to be baked into the container image, but shared filesystems are still beneficial for storing training artifacts, data, logs, and checkpoints. If Conda environments are still required, FSx for OpenZFS has proven optimal to avoid IOPS saturation with many small files. 
+The login and compute node pods also have FSx for Lustre and (optionally) FSx for OpenZFS shared filesystems mounted. Having containerized compute node pods allows many dependencies that would traditionally be installed manually using Conda or a Python virtual environment to be baked into the container image, but shared filesystems are still beneficial for storing training artifacts, data, logs, and checkpoints. If Conda environments are still required, FSx for OpenZFS has proven optimal to avoid IOPS saturation with many small files. 
 
 ---
 
@@ -517,7 +517,7 @@ kubectl get pv $(kubectl get pvc openzfs-claim -n slurm -ojson \
 ```
 ---
 #### Review Volume Mounts:
-FSx for Lustre and OpenZFS PVCs are added to the list of `extraVolumeMounts` and `extraVolumes` for both the login service and compute nodes in [g5-values.yaml](./g5/g5-values.yaml) and [p5-values.yaml](./p5/p5-values.yaml): 
+FSx for Lustre and OpenZFS PVCs are added to the list of `extraVolumeMounts` and `extraVolumes` for both the login service and compute nodes in [g5-values.yaml](./g5/g5-values.yaml) and [p5-values.yaml](./p5/p5-values.yaml). If you are using FSx for OpenZFS you will have to uncomment the mount under `extraVolumeMounts` and `extraVolumes`: 
 
 ```
 login:

--- a/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/g5/g5-values.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/g5/g5-values.yaml
@@ -451,8 +451,8 @@ login:
   extraVolumeMounts:
     - name: fsx-lustre
       mountPath: /fsx
-    - name: fsx-openzfs
-      mountPath: /home
+    # - name: fsx-openzfs
+    #   mountPath: /home
     # - name: nfs-home
     #   mountPath: /home
     # - name: nfs-data
@@ -465,9 +465,9 @@ login:
      - name: fsx-lustre
        persistentVolumeClaim: 
         claimName: fsx-claim
-     - name: fsx-openzfs
-       persistentVolumeClaim: 
-        claimName: openzfs-claim
+    #  - name: fsx-openzfs
+    #    persistentVolumeClaim: 
+    #     claimName: openzfs-claim
     # - name: nfs-home
     #   persistentVolumeClaim:
     #     claimName: nfs-home
@@ -676,8 +676,8 @@ compute:
       extraVolumeMounts:
         - name: fsx-lustre
           mountPath: /fsx
-        - name: fsx-openzfs
-          mountPath: /home
+        # - name: fsx-openzfs
+        #   mountPath: /home
         - name: shmem
           mountPath: /dev/shm
         # - name: nfs-home
@@ -692,9 +692,9 @@ compute:
         - name: fsx-lustre
           persistentVolumeClaim: 
             claimName: fsx-claim
-        - name: fsx-openzfs
-          persistentVolumeClaim: 
-            claimName: openzfs-claim
+        # - name: fsx-openzfs
+        #   persistentVolumeClaim: 
+        #     claimName: openzfs-claim
         - name: shmem
           hostPath: 
                 path: /dev/shm

--- a/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/p5/p5-values.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/p5/p5-values.yaml
@@ -451,8 +451,8 @@ login:
   extraVolumeMounts:
     - name: fsx-lustre
       mountPath: /fsx
-    - name: fsx-openzfs
-      mountPath: /home
+    # - name: fsx-openzfs
+    #   mountPath: /home
     # - name: nfs-home
     #   mountPath: /home
     # - name: nfs-data
@@ -465,9 +465,9 @@ login:
      - name: fsx-lustre
        persistentVolumeClaim: 
         claimName: fsx-claim
-     - name: fsx-openzfs
-       persistentVolumeClaim: 
-        claimName: openzfs-claim
+    #  - name: fsx-openzfs
+    #    persistentVolumeClaim: 
+    #     claimName: openzfs-claim
     # - name: nfs-home
     #   persistentVolumeClaim:
     #     claimName: nfs-home
@@ -678,8 +678,8 @@ compute:
       extraVolumeMounts:
         - name: fsx-lustre
           mountPath: /fsx
-        - name: fsx-openzfs
-          mountPath: /home
+        # - name: fsx-openzfs
+        #   mountPath: /home
         - name: shmem
           mountPath: /dev/shm
         # - name: nfs-home
@@ -694,9 +694,9 @@ compute:
         - name: fsx-lustre
           persistentVolumeClaim: 
             claimName: fsx-claim
-        - name: fsx-openzfs
-          persistentVolumeClaim: 
-            claimName: openzfs-claim
+        # - name: fsx-openzfs
+        #   persistentVolumeClaim: 
+        #     claimName: openzfs-claim
         - name: shmem
           hostPath: 
                 path: /dev/shm


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
FSx for OpenZFS is mentioned as optional and the FSDP script doesn't use OpenZFS. It is included in the Slinky configuration by default causing it to fail unless configured.

This change comments out the OpenZFS mount so it is optional without changes. There is a note included in the README to add it back if OpenZFS is desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
