### PR TITLE
Update README.md to resolve CF stack deployment error

### DIFF
--- a/4.validation_and_observability/4.prometheus-grafana/1click-dashboards-deployment/README.md
+++ b/4.validation_and_observability/4.prometheus-grafana/1click-dashboards-deployment/README.md
@@ -35,7 +35,7 @@ sam build -t managed-cluster-observability-pc.yaml
 sam deploy -t managed-cluster-observability-pc.yaml\
     --stack-name ${OBS_DASHBOARD_NAME} \
     --guided \
-    --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
+    --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND CAPABILITY_NAMED_IAM \
     --parameter-overrides \
     ParameterKey=PCClusterName,ParameterValue=<CLUSTER_NAME> \
     ParameterKey=SubnetId,ParameterValue=<SUBNET_ID> \


### PR DESCRIPTION
Adding "CAPABILITY_NAMED_IAM"  to the deployment command to resolve the error:

CREATE_FAILED AWS::CloudFormation::Stack GrafanaPrometheus Requires capabilities : [CAPABILITY_NAMED_IAM]

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
