### PR TITLE
regionalized hma helm deployment and simplified helm_chart module

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/README.md
@@ -33,6 +33,7 @@ kubernetes_version = "1.32"
 eks_cluster_name = "my-eks-cluster"
 hyperpod_cluster_name = "my-hp-cluster"
 resource_name_prefix = "hp-eks-test"
+aws_region = "us-west-2"
 availability_zone_id  = "usw2-az2"
 instance_groups = {
     accelerated-instance-group-1 = {
@@ -61,6 +62,7 @@ existing_vpc_id = "vpc-1234567890abcdef0"
 existing_nat_gateway_id = "nat-1234567890abcdef0"
 hyperpod_cluster_name = "my-hp-cluster"
 resource_name_prefix = "hp-eks-test"
+aws_region = "us-west-2"
 availability_zone_id  = "usw2-az2"
 instance_groups = {
     accelerated-instance-group-1 = {
@@ -78,6 +80,10 @@ EOL
 ---
 
 ## Deployment 
+First, clone the [HyperPod Helm charts GitHub repository](https://github.com/aws/sagemaker-hyperpod-cli/tree/main/helm_chart) to locally stage the dependencies Helm chart.  
+```bash
+git clone https://github.com/aws/sagemaker-hyperpod-cli.git /tmp/helm-repo
+```
 Run `terraform init` to initialize the Terraform working directory, install necessary provider plugins, download modules, set up state storage, and configure the backend for managing infrastructure state: 
 
 ```bash 

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/custom.tfvars
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/custom.tfvars
@@ -2,6 +2,7 @@ kubernetes_version = "1.32"
 eks_cluster_name = "tf-eks-cluster"
 hyperpod_cluster_name = "tf-hp-cluster"
 resource_name_prefix = "tf-eks-test"
+aws_region = "us-west-2"
 availability_zone_id  = "usw2-az2"
 instance_groups = {
     accelerated-instance-group-1 = {

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/main.tf
@@ -1,3 +1,13 @@
+data "aws_eks_cluster" "existing_eks_cluster" {
+  count  = var.create_eks_module ? 0 : 1
+  name = var.existing_eks_cluster_name
+}
+
+data "aws_s3_bucket" "existing_s3_bucket" {
+  count  =  var.create_s3_bucket_module ? 0 : (var.existing_s3_bucket_name != "" ? 1 : 0)
+  bucket = var.existing_s3_bucket_name
+}
+
 locals {
   vpc_id = var.create_vpc_module ? module.vpc[0].vpc_id : var.existing_vpc_id
   private_subnet_id = var.create_private_subnet_module ? module.private_subnet[0].private_subnet_id : var.existing_private_subnet_id
@@ -82,7 +92,7 @@ module "sagemaker_iam_role" {
   source = "./modules/sagemaker_iam_role"
 
   resource_name_prefix = var.resource_name_prefix
-  s3_bucket_name      = local.s3_bucket_name
+  s3_bucket_name       = local.s3_bucket_name
 }
 
 module "helm_chart" {
@@ -123,17 +133,4 @@ module "hyperpod_cluster" {
   s3_bucket_name          = local.s3_bucket_name
   sagemaker_iam_role_name = local.sagemaker_iam_role_name
 
-}
-
-# Data source for current AWS region
-data "aws_region" "current" {}
-
-data "aws_eks_cluster" "existing_eks_cluster" {
-  count  = var.create_eks_module ? 0 : 1
-  name = var.existing_eks_cluster_name
-}
-
-data "aws_s3_bucket" "existing_s3_bucket" {
-  count  =  var.create_s3_bucket_module ? 0 : (var.existing_s3_bucket_name != "" ? 1 : 0)
-  bucket = var.existing_s3_bucket_name
 }

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/main.tf
@@ -102,7 +102,6 @@ module "helm_chart" {
   depends_on = [module.eks_cluster]
 
   resource_name_prefix = var.resource_name_prefix
-  helm_repo_url       = var.helm_repo_url
   helm_repo_path      = var.helm_repo_path
   namespace           = var.namespace
   helm_release_name   = var.helm_release_name

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/eks_cluster/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/eks_cluster/main.tf
@@ -1,6 +1,4 @@
-# Data source for current AWS region
 data "aws_region" "current" {}
-
 data "aws_caller_identity" "current" {}
 
 data "aws_vpc" "selected" {

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/helm_chart/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/helm_chart/main.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 data "aws_eks_cluster" "cluster" {
   name = var.eks_cluster_name
 }
@@ -6,92 +8,15 @@ data "aws_eks_cluster_auth" "cluster" {
   name = var.eks_cluster_name
 }
 
-resource "null_resource" "git_clone" {
-  triggers = {
-    helm_repo_url = var.helm_repo_url
-    # Add a random trigger to force recreation
-    random = uuid()
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      echo "Starting git clone operation..."
-      echo "Cleaning up existing directory..."
-      rm -rf /tmp/helm-repo
-      echo "Creating fresh directory..."
-      mkdir -p /tmp/helm-repo
-      echo "Cloning from ${var.helm_repo_url}..."
-      git clone ${var.helm_repo_url} /tmp/helm-repo
-      echo "Contents of /tmp/helm-repo:"
-      ls -la /tmp/helm-repo
-      echo "Git clone complete"
-    EOT
-  }
-}
-
-resource "null_resource" "helm_dep_update" {
-  triggers = {
-    helm_repo_url = var.helm_repo_url
-    git_clone = null_resource.git_clone.id
-    # Add a random trigger to force recreation
-    random = uuid()
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      echo "Starting helm dependency update..."
-      echo "Checking for /tmp/helm-repo..."
-      if [ ! -d "/tmp/helm-repo" ]; then
-        echo "Error: /tmp/helm-repo directory does not exist"
-        exit 1
-      fi
-      
-      echo "Checking for chart directory..."
-      if [ ! -d "/tmp/helm-repo/${var.helm_repo_path}" ]; then
-        echo "Error: Chart directory ${var.helm_repo_path} not found"
-        echo "Contents of /tmp/helm-repo:"
-        ls -la /tmp/helm-repo
-        exit 1
-      fi
-
-      echo "Creating charts directory if it doesn't exist..."
-      mkdir -p "/tmp/helm-repo/${var.helm_repo_path}/charts"
-      
-      echo "Creating empty Chart.yaml in charts directory if needed..."
-      for dep in $(grep -o 'name: [a-zA-Z0-9_-]\+' "/tmp/helm-repo/${var.helm_repo_path}/Chart.yaml" | cut -d' ' -f2); do
-        if [ ! -d "/tmp/helm-repo/${var.helm_repo_path}/charts/$dep" ]; then
-          mkdir -p "/tmp/helm-repo/${var.helm_repo_path}/charts/$dep"
-          echo "apiVersion: v2\nname: $dep\nversion: 0.1.0" > "/tmp/helm-repo/${var.helm_repo_path}/charts/$dep/Chart.yaml"
-        fi
-      done
-
-      echo "Running helm dependency update..."
-      helm dependency update /tmp/helm-repo/${var.helm_repo_path}
-      echo "Helm dependency update complete"
-    EOT
-  }
-
-  depends_on = [null_resource.git_clone]
-}
-
-
 resource "helm_release" "hyperpod" {
   name       = var.helm_release_name
   chart      = "/tmp/helm-repo/${var.helm_repo_path}"
   namespace  = var.namespace
-  skip_crds  = true
   dependency_update = true
-
-  depends_on = [
-    null_resource.git_clone,
-    null_resource.helm_dep_update
+  set = [
+    {
+      name  = "health-monitoring-agent.region", 
+      value = data.aws_region.current.id
+    }
   ]
-
-  # Force recreation of the helm release when git repo changes
-  lifecycle {
-    replace_triggered_by = [
-      null_resource.git_clone,
-      null_resource.helm_dep_update
-    ]
-  }
 }

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/helm_chart/variables.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/helm_chart/variables.tf
@@ -8,12 +8,6 @@ variable "eks_cluster_name" {
   type        = string
 }
 
-variable "helm_repo_url" {
-  description = "The URL of the Helm repo containing the HyperPod Helm chart"
-  type        = string
-  default     = "https://github.com/aws/sagemaker-hyperpod-cli.git"
-}
-
 variable "helm_repo_path" {
   description = "The path to the HyperPod Helm chart in the Helm repo"
   type        = string

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/s3_bucket/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/s3_bucket/main.tf
@@ -1,3 +1,6 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
 resource "aws_s3_bucket" "bucket" {
   bucket = "${var.resource_name_prefix}-bucket-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.id}"
 }
@@ -12,8 +15,3 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption
   }
 }
 
-# Data source for current AWS region
-data "aws_region" "current" {}
-
-# Data source for AWS caller identity
-data "aws_caller_identity" "current" {}

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/s3_endpoint/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/s3_endpoint/main.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = var.vpc_id
   service_name = "com.amazonaws.${data.aws_region.current.id}.s3"
@@ -17,6 +19,3 @@ resource "aws_vpc_endpoint" "s3" {
   route_table_ids = [var.private_route_table_id]
   vpc_endpoint_type = "Gateway"
 }
-
-# Data source for current AWS region
-data "aws_region" "current" {}

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/sagemaker_iam_role/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/sagemaker_iam_role/main.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 # IAM Role
 resource "aws_iam_role" "sagemaker_execution_role" {
   name = "${var.resource_name_prefix}-SMHP-Exec-Role-${data.aws_region.current.id}"
@@ -92,6 +94,3 @@ resource "aws_iam_role_policy_attachment" "sagemaker_execution_policy_attachment
   role       = aws_iam_role.sagemaker_execution_role.name
   policy_arn = aws_iam_policy.sagemaker_execution_policy.arn
 }
-
-# Data source for current AWS region
-data "aws_region" "current" {}

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/outputs.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/outputs.tf
@@ -121,5 +121,5 @@ output "hyperpod_cluster_status" {
 # Region Output
 output "aws_region" {
   description = "AWS region"
-  value       = data.aws_region.current.id
+  value       = var.aws_region
 }

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/providers.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/providers.tf
@@ -1,9 +1,9 @@
 provider "aws" {
-  region = "us-west-2" # Adjust as needed
+  region = var.aws_region
 }
 
 provider "awscc" {
-  region = "us-west-2"
+  region = var.aws_region
 }
 
 provider "helm" {

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/terraform.tfvars
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/terraform.tfvars
@@ -45,7 +45,6 @@ existing_sagemaker_iam_role_name = ""
 
 # Helm Chart Module Variables
 create_helm_chart_module = true
-helm_repo_url            = "https://github.com/aws/sagemaker-hyperpod-cli.git"
 helm_repo_path           = "helm_chart/HyperPodHelmChart"
 namespace                = "kube-system"
 helm_release_name        = "hyperpod-dependencies"

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/terraform.tfvars
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/terraform.tfvars
@@ -1,4 +1,5 @@
 resource_name_prefix = "sagemaker-hyperpod-eks"
+aws_region           = "us-west-2"
 
 # VPC Module Variables
 create_vpc_module    = true

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/variables.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/variables.tf
@@ -181,12 +181,6 @@ variable "create_helm_chart_module" {
   default     = true
 }
 
-variable "helm_repo_url" {
-  description = "The URL of the Helm repo"
-  type        = string
-  default     = "https://github.com/aws/sagemaker-hyperpod-cli.git"
-}
-
 variable "helm_repo_path" {
   description = "The path to the HyperPod Helm chart"
   type        = string

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/variables.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/variables.tf
@@ -4,6 +4,12 @@ variable "resource_name_prefix" {
   default     = "sagemaker-hyperpod-eks"
 }
 
+variable "aws_region" {
+  description = "AWS Region to be targeted for deployment"
+  type        = string
+  default     = "us-west-2"
+}
+
 # VPC Module Variables
 variable "create_vpc_module" {
   description = "Whether to create VPC module"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**TLDR;** you can set the region for the health monitoring agent now to support restricted instance groups for Nova model customization. On a separate note, users now have to clone the Helm chart repo as a prerequisite, but this simplifies the terraform logic and makes behavior more consistent between plan and apply phases. 

- `helm_release.hyperpod` now sets `health-monitoring-agent.region` equal to the target region, as set by `var.region` in the main module, which configures the `aws` provider. 
- `helm_chart` module simplified to avoid `terraform plan` errors when the `/tmp/helm-repo/helm_chart/HyperPodHelmChart/Chart.yaml` file doesn't yet exist.
    **Explanation:** Even though the `null_resource.git_clone` resource did successfully fetch the helm charts before `helm_release.hyperpod` is evaluated during the `terraform apply` phase according to the `depends_on` reference, `null_resource` types are not executed during the `terraform plan` phase, causing this issue. This is primarily a side effect of the helm charts being stored and pulled from a GitHub repo rather than using an OCI registry like GHCR or ECR. This requires running git client commands to stage the helm charts locally. If they were stored in an OCI registry, the `terraform plan` phase would succeed natively since the `helm_release.hyperpod` resource would be able to resolve the `chart` URL. Other work arounds were explored, but they all required adding at least one additional step for the user to execute, so the README instructions have been updated to simply require `git clone https://github.com/aws/sagemaker-hyperpod-cli.git /tmp/helm-repo` as an initial step rather than housing and executing that logic within the `helm_chart` module. With this change, `terraform plan` now runs consistently with `terraform apply`, and the `helm_chart` module code is primed for migrating the helm charts to an OCI registry. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
