### PR TITLE
patch(no-op): Add No Op for Al2023 to use default root for containerd

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
@@ -43,21 +43,10 @@ if mount | grep -q "/opt/sagemaker"; then
 
   elif [[ "$os_version" == "2023" ]]; then
     # Amazon Linux 2023 logic (systemd override)
-    logger "Amazon Linux 2023 detected. Writing systemd override for containerd"
-
-    mkdir -p /etc/systemd/system/containerd.service.d
-
-    cat <<EOF | tee /etc/systemd/system/containerd.service.d/override.conf
-[Service]
-Environment="CONTAINERD_CONFIG=/etc/containerd/config.toml"
-ExecStart=
-ExecStart=/usr/bin/containerd --root /opt/sagemaker/containerd/data-root --config \$CONTAINERD_CONFIG
-EOF
-
-    logger "Reloading and restarting containerd"
-    systemctl daemon-reexec
-    systemctl daemon-reload
-    systemctl restart containerd
+    logger "Amazon Linux 2023 detected. WARNING: nodeadm will override containerd configuration"
+    logger "Current containerd config will be reset by nodeadm to use /var/lib/containerd"
+    logger "Manual intervention required post-nodeadm execution to set data-root to /opt/sagemaker/containerd/data-root"
+    logger "Consider implementing post-nodeadm hook or alternative solution"
 
   else
     logger "Unsupported OS version: $os_version. Skipping containerd configuration."


### PR DESCRIPTION
type: patch

description:

- cx are unable to pull the pause image post switching the root mount on containerd
- nodeadm overwrites the default /etc/eks/containerd/containerd-config.toml. so the are not holding true.
- ignore temporarily till we mitigate the behaviour.

*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/2122
*Description of changes:*




## Manual tests

Before

```
amazon-cloudwatch        fluent-bit-str5h                                       0/1     CrashLoopBackOff   8 (2m18s ago)    23d
hyperpod-observability   hyp-obs-efa-exporter-prometheus-node-exporter-k4qm2    0/1     CrashLoopBackOff   8 (3m56s ago)    6d7h
hyperpod-observability   hyp-obs-node-exporter-prometheus-node-exporter-l95rp   0/1     CrashLoopBackOff   8 (101s ago)     6d7h
hyperpod-observability   hyperpod-observability-node-collector-gd54w            0/1     CrashLoopBackOff   7 (4m31s ago)    6d7h


```

After

```
➜  ~ kubectl get pods -A
NAMESPACE     NAME                                                       READY   STATUS    RESTARTS   AGE
default       nginx-deployment-d556bf558-4mjm4                           1/1     Running   0          4m44s
default       nginx-deployment-d556bf558-89cl4                           1/1     Running   0          4m44s
default       nginx-deployment-d556bf558-h58nl                           1/1     Running   0          4m44s
kube-system   aws-node-tm9qx                                             2/2     Running   0          74s
kube-system   coredns-57d5bfd8f-8x4hc                                    1/1     Running   0          4m43s
kube-system   coredns-57d5bfd8f-dvrqq                                    1/1     Running   0          4m43s
kube-system   eks-pod-identity-agent-6sxcs                               1/1     Running   0          74s
kube-system   hyperpod-dependencies-mpi-operator-76dcfccc48-dzvhm        1/1     Running   0          4m44s
kube-system   kube-proxy-ngrc5                                           1/1     Running   0          74s
kubeflow      hyperpod-dependencies-training-operators-6c47bd8d5-dh4ds   1/1     Running   0          4m43s


```
