### PR TITLE
updated easy ssh script to add cluster names with similar prefix

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
@@ -57,7 +57,7 @@ parse_args() {
 
 # Function to check if ml-cluster exists in ~/.ssh/config
 check_ssh_config() {
-    if grep -q "Host ${cluster_name}" ~/.ssh/config; then
+    if grep -wq "Host ${cluster_name}$" ~/.ssh/config; then
         echo -e "${BLUE}1. Detected ${GREEN}${cluster_name}${BLUE} in  ${GREEN}~/.ssh/config${BLUE}. Skipping adding...${NC}"
     else
         echo -e "${BLUE}Would you like to add ${GREEN}${cluster_name}${BLUE} to  ~/.ssh/config (yes/no)?${NC}"


### PR DESCRIPTION
*Issue #, if available:* #826

*Description of changes:* 
Updated the `checkssh_config` function in `easy_ssh.sh` script to not avoid cluster name with similar prefix. The `grep` command now has stricter string matching that allows multiple cluster names with similar prefix to be recognized as individual clusters. 
Minor change tested and is good to go. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
