### PR TITLE
Update package versions in nemo Dockerfile

### DIFF
--- a/3.test_cases/megatron/nemo/Dockerfile
+++ b/3.test_cases/megatron/nemo/Dockerfile
@@ -1,10 +1,11 @@
 FROM nvcr.io/nvidia/nemo:25.07.00
-ARG GDRCOPY_VERSION=v2.5
-ARG EFA_INSTALLER_VERSION=1.43.1
+ARG GDRCOPY_VERSION=v2.5.1
+ARG EFA_INSTALLER_VERSION=1.43.2
 # ARG AWS_OFI_NCCL_VERSION=v1.13.2-aws    # OFI NCCL already packaged into EFA installation (/opt/amazon/ofi-nccl) cf. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-changelog.html
-ARG NCCL_VERSION=v2.27.5-1
-ARG NCCL_TESTS_VERSION=v2.16.7
-ARG TRANSFORMERS_VERSION=4.54.1
+ARG NCCL_VERSION=v2.27.7-1
+ARG NCCL_TESTS_VERSION=v2.16.9
+ARG TRANSFORMERS_VERSION=4.56.1
+
 
 ARG OPEN_MPI_PATH=/opt/amazon/openmpi    # Open MPI already packaged into EFA installation (/opt/amazon/openmpi)
 


### PR DESCRIPTION
Updating EFA, NCCL, GDRCOPY and Transformers versions

*Issue #, if available:*
To resolve the error :
>  ImportError: huggingface-hub>=0.34.0,<1.0 is required for a normal functioning of this module, but found huggingface-hub==0.33.4.
and to ensure we are using the latest version of EFA, NCCL GDRCOPY and NCCL tests
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
