### PR TITLE
Update run.py to fix missing import

### DIFF
--- a/3.test_cases/megatron/nemo/slurm/run.py
+++ b/3.test_cases/megatron/nemo/slurm/run.py
@@ -3,6 +3,7 @@ import json
 import argparse
 import math
 import os
+import signal
 from functools import partial
 from typing import Any, Optional
 from nemo.collections import llm


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Adding "import signal" to resolve the error:

```
Traceback (most recent call last):
  File "awsome-distributed-training/3.test_cases/megatron/nemo/slurm/run.py", line 150, in <module>
    plugins.PreemptionPlugin(callbacks=[run.Config(PreemptionCallback, sig=signal.SIGINT)]),
NameError: name 'signal' is not defined
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
