### PR TITLE
Fixing Slurm exporter installation script for HyperPod Slurm

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_slurm_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_slurm_exporter.sh
@@ -23,6 +23,7 @@ if systemctl is-active --quiet slurmctld; then
     echo "This was identified as the controller node because Slurmctld is running. Begining SLURM Exporter Installation"
     git clone -b v1.1.0 https://github.com/SckyzO/slurm_exporter.git
     cd slurm_exporter
+
     make build && cp bin/slurm_exporter /usr/bin/
     tee /etc/systemd/system/slurm_exporter.service > /dev/null <<EOF
 [Unit]


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/awsome-distributed-training/issues/872

*Description of changes:*
Environment variable HOME is not set in LCS. It is needed for Go. Setting it only for this script & child processes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
