### PR TITLE
update nccl-tests.yaml paths

### DIFF
--- a/micro-benchmarks/nccl-tests/kubernetes/nccl-tests.yaml
+++ b/micro-benchmarks/nccl-tests/kubernetes/nccl-tests.yaml
@@ -18,10 +18,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: test-nccl-launcher
             env:
-             - name: PATH
-               value: $PATH:/opt/amazon/efa/bin:/usr/bin
              - name: LD_LIBRARY_PATH
-               value: /opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+               value: /opt/nccl/build/lib:/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu
             command:
             - /opt/amazon/openmpi/bin/mpirun
             - --allow-run-as-root
@@ -33,21 +31,13 @@ spec:
             - --bind-to
             - none
             - -x
-            - PATH
-            - -x
             - LD_LIBRARY_PATH
             - -x
             - FI_PROVIDER=efa
             - -x
-            - FI_EFA_FORK_SAFE=1
-            - -x
             - NCCL_DEBUG=INFO
             - -x
-            - NCCL_BUFFSIZE=8388608
-            - -x
-            - NCCL_P2P_NET_CHUNKSIZE=524288
-            - -x
-            - NCCL_TUNER_PLUGIN=/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-ofi-tuner.so
+            - NCCL_TUNER_PLUGIN=ofi
             - --mca
             - pml
             - ^ucx


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated OFI NCCL plugin path to `/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu`
Updated CUDA toolkit path to `/usr/local/cuda/lib64`
Updated OFI NCCL tuner plugin path to `/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-ofi-tuner.so`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
