### PR TITLE
minor patch for AL2023

### DIFF
--- a/3.test_cases/pytorch/cpu-ddp/kubernetes/fsdp.yaml-template
+++ b/3.test_cases/pytorch/cpu-ddp/kubernetes/fsdp.yaml-template
@@ -104,7 +104,11 @@ spec:
                 - "10"
                 - --batch_size=32
                 - --checkpoint_path=/fsx/snapshot.pt
-
+              env:
+                - name: NVIDIA_VISIBLE_DEVICES
+                  value: "void"
+                - name: NVIDIA_DRIVER_CAPABILITIES
+                  value: ""
               volumeMounts:
                 - name: shmem
                   mountPath: /dev/shm


### PR DESCRIPTION
*Description of changes:*
pytorch cpu-ddp example fails currently. With AL2023 release, we should explicitly set for our cpu pods:

```
env:
- name: NVIDIA_VISIBLE_DEVICES
  value: "void"
- name: NVIDIA_DRIVER_CAPABILITIES
  value: ""
```
This has been successfully tested on my local EKS cluster with 2x `ml.m5.2xlarge` instances.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
