### PR TITLE
Nodes upgraded from Amazon Linux 2 to AL23 fail to create pod sandboxes

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
@@ -45,6 +45,12 @@ if mount | grep -q "/opt/sagemaker"; then
     # Amazon Linux 2023 logic (systemd override with custom config)
     logger "Amazon Linux 2023 detected. Creating custom containerd config and systemd override"
 
+    # Clean up old containerd data to avoid AL2->AL23 compatibility issues
+    if [[ -d "/opt/sagemaker/containerd/data-root" ]]; then
+      logger "Removing existing containerd data-root to prevent AL2/AL23 incompatibility"
+      rm -rf /opt/sagemaker/containerd/data-root
+    fi
+
     # Create custom containerd config directory
     mkdir -p /opt/sagemaker/containerd
 


### PR DESCRIPTION
**Root Cause:** 
AL2 and AL23 have different containerd versions. Persisted AL2 containerd data on `/opt/sagemaker/containerd/data-root` is incompatible with AL23 containerd.

Solution
Modified the LCS script to clean stale containerd data before AL23 setup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
