### PR TITLE
EFA Node exporter updates

### DIFF
--- a/4.validation_and_observability/3.efa-node-exporter/amazon_efa_linux.go
+++ b/4.validation_and_observability/3.efa-node-exporter/amazon_efa_linux.go
@@ -48,36 +48,41 @@ func NewAmazonEfaCollector(logger *slog.Logger) (Collector, error) {
 
 	// Detailed description for all metrics.
 	descriptions := map[string]string{
-		"alloc_pd_err":          "Number of allocations PD errors",
-		"alloc_ucontext_err":    "Number of allocations UContext errors",
-		"cmds_err":              "Number of commands errors",
-		"completed_cmds":        "Number of completed commands",
-		"create_ah_err":         "Number of create AH errors",
-		"create_cq_err":         "Number of create CQ errors",
-		"create_qp_err":         "Number of create qp errors",
-		"keep_alive_rcvd":       "Number of keep-alive packets received",
-		"lifespan":              "Lifespan of the port",
-		"mmap_err":              "Number of mmap errors",
-		"no_completion_cmds":    "Number of commands with no completion",
-		"rdma_read_bytes":       "Number of bytes read with RDMA",
-		"rdma_read_resp_bytes":  "Number of read reponses bytes with RDMA",
-		"rdma_read_wr_err":      "Number of read write errors with RDMA",
-		"rdma_read_wrs":         "Number of read rs with RDMA",
-		"rdma_write_bytes":      "Number of bytes wrote with RDMA",
-		"rdma_write_recv_bytes": "Number of bytes wrote and received with RDMA",
-		"rdma_write_wr_err":     "Number of bytes wrote wr with error RDMA",
-		"rdma_write_wrs":        "Number of bytes wrote wrs RDMA",
-		"recv_bytes":            "Number of bytes recv bytes",
-		"recv_wrs":              "Number of bytes recv wrs",
-		"reg_mr_err":            "Number of reg_mr errors",
-		"rx_bytes":              "Number of bytes received",
-		"rx_drops":              "Number of packets droped",
-		"rx_pkts":               "Number of packets received",
-		"send_bytes":            "Number of bytes send",
-		"send_wrs":              "Number of wrs send",
-		"submitted_cmds":        "Number of submitted commands",
-		"tx_bytes":              "Number of bytes transmitted",
-		"tx_pkts":               "Number of packets transmitted",
+		"alloc_pd_err":          		"Number of allocations PD errors",
+		"alloc_ucontext_err":   		"Number of allocations UContext errors",
+		"cmds_err":              		"Number of commands errors",
+		"completed_cmds":        		"Number of completed commands",
+		"create_ah_err":         		"Number of create AH errors",
+		"create_cq_err":         		"Number of create CQ errors",
+		"create_qp_err":         		"Number of create qp errors",
+		"impaired_remote_conn_events": 	"Number of EFA SRD connections entered an impaired state, resulting in a reduced throughput rate limit.",
+		"keep_alive_rcvd":       		"Number of keep-alive packets received",
+		"lifespan":              		"Lifespan of the port",
+		"mmap_err":              		"Number of mmap errors",
+		"no_completion_cmds":    		"Number of commands with no completion",
+		"rdma_read_bytes":       		"Number of bytes read with RDMA",
+		"rdma_read_resp_bytes":  		"Number of read reponses bytes with RDMA",
+		"rdma_read_wr_err":      		"Number of read write errors with RDMA",
+		"rdma_read_wrs":         		"Number of read rs with RDMA",
+		"rdma_write_bytes":      		"Number of bytes wrote with RDMA",
+		"rdma_write_recv_bytes": 		"Number of bytes wrote and received with RDMA",
+		"rdma_write_wr_err":     		"Number of bytes wrote wr with error RDMA",
+		"rdma_write_wrs":        		"Number of bytes wrote wrs RDMA",
+		"recv_bytes":            		"Number of bytes recv bytes",
+		"recv_wrs":              		"Number of bytes recv wrs",
+		"reg_mr_err":            		"Number of reg_mr errors",
+		"retrans_bytes":		 		"Number of efa_srd bytes retransmitted",
+		"retrans_pkts":			 		"Number of efa_srd packets retransmitted",
+		"retrans_timeout_events":		"Number of times SRD traffic reached timeout and required network path change",
+		"rx_bytes":              		"Number of bytes received",
+		"rx_drops":              		"Number of packets droped",
+		"rx_pkts":               		"Number of packets received",
+		"send_bytes":            		"Number of bytes send",
+		"send_wrs":              		"Number of wrs send",
+		"submitted_cmds":        		"Number of submitted commands",
+		"tx_bytes":              		"Number of bytes transmitted",
+		"tx_pkts":               		"Number of packets transmitted",
+		"unresponsive_remote_events":	"Number of times SRD connection remote was unresponsive",
 	}
 
 	i.metricDescs = make(map[string]*prometheus.Desc)
@@ -139,6 +144,7 @@ func (c *AmazonEfaCollector) Update(ch chan<- prometheus.Metric) error {
 			c.pushCounter(ch, "create_ah_err", port.Counters.CreateAhErr, port.Name, portStr)
 			c.pushCounter(ch, "create_cq_err", port.Counters.CreateCqErr, port.Name, portStr)
 			c.pushCounter(ch, "create_qp_err", port.Counters.CreateQpErr, port.Name, portStr)
+			c.pushCounter(ch, "impaired_remote_conn_events", port.Counters.ImpairedRemoteConnEvents, port.Name, portStr)
 			c.pushCounter(ch, "keep_alive_rcvd", port.Counters.KeepAliveRcvd, port.Name, portStr)
 			c.pushCounter(ch, "lifespan", port.Counters.Lifespan, port.Name, portStr)
 			c.pushCounter(ch, "mmap_err", port.Counters.MmapErr, port.Name, portStr)
@@ -153,6 +159,9 @@ func (c *AmazonEfaCollector) Update(ch chan<- prometheus.Metric) error {
 			c.pushCounter(ch, "rdma_write_wrs", port.Counters.RdmaWriteWrs, port.Name, portStr)
 			c.pushCounter(ch, "recv_bytes", port.Counters.RecvBytes, port.Name, portStr)
 			c.pushCounter(ch, "recv_wrs", port.Counters.RecvWrs, port.Name, portStr)
+			c.pushCounter(ch, "retrans_bytes", port.Counters.RetransBytes, port.Name, portStr)
+			c.pushCounter(ch, "retrans_pkts", port.Counters.RetransPkts, port.Name, portStr)
+			c.pushCounter(ch, "retrans_timeout_events", port.Counters.RetransTimeoutEvents, port.Name, portStr)
 			c.pushCounter(ch, "reg_mr_err", port.Counters.RegMrErr, port.Name, portStr)
 			c.pushCounter(ch, "rx_bytes", port.Counters.RxBytes, port.Name, portStr)
 			c.pushCounter(ch, "rx_drops", port.Counters.RxDrops, port.Name, portStr)
@@ -162,6 +171,7 @@ func (c *AmazonEfaCollector) Update(ch chan<- prometheus.Metric) error {
 			c.pushCounter(ch, "submitted_cmds", port.Counters.SubmittedCmds, port.Name, portStr)
 			c.pushCounter(ch, "tx_bytes", port.Counters.TxBytes, port.Name, portStr)
 			c.pushCounter(ch, "tx_pkts", port.Counters.TxPkts, port.Name, portStr)
+			c.pushCounter(ch, "unresponsive_remote_events", port.Counters.UnresponsiveRemoteEvents, port.Name, portStr)
 		}
 	}
 

--- a/4.validation_and_observability/3.efa-node-exporter/class_amazon_efa.go
+++ b/4.validation_and_observability/3.efa-node-exporter/class_amazon_efa.go
@@ -31,36 +31,41 @@ const AmazonEfaPath = "class/infiniband"
 // /sys/class/infiniband/<Name>/ports/<Port>/hw_counters
 // for a single port of one Amazon Elastic Fabric Adapter device.
 type AmazonEfaCounters struct {
-	AllocPdErr         *uint64 // hw_counters/alloc_pd_err
-	AllocUcontextErr   *uint64 // hw_counters/alloc_ucontext_err
-	CmdsErr            *uint64 // hw_counters/cmds_err
-	CompletedCmds      *uint64 // hw_counters/completed_cmds
-	CreateAhErr        *uint64 // hw_counters/create_ah_err
-	CreateCqErr        *uint64 // hw_counters/create_cq_err
-	CreateQpErr        *uint64 // hw_counters/create_qp_err
-	KeepAliveRcvd      *uint64 // hw_counters/keep_alive_rcvd
-	Lifespan           *uint64 // hw_counters/lifespan
-	MmapErr            *uint64 // hw_counters/mmap_err
-	NoCompletionCmds   *uint64 // hw_counters/no_completion_cmds
-	RdmaReadBytes      *uint64 // hw_counters/rdma_read_bytes
-	RdmaReadRespBytes  *uint64 // hw_counters/rdma_read_resp_bytes
-	RdmaReadWrErr      *uint64 // hw_counters/rdma_read_wr_err
-	RdmaReadWrs        *uint64 // hw_counters/rdma_read_wrs
-	RdmaWriteBytes     *uint64 // hw_counters/rdma_write_bytes
-	RdmaWriteRecvBytes *uint64 // hw_counters/rdma_write_resp_bytes
-	RdmaWriteWrErr     *uint64 // hw_counters/rdma_write_wr_err
-	RdmaWriteWrs       *uint64 // hw_counters/rdma_write_wrs
-	RecvBytes          *uint64 // hw_counters/recv_bytes
-	RecvWrs            *uint64 // hw_counters/recv_wrs
-	RegMrErr           *uint64 // hw_counters/reg_mr_err
-	RxBytes            *uint64 // hw_counters/rx_bytes
-	RxDrops            *uint64 // hw_counters/rx_drops
-	RxPkts             *uint64 // hw_counters/rx_pkts
-	SendBytes          *uint64 // hw_counters/send_bytes
-	SendWrs            *uint64 // hw_counters/send_wrs
-	SubmittedCmds      *uint64 // hw_counters/submitted_cmds
-	TxBytes            *uint64 // hw_counters/tx_bytes
-	TxPkts             *uint64 // hw_counters/tx_pkts
+    AllocPdErr               *uint64 // hw_counters/alloc_pd_err
+    AllocUcontextErr         *uint64 // hw_counters/alloc_ucontext_err
+    CmdsErr                  *uint64 // hw_counters/cmds_err
+    CompletedCmds            *uint64 // hw_counters/completed_cmds
+    CreateAhErr              *uint64 // hw_counters/create_ah_err
+    CreateCqErr              *uint64 // hw_counters/create_cq_err
+    CreateQpErr              *uint64 // hw_counters/create_qp_err
+    KeepAliveRcvd            *uint64 // hw_counters/keep_alive_rcvd
+    ImpairedRemoteConnEvents *uint64 // hw_counters/impaired_remote_conn_events
+    Lifespan                 *uint64 // hw_counters/lifespan
+    MmapErr                  *uint64 // hw_counters/mmap_err
+    NoCompletionCmds         *uint64 // hw_counters/no_completion_cmds
+    RdmaReadBytes            *uint64 // hw_counters/rdma_read_bytes
+    RdmaReadRespBytes        *uint64 // hw_counters/rdma_read_resp_bytes
+    RdmaReadWrErr            *uint64 // hw_counters/rdma_read_wr_err
+    RdmaReadWrs              *uint64 // hw_counters/rdma_read_wrs
+    RdmaWriteBytes           *uint64 // hw_counters/rdma_write_bytes
+    RdmaWriteRecvBytes       *uint64 // hw_counters/rdma_write_recv_bytes
+    RdmaWriteWrErr           *uint64 // hw_counters/rdma_write_wr_err
+    RdmaWriteWrs             *uint64 // hw_counters/rdma_write_wrs
+    RecvBytes                *uint64 // hw_counters/recv_bytes
+    RecvWrs                  *uint64 // hw_counters/recv_wrs
+    RegMrErr                 *uint64 // hw_counters/reg_mr_err
+    RetransBytes             *uint64 // hw_counters/retrans_bytes
+    RetransPkts              *uint64 // hw_counters/retrans_pkts
+    RetransTimeoutEvents     *uint64 // hw_counters/retrans_timeout_events
+    RxBytes                  *uint64 // hw_counters/rx_bytes
+    RxDrops                  *uint64 // hw_counters/rx_drops
+    RxPkts                   *uint64 // hw_counters/rx_pkts
+    SendBytes                *uint64 // hw_counters/send_bytes
+    SendWrs                  *uint64 // hw_counters/send_wrs
+    SubmittedCmds            *uint64 // hw_counters/submitted_cmds
+    TxBytes                  *uint64 // hw_counters/tx_bytes
+    TxPkts                   *uint64 // hw_counters/tx_pkts
+    UnresponsiveRemoteEvents *uint64 // hw_counters/unresponsive_remote_events
 }
 
 // AmazonEfaPort contains info from files in
@@ -252,7 +257,8 @@ func parseAmazonEfaCounters(portPath string) (*AmazonEfaCounters, error) {
 		//vp := util.NewValueParser(value)
 
 		switch f.Name() {
-
+			case "impaired_remote_conn_events":
+				counters.ImpairedRemoteConnEvents, err = parseUInt64(value)
 			case "lifespan":
 				counters.Lifespan, err = parseUInt64(value)
 			case "rdma_read_bytes":
@@ -275,6 +281,12 @@ func parseAmazonEfaCounters(portPath string) (*AmazonEfaCounters, error) {
 				counters.RecvBytes, err = parseUInt64(value)
 			case "recv_wrs":
 				counters.RecvWrs, err = parseUInt64(value)
+			case "retrans_bytes":
+				counters.RetransBytes, err = parseUInt64(value)
+			case "retrans_pkts":
+				counters.RetransPkts, err = parseUInt64(value)
+			case "retrans_timeout_events":
+				counters.RetransTimeoutEvents, err = parseUInt64(value)
 			case "rx_bytes":
 				counters.RxBytes, err = parseUInt64(value)
 			case "rx_drops":
@@ -289,6 +301,8 @@ func parseAmazonEfaCounters(portPath string) (*AmazonEfaCounters, error) {
 				counters.TxBytes, err = parseUInt64(value)
 			case "tx_pkts":
 				counters.TxPkts, err = parseUInt64(value)
+			case "unresponsive_remote_events":
+				counters.UnresponsiveRemoteEvents, err = parseUInt64(value)
 
 			if err != nil {
 				// Ugly workaround for handling https://github.com/prometheus/node_exporter/issues/966


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. fix the typos for RDMA Write coutner
2. Add latest 5 new counters: retrans_bytes, retrans_pkts, retrans_timeout_events, impaired_remote_conn_events, unresponsive_remote_events

Below is the result of testing with NCCL tests and deleting the security group in a middle of the run
<img width="718" height="120" alt="image" src="https://github.com/user-attachments/assets/74a279a9-234d-4d06-b093-e8c0c29a17df" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
