### PR TITLE
Fix version parsing logic of ofi nccl plugin

### DIFF
--- a/4.validation_and_observability/efa-versions.py
+++ b/4.validation_and_observability/efa-versions.py
@@ -41,12 +41,12 @@ def get_nccl_version(container=[]):
 
 def get_aws_ofi_nccl_version(container=[]):
     try:
-        version = subprocess.check_output(container + ['strings', '/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-net.so'])
+        lib_path = subprocess.check_output(container + ['cat', '/etc/ld.so.conf.d/100_ofinccl.conf']).decode().strip()
+        version = subprocess.check_output(container + ['strings', f'{lib_path}/libnccl-net.so'])
         version = version.decode('utf-8')
         version = re.search(r'NET/OFI Initializing aws-ofi-nccl (\d+\.\d+\.\d+)', version).group(1)
         return version
     except Exception as e:
-        
         print(f'Error: {e}')
         return None
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Per `aws-ofi-nccl` [commit](https://github.com/aws/aws-ofi-nccl/commit/6eb0870a8565687b668fb668d70e7f268aa77ce5), the. `MULTIARCH_DIR` has been removed. Also, it is possible to simply cat `/etc/ld.so.conf.d/100_ofinccl.conf` to retrieve the "real" absolute path for `libnccl-net.so`

For example

```
% cat /etc/ld.so.conf.d/100_ofinccl.conf
/opt/amazon/ofi-nccl/lib
```


**Testing**

```
strings $(cat /etc/ld.so.conf.d/100_ofinccl.conf)/libnccl-net.so | grep "NET/OFI Initializing aws-ofi-nccl"

NET/OFI Initializing aws-ofi-nccl 1.17.1
```

```
Error: [Errno 2] No such file or directory: 'locate'
Error: [Errno 2] No such file or directory: 'fi_info'
Error: [Errno 2] No such file or directory: 'nvcc'
+--------------------------+-------------+
|  Package                 |  Version    |
+--------------------------+-------------+
|  EFA installer version:  |  1.44.0     |
+--------------------------+-------------+
|  NCCL Version            |  None       |
+--------------------------+-------------+
|  Libfabric Version       |  None       |
+--------------------------+-------------+
|  AWS OFI NCCL version:   |  1.17.1     |
+--------------------------+-------------+
|  Nvidia Driver           |  580.95.05  |
+--------------------------+-------------+
|  CUDA Version:           |  None       |
+--------------------------+-------------+
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
