### PR TITLE
Fix formatting and whitespace in EFA node exporter files

### DIFF
--- a/4.validation_and_observability/3.efa-node-exporter/Dockerfile
+++ b/4.validation_and_observability/3.efa-node-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG PROCFS_EXPORTER_VERSION=v0.19.2
 
 # Install ProcFS
 RUN git clone -b $PROCFS_EXPORTER_VERSION https://github.com/prometheus/procfs.git /workspace/procfs
-COPY class_amazon_efa.go  /workspace/procfs/sysfs/
+COPY class_amazon_efa.go /workspace/procfs/sysfs/
 RUN cd /workspace/procfs && make test
 
 # Install Node Exporter
@@ -13,8 +13,8 @@ RUN git clone -b $NODE_EXPORTER_VERSION https://github.com/prometheus/node_expor
 COPY amazon_efa_linux.go /workspace/node_exporter/collector/
 
 WORKDIR /workspace/node_exporter
-RUN  go mod edit --replace=github.com/prometheus/procfs=/workspace/procfs
-RUN  go mod tidy && CGO_ENABLED=0 go build -o /go/bin/node_exporter
+RUN go mod edit --replace=github.com/prometheus/procfs=/workspace/procfs
+RUN go mod tidy && CGO_ENABLED=0 go build -o /go/bin/node_exporter
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /go/bin/node_exporter /workspace/

--- a/4.validation_and_observability/3.efa-node-exporter/buildspec.yaml
+++ b/4.validation_and_observability/3.efa-node-exporter/buildspec.yaml
@@ -34,4 +34,3 @@ phases:
       - docker image tag ${REPO_URI}:${TAG} public.ecr.aws/hpc-cloud/${ECR_REPOSITORY_NAME}:latest
       - docker push public.ecr.aws/hpc-cloud/${ECR_REPOSITORY_NAME}:${TAG}
       - docker push public.ecr.aws/hpc-cloud/${ECR_REPOSITORY_NAME}:latest
-

--- a/4.validation_and_observability/3.efa-node-exporter/docker-compose.yml
+++ b/4.validation_and_observability/3.efa-node-exporter/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '2.1'
+version: "2.1"
 
 services:
-
   node_exporter_efa:
     build: .
     container_name: node_exporter_efa
@@ -10,9 +9,9 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
     restart: unless-stopped
     network_mode: host


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR fixes minor formatting and whitespace issues in the EFA node exporter configuration files to improve code consistency and readability:

**Files changed:**
- `4.validation_and_observability/3.efa-node-exporter/Dockerfile`: Removed extra spaces in COPY and RUN commands
- `4.validation_and_observability/3.efa-node-exporter/buildspec.yaml`: Removed trailing empty line
- `4.validation_and_observability/3.efa-node-exporter/docker-compose.yml`: 
  - Standardized quotes (single to double quotes)
  - Removed extra blank line in services section
  - Improved YAML formatting consistency

These are low-impact formatting improvements that don't change functionality but enhance code maintainability and follow consistent styling conventions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
