### PR TITLE
dynamically set Global Batch Size

### DIFF
--- a/3.test_cases/megatron/megatron-lm/slurm/gpt3/2.distributed-training.sbatch
+++ b/3.test_cases/megatron/megatron-lm/slurm/gpt3/2.distributed-training.sbatch
@@ -14,9 +14,18 @@ set -ex;
 ###### User Variables #####
 ###########################
 
-# Parallelism decomposition variables
-: "${TENSOR_PARALLEL:=4}"
-: "${PIPELINE_PARALLEL:=2}"
+# configure TP/PP/GBS based on node count
+if [ $NODES -le 4 ]; then
+    : "${TENSOR_PARALLEL:=4}"
+    : "${PIPELINE_PARALLEL:=2}"
+    : "${GLOBAL_BATCH_SIZE:=288}"
+elif [ $NODES -ge 8 ]; then
+    : "${TENSOR_PARALLEL:=8}"
+    : "${PIPELINE_PARALLEL:=4}"
+    TOTAL_GPUS=$((NODES * 8))
+    DATA_PARALLEL=$((TOTAL_GPUS / (TENSOR_PARALLEL * PIPELINE_PARALLEL)))
+    : "${GLOBAL_BATCH_SIZE:=$((DATA_PARALLEL * 576))}"
+fi
 
 # Model parameters, defaults to 39B model
 # Refer to page 8 of this paper on how to tune models parameters
@@ -24,14 +33,10 @@ set -ex;
 : "${NUM_LAYERS:=36}"
 : "${HIDDEN_SIZE:=4096}"
 : "${NUM_ATTENTION_HEADS:=32}"
-
 : "${SEQ_LENGTH:=2048}"
 : "${MAX_POSITION_EMBEDDINGS:=2048}"
 : "${MICRO_BATCH_SIZE:=1}"
 
-# set GBS dynamically
-NODES=${SLURM_JOB_NUM_NODES}
-: "${GLOBAL_BATCH_SIZE:=$((288 * NODES / 2))}"
 
 # default variables for Enroot
 : "${IMAGE:=$(pwd)/megatron-training.sqsh}"


### PR DESCRIPTION
removing the static GBS to dynamically set GBS to correspond to num of nodes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
