### PR TITLE
feat(nodeadm): enable CDI by default in containerd config

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
@@ -69,7 +69,7 @@ discard_unpacked_layers = true
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "localhost/kubernetes/pause"
-enable_cdi = false
+enable_cdi = true
 
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"


### PR DESCRIPTION
*Problem Summary*

Customer's cluster on HyperPod EKS has a critical issue where NVIDIA's DRA driver isn't properly mounting IMEX channels into application pods, preventing distributed GPU workloads from running. The root problem has been identified as the IMEX daemon containers being unable to detect ClusterUUID and CliqueId values, even though these values exist on the host nodes. 

*Description of changes:*
When we enable EBS volume during the cluster creation, public LCS override the containerd config and set CDI to false. This was expected behaviour until AL23 launch and was hardcoded in public LCS but Nodeadm updated their service to enable CDI for 1.32+ as covered in this PR: https://github.com/awslabs/amazon-eks-ami/pull/2173. This PR changes were not reflected in the public LCS, causing CDI was set to false by default.

The below changes has been properly tested on p6e-gb200, p5.48xlarge, g5 and t3 instances type with EKS1.31 and EKS.133 versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
