### PR TITLE
slurm: set containerd root to EBS

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
@@ -73,8 +73,7 @@ EOL
     if [[ ! -f /etc/containerd/config.toml ]]; then
         containerd config default | sudo tee /etc/containerd/config.toml >/dev/null
     fi
-    sudo sed -i \
-        -e 's|^#\\?root *=.*|root = "/opt/sagemaker/docker/containerd"|' \
+    sudo sed -i -e 's|^#\?root *=.*|root = "/opt/sagemaker/containerd/data-root"|' \
         /etc/containerd/config.toml
 elif [[ $(mount | grep /opt/dlami/nvme) ]]; then
     cat <<EOL >> /etc/docker/daemon.json


### PR DESCRIPTION
*Issue #, if available:*
#913 (related #127)

*Description of changes:*
- Change containerd root to EBS volume instead of root volume to prevent Docker build cache occupying root volume.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
