### PR TITLE
Add optional SageMaker Training Plan support for HyperPod compute instance groups

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/main.tf
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/main.tf
@@ -4,14 +4,14 @@ data "aws_s3_bucket" "existing_s3_bucket" {
 }
 
 locals {
-  vpc_id = var.create_vpc_module ? module.vpc[0].vpc_id : var.existing_vpc_id
-  private_subnet_id = var.create_private_subnet_module ? module.private_subnet[0].private_subnet_id : var.existing_private_subnet_id
-  security_group_id = var.create_security_group_module ? module.security_group[0].security_group_id : var.existing_security_group_id
-  s3_bucket_name = var.create_s3_bucket_module ? module.s3_bucket[0].s3_bucket_name : var.existing_s3_bucket_name
+  vpc_id                  = var.create_vpc_module ? module.vpc[0].vpc_id : var.existing_vpc_id
+  private_subnet_id       = var.create_private_subnet_module ? module.private_subnet[0].private_subnet_id : var.existing_private_subnet_id
+  security_group_id       = var.create_security_group_module ? module.security_group[0].security_group_id : var.existing_security_group_id
+  s3_bucket_name          = var.create_s3_bucket_module ? module.s3_bucket[0].s3_bucket_name : var.existing_s3_bucket_name
   sagemaker_iam_role_name = var.create_sagemaker_iam_role_module ? module.sagemaker_iam_role[0].sagemaker_iam_role_name : var.existing_sagemaker_iam_role_name
-  fsx_lustre_dns_name = var.create_fsx_lustre_module ? module.fsx_lustre[0].fsx_lustre_dns_name : var.existing_fsx_lustre_dns_name
-  fsx_lustre_mount_name = var.create_fsx_lustre_module ? module.fsx_lustre[0].fsx_lustre_mount_name : var.existing_fsx_lustre_mount_name
-  fsx_openzfs_dns_name = var.create_fsx_openzfs_module ? module.fsx_openzfs[0].fsx_openzfs_dns_name : var.existing_fsx_openzfs_dns_name
+  fsx_lustre_dns_name     = var.create_fsx_lustre_module ? module.fsx_lustre[0].fsx_lustre_dns_name : var.existing_fsx_lustre_dns_name
+  fsx_lustre_mount_name   = var.create_fsx_lustre_module ? module.fsx_lustre[0].fsx_lustre_mount_name : var.existing_fsx_lustre_mount_name
+  fsx_openzfs_dns_name    = var.create_fsx_openzfs_module ? module.fsx_openzfs[0].fsx_openzfs_dns_name : var.existing_fsx_openzfs_dns_name
   # For Multi-AZ, use provided subnet IDs; for Single-AZ, use single private subnet
   fsx_openzfs_subnet_ids = var.fsx_openzfs_deployment_type == "MULTI_AZ_1" ? var.fsx_openzfs_subnet_ids : []
 }
@@ -93,13 +93,13 @@ module "lifecycle_script" {
   count  = var.create_lifecycle_script_module ? 1 : 0
   source = "./modules/lifecycle_script"
 
-  resource_name_prefix     = var.resource_name_prefix
-  s3_bucket_name           = local.s3_bucket_name
-  fsx_lustre_dns_name      = local.fsx_lustre_dns_name
-  fsx_lustre_mount_name    = local.fsx_lustre_mount_name
-  fsx_openzfs_dns_name     = local.fsx_openzfs_dns_name
-  lifecycle_scripts_path   = var.lifecycle_scripts_path
-  instance_groups          = var.instance_groups
+  resource_name_prefix   = var.resource_name_prefix
+  s3_bucket_name         = local.s3_bucket_name
+  fsx_lustre_dns_name    = local.fsx_lustre_dns_name
+  fsx_lustre_mount_name  = local.fsx_lustre_mount_name
+  fsx_openzfs_dns_name   = local.fsx_openzfs_dns_name
+  lifecycle_scripts_path = var.lifecycle_scripts_path
+  instance_groups        = var.instance_groups
 }
 
 module "sagemaker_iam_role" {
@@ -126,12 +126,18 @@ module "hyperpod_cluster" {
     module.sagemaker_iam_role
   ]
 
-  resource_name_prefix    = var.resource_name_prefix
-  hyperpod_cluster_name   = var.hyperpod_cluster_name
-  node_recovery           = var.node_recovery
-  instance_groups         = var.instance_groups
-  private_subnet_id       = local.private_subnet_id
-  security_group_id       = local.security_group_id
-  s3_bucket_name          = local.s3_bucket_name
-  sagemaker_iam_role_name = local.sagemaker_iam_role_name
+  resource_name_prefix                  = var.resource_name_prefix
+  hyperpod_cluster_name                 = var.hyperpod_cluster_name
+  node_recovery                         = var.node_recovery
+  instance_groups                       = var.instance_groups
+  private_subnet_id                     = local.private_subnet_id
+  security_group_id                     = local.security_group_id
+  s3_bucket_name                        = local.s3_bucket_name
+  sagemaker_iam_role_name               = local.sagemaker_iam_role_name
+  use_training_plan                     = var.use_training_plan
+  training_plan_arn                     = var.training_plan_arn
+  training_plan_instance_group_name     = var.training_plan_instance_group_name
+  training_plan_expected_instance_type  = var.training_plan_expected_instance_type
+  training_plan_expected_instance_count = var.training_plan_expected_instance_count
+
 }

--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/hyperpod_cluster/main.tf
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/hyperpod_cluster/main.tf
@@ -8,45 +8,65 @@ resource "time_sleep" "wait_for_iam_role" {
 }
 
 locals {
-  # Create configurations for each instance group
-  instance_groups_list = [
-    for name, config in var.instance_groups : {
-      instance_group_name = name
-      instance_type       = config.instance_type
-      instance_count      = config.instance_count
-      threads_per_core    = config.threads_per_core
-      execution_role      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${var.sagemaker_iam_role_name}"
-      
-      instance_storage_configs = [
-        {
-          ebs_volume_config = {
-            volume_size_in_gb = config.ebs_volume_size
-          }
-        }
-      ]
+  # Training plan target group (by name/key in var.instance_groups)
+  training_group_name   = var.training_plan_instance_group_name
+  training_group_config = try(var.instance_groups[local.training_group_name], null)
 
-      life_cycle_config = {
-        on_create     = config.lifecycle_script
-        source_s3_uri = "s3://${var.s3_bucket_name}/LifecycleScripts/base-config/"
-      }
-    }
+  training_group_instance_type  = try(local.training_group_config.instance_type, null)
+  training_group_instance_count = try(local.training_group_config.instance_count, null)
+
+  # Create configurations for each instance group
+  # - instance group "name" comes from the map key of var.instance_groups
+  # - training_plan_arn is attached ONLY when:
+  #     use_training_plan = true
+  #     training_plan_arn is provided (not null)
+  #     group name matches var.training_plan_instance_group_name (default: "compute")
+  instance_groups_list = [
+    for name, config in var.instance_groups :
+    merge(
+      {
+        instance_group_name = name
+        instance_type       = config.instance_type
+        instance_count      = config.instance_count
+        threads_per_core    = config.threads_per_core
+        execution_role      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${var.sagemaker_iam_role_name}"
+
+        instance_storage_configs = [
+          {
+            ebs_volume_config = {
+              volume_size_in_gb = config.ebs_volume_size
+            }
+          }
+        ]
+
+        life_cycle_config = {
+          on_create     = config.lifecycle_script
+          source_s3_uri = "s3://${var.s3_bucket_name}/LifecycleScripts/base-config/"
+        }
+      },
+
+      # Attach Training Plan ONLY to the configured instance group name
+      (var.use_training_plan &&
+        var.training_plan_arn != null &&
+        name == var.training_plan_instance_group_name) ? {
+        training_plan_arn = var.training_plan_arn
+      } : {}
+    )
   ]
 }
 
 resource "awscc_sagemaker_cluster" "hyperpod_cluster" {
   depends_on = [time_sleep.wait_for_iam_role]
-  
+
   cluster_name = var.hyperpod_cluster_name
-  
+
   instance_groups = local.instance_groups_list
 
   node_recovery = var.node_recovery
 
-
-
   vpc_config = {
     security_group_ids = [var.security_group_id]
-    subnets           = [var.private_subnet_id]
+    subnets            = [var.private_subnet_id]
   }
 
   tags = [
@@ -55,4 +75,21 @@ resource "awscc_sagemaker_cluster" "hyperpod_cluster" {
       value = "${var.resource_name_prefix}-hyperpod-cluster"
     }
   ]
+
+  lifecycle {
+    precondition {
+      condition = (
+        !var.use_training_plan
+        ||
+        (
+          var.training_plan_arn != null
+          && local.training_group_config != null
+          && (var.training_plan_expected_instance_type == null || var.training_plan_expected_instance_type == local.training_group_instance_type)
+          && (var.training_plan_expected_instance_count == null || var.training_plan_expected_instance_count == local.training_group_instance_count)
+        )
+      )
+
+      error_message = "Training Plan is enabled, but validation failed. Ensure: (1) training_plan_arn is set, (2) instance group '${var.training_plan_instance_group_name}' exists in var.instance_groups, and (3) its instance_type/instance_count match the Training Plan requirements (if expected values are provided)."
+    }
+  }
 }

--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/hyperpod_cluster/variables.tf
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/hyperpod_cluster/variables.tf
@@ -43,3 +43,34 @@ variable "sagemaker_iam_role_name" {
   description = "Name of the SageMaker IAM role"
   type        = string
 }
+
+variable "use_training_plan" {
+  description = "Whether to attach a SageMaker Training Plan to cluster instance groups."
+  type        = bool
+  default     = false
+}
+
+variable "training_plan_arn" {
+  description = "ARN of the SageMaker Training Plan to attach (when enabled)."
+  type        = string
+  default     = null
+}
+
+variable "training_plan_instance_group_name" {
+  description = "Instance group name that should receive the SageMaker Training Plan."
+  type        = string
+  default     = "compute"
+}
+
+variable "training_plan_expected_instance_type" {
+  description = "Expected instance type required by the Training Plan (optional validation)."
+  type        = string
+  default     = null
+}
+
+variable "training_plan_expected_instance_count" {
+  description = "Expected instance count required by the Training Plan (optional validation)."
+  type        = number
+  default     = null
+}
+

--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/lifecycle_script/main.tf
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/lifecycle_script/main.tf
@@ -2,10 +2,10 @@ locals {
   # Generate provisioning parameters JSON
   provisioning_parameters = merge(
     {
-      version           = "1.0.0"
-      workload_manager  = "slurm"
-      controller_group  = "controller-machine"
-      login_group       = "login-nodes"
+      version          = "1.0.0"
+      workload_manager = "slurm"
+      controller_group = "controller-machine"
+      login_group      = "login-nodes"
       worker_groups = [
         for name, config in var.instance_groups : {
           instance_group_name = name

--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/terraform.tfvars.example
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/terraform.tfvars.example
@@ -70,3 +70,15 @@ create_hyperpod_module = true
 
 # Lifecycle Scripts Configuration
 lifecycle_scripts_path = "../../LifecycleScripts/base-config"
+
+
+# Training Plan (optional)
+use_training_plan = false
+# training_plan_arn = "arn:aws:sagemaker:us-west-2:123456789012:training-plan/your-plan-name"
+
+# If your compute group key in instance_groups is not "compute"
+# training_plan_instance_group_name = "workers"
+
+# Optional validation (recommended)
+# training_plan_expected_instance_type  = "ml.p4d.24xlarge"
+# training_plan_expected_instance_count = 8

--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/variables.tf
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/variables.tf
@@ -303,3 +303,34 @@ variable "instance_groups" {
     }
   }
 }
+
+variable "use_training_plan" {
+  description = "Whether to attach a SageMaker Training Plan to a specific instance group."
+  type        = bool
+  default     = false
+}
+
+variable "training_plan_arn" {
+  description = "ARN of the SageMaker Training Plan to attach (when enabled)."
+  type        = string
+  default     = null
+}
+
+variable "training_plan_instance_group_name" {
+  description = "Instance group name that should receive the training plan (default matches repo examples: compute)."
+  type        = string
+  default     = "compute"
+}
+
+variable "training_plan_expected_instance_type" {
+  description = "Expected instance type required by the Training Plan (optional validation)."
+  type        = string
+  default     = null
+}
+
+variable "training_plan_expected_instance_count" {
+  description = "Expected instance count required by the Training Plan (optional validation)."
+  type        = number
+  default     = null
+}
+


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p data-start="406" data-end="585">This PR adds <strong data-start="419" data-end="479">optional support for attaching a SageMaker Training Plan</strong> to a specific HyperPod instance group (e.g. compute/workers) in the <code data-start="548" data-end="567">hyperpod-slurm-tf</code> Terraform module.</p>
<p data-start="587" data-end="727">The change enables users to run HyperPod clusters under a Training Plan while preserving full backward compatibility for existing workflows.</p>
<hr data-start="729" data-end="732">
<h2 data-start="734" data-end="751"><strong data-start="737" data-end="751">What’s new</strong></h2>
<ul data-start="753" data-end="1242">
<li data-start="753" data-end="903">
<p data-start="755" data-end="815">Introduces optional variables to enable Training Plan usage:</p>
<ul data-start="818" data-end="903">
<li data-start="818" data-end="839">
<p data-start="820" data-end="839"><code data-start="820" data-end="839">use_training_plan</code></p>
</li>
<li data-start="842" data-end="863">
<p data-start="844" data-end="863"><code data-start="844" data-end="863">training_plan_arn</code></p>
</li>
<li data-start="866" data-end="903">
<p data-start="868" data-end="903"><code data-start="868" data-end="903">training_plan_instance_group_name</code></p>
</li>
</ul>
</li>
<li data-start="904" data-end="997">
<p data-start="906" data-end="997">Attaches <code data-start="915" data-end="934">training_plan_arn</code> <strong data-start="935" data-end="976">only to the configured instance group</strong> (default: <code data-start="987" data-end="996">compute</code>)</p>
</li>
<li data-start="998" data-end="1070">
<p data-start="1000" data-end="1070">Supports custom instance group names (e.g. <code data-start="1043" data-end="1052">workers</code>, <code data-start="1054" data-end="1069">compute-nodes</code>)</p>
</li>
<li data-start="1071" data-end="1242">
<p data-start="1073" data-end="1109">Adds optional safety validation for:</p>
<ul data-start="1112" data-end="1242">
<li data-start="1112" data-end="1127">
<p data-start="1114" data-end="1127">instance type</p>
</li>
<li data-start="1130" data-end="1155">
<p data-start="1132" data-end="1155">instance count<br data-start="1146" data-end="1149">
via:</p>
</li>
<li data-start="1158" data-end="1198">
<p data-start="1160" data-end="1198"><code data-start="1160" data-end="1198">training_plan_expected_instance_type</code></p>
</li>
<li data-start="1201" data-end="1242">
<p data-start="1203" data-end="1242"><code data-start="1203" data-end="1242">training_plan_expected_instance_count</code></p>
</li>
</ul>
</li>
</ul>
<hr data-start="1244" data-end="1247">
<h2 data-start="1249" data-end="1264"><strong data-start="1252" data-end="1264">Behavior</strong></h2>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
Scenario | Result
-- | --
use_training_plan = false | No change from current behavior
use_training_plan = true + valid config | Training Plan attached to target group
ARN missing | Terraform fails fast with clear error
Group name not found | Terraform fails fast with clear error
Instance type/count mismatch (when provided) | Terraform fails fast with clear error

</div></div>
<p data-start="1677" data-end="1768">Validation is implemented using Terraform <code data-start="1719" data-end="1733">precondition</code> to avoid runtime cluster failures.</p>
<hr data-start="1770" data-end="1773">
<h2 data-start="1775" data-end="1804"><strong data-start="1778" data-end="1804">Backward compatibility</strong></h2>
<ul data-start="1806" data-end="2003">
<li data-start="1806" data-end="1865">
<p data-start="1808" data-end="1865">The feature is <strong data-start="1823" data-end="1865">fully optional and disabled by default</strong></p>
</li>
<li data-start="1866" data-end="1929">
<p data-start="1868" data-end="1929">Existing configurations continue to work without modification</p>
</li>
<li data-start="1930" data-end="2003">
<p data-start="1932" data-end="2003">No behavior changes unless <code data-start="1959" data-end="1985">use_training_plan = true</code> is explicitly set</p>
</li>
</ul>
<hr data-start="2005" data-end="2008">
<h2 data-start="2010" data-end="2039"><strong data-start="2013" data-end="2039">Implementation details</strong></h2>
<ul data-start="2041" data-end="2337">
<li data-start="2041" data-end="2119">
<p data-start="2043" data-end="2119">Training Plan is injected using a conditional <code data-start="2089" data-end="2098">merge()</code> in <code data-start="2102" data-end="2119">instance_groups</code></p>
</li>
<li data-start="2120" data-end="2193">
<p data-start="2122" data-end="2193">Target group is resolved dynamically from <code data-start="2164" data-end="2185">var.instance_groups</code> map key</p>
</li>
<li data-start="2194" data-end="2267">
<p data-start="2196" data-end="2267">Validation is implemented using Terraform 1.2+ <code data-start="2243" data-end="2267">lifecycle.precondition</code></p>
</li>
<li data-start="2268" data-end="2337">
<p data-start="2270" data-end="2337">Default target group name is <code data-start="2299" data-end="2308">compute</code> (matching existing examples)</p>
</li>
</ul>
<hr data-start="2339" data-end="2342">
<h2 data-start="2344" data-end="2364"><strong data-start="2347" data-end="2364">Example usage</strong></h2>
<pre class="overflow-visible! px-0!" data-start="2366" data-end="2640"><div class="contain-inline-size rounded-2xl corner-superellipse/1.1 relative bg-token-sidebar-surface-primary"><div class="sticky top-[calc(--spacing(9)+var(--header-height))] @w-xl/main:top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-hcl"><span>use_training_plan = true
training_plan_arn = "arn:aws:sagemaker:us-west-2:123456789012:training-plan/my-plan"
training_plan_instance_group_name = "compute-nodes"

training_plan_expected_instance_type  = "ml.trn1.32xlarge"
training_plan_expected_instance_count = 4
</span></code></div></div></pre>
<hr data-start="2642" data-end="2645">
<h2 data-start="2647" data-end="2661"><strong data-start="2650" data-end="2661">Testing</strong></h2>
<ul data-start="2663" data-end="2858">
<li data-start="2663" data-end="2685">
<p data-start="2665" data-end="2685"><code data-start="2665" data-end="2685">terraform validate</code></p>
</li>
<li data-start="2686" data-end="2704">
<p data-start="2688" data-end="2704"><code data-start="2688" data-end="2704">terraform plan</code></p>
</li>
<li data-start="2705" data-end="2858">
<p data-start="2707" data-end="2716">Verified:</p>
<ul data-start="2719" data-end="2858">
<li data-start="2719" data-end="2764">
<p data-start="2721" data-end="2764">Training Plan attached only to target group</p>
</li>
<li data-start="2767" data-end="2810">
<p data-start="2769" data-end="2810">Validation triggers correctly on mismatch</p>
</li>
<li data-start="2813" data-end="2858">
<p data-start="2815" data-end="2858">No behavior change when feature is disabled</p>
</li>
</ul>
</li>
</ul>
<hr data-start="2860" data-end="2863">
<h2 data-start="2865" data-end="2888"><strong data-start="2868" data-end="2888">Why this matters</strong></h2>
<p data-start="2890" data-end="2941">SageMaker Training Plans are increasingly used for:</p>
<ul data-start="2942" data-end="3005">
<li data-start="2942" data-end="2964">
<p data-start="2944" data-end="2964">capacity reservation</p>
</li>
<li data-start="2965" data-end="2984">
<p data-start="2967" data-end="2984">cost optimization</p>
</li>
<li data-start="2985" data-end="3005">
<p data-start="2987" data-end="3005">scheduling control</p>
</li>
</ul>
<p data-start="3007" data-end="3165">This change allows users to adopt Training Plans <strong data-start="3056" data-end="3086">without forking the module</strong> and keeps the official AWS sample aligned with current SageMaker capabilities.</p><!--EndFragment-->
</body>
</html>