### PR TITLE
nccl-tests.yaml LD_LIBRARY_PATH for libnccl-net.so

### DIFF
--- a/micro-benchmarks/nccl-tests/kubernetes/nccl-tests.yaml
+++ b/micro-benchmarks/nccl-tests/kubernetes/nccl-tests.yaml
@@ -21,7 +21,7 @@ spec:
              - name: PATH
                value: $PATH:/opt/amazon/efa/bin:/usr/bin
              - name: LD_LIBRARY_PATH
-               value: /opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/nvidia/lib:$LD_LIBRARY_PATH
+               value: /opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu:/usr/local/nvidia/lib:$LD_LIBRARY_PATH
             command:
             - /opt/amazon/openmpi/bin/mpirun
             - --allow-run-as-root


### PR DESCRIPTION
This issue was introduced by me, when I removed AWS-OFI-NCCL plugin https://github.com/aws-samples/awsome-distributed-training/pull/861

```bash
find / -name "libnccl-net.so"
/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-net.so
```

For ARM(GB200) this path is probably different, should be addressed later