### PR TITLE
Check if on_create_main.sh exist and skip if doesn't

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh
@@ -12,12 +12,16 @@ logger() {
 
 logger "[start] on_create.sh"
 
-if ! bash ./on_create_main.sh >> "$LOG_FILE" 2>&1; then
-  logger "[error] on_create_main.sh failed, waiting 60 seconds before exit, to make sure logs are uploaded"
-  sync
-  sleep 60
-  logger "[stop] on_create.sh with error"
-  exit 1
+if [ -f "./on_create_main.sh" ]; then
+  if ! bash ./on_create_main.sh >> "$LOG_FILE" 2>&1; then
+    logger "[error] on_create_main.sh failed, waiting 60 seconds before exit, to make sure logs are uploaded"
+    sync
+    sleep 60
+    logger "[stop] on_create.sh with error"
+    exit 1
+  fi
+else
+  logger "[warning] on_create_main.sh not found, skipping execution"
 fi
 
 logger "[stop] on_create.sh"


### PR DESCRIPTION
*Description of changes:*

Changing the lifecycle script for HyperPod EKS to check the existence of on_create_main.sh, and skip if it doesn't. This is a compatibility fix for old workshops where only on_create.sh is copied to S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
