### PR TITLE
Remove nvidia-container-toolkit version pinning in install_docker.sh

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
-
 set -exo pipefail
 
-# If docker is alrady installed, skip installing again
+# If docker is already installed, skip installing again
 if command -v docker &> /dev/null; then
     echo "Docker is already installed and in the PATH."
     exit 0
 fi
 
-echo "
-###################################
-# BEGIN: install docker
-###################################
-"
+echo "####################################"
+echo " BEGIN: install docker"
+echo "####################################"
 
 apt-get -y -o DPkg::Lock::Timeout=120 update
 apt-get -y -o DPkg::Lock::Timeout=120 install \
@@ -20,59 +17,54 @@ apt-get -y -o DPkg::Lock::Timeout=120 install \
     curl \
     gnupg \
     lsb-release
+
 mkdir -m 0755 -p /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
 echo \
-"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-$(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 apt-get -y -o DPkg::Lock::Timeout=120 update
 apt-get -y -o DPkg::Lock::Timeout=120 install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
 groupadd -f docker
 chgrp docker $(which docker)
 chmod g+s $(which docker)
+
 systemctl enable docker.service
 systemctl start docker.service
 
-# install nvidia docker toolkit, pinning to version 1.17.6-1 due to known issue https://github.com/NVIDIA/nvidia-container-toolkit/issues/1093
-export NVIDIA_CONTAINER_TLK_VERSION="1.17.6-1"
+# install nvidia docker toolkit
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
     sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-sudo apt update
-sudo apt-get install -y --allow-downgrades -o DPkg::Lock::Timeout=120 nvidia-container-toolkit=${NVIDIA_CONTAINER_TLK_VERSION} nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TLK_VERSION} libnvidia-container-tools=${NVIDIA_CONTAINER_TLK_VERSION} libnvidia-container1=${NVIDIA_CONTAINER_TLK_VERSION}
-# Lock nvidia-container-toolkit version
-sudo apt-mark hold nvidia-container-toolkit nvidia-container-toolkit-base libnvidia-container-tools libnvidia-container1
 
-# Print NV_COTNAINER_TLK_VERSIONS to logs 
-echo "Expected NV_TLK_VERSION: ${NVIDIA_CONTAINER_TLK_VERSION}"
+sudo apt-get -y -o DPkg::Lock::Timeout=120 update
+sudo apt-get -y -o DPkg::Lock::Timeout=120 install nvidia-container-toolkit
+
+# Print installed version
 echo "Installed NV_TLK_VERSION: $(dpkg -l nvidia-container-toolkit | awk '/nvidia-container-toolkit/ {print $3}')"
 
 # add user to docker group
 sudo usermod -aG docker ubuntu
 
-
-# Opportunistically use /opt/sagemaker or /opt/dlami/nvme if present. Let's be extra careful in the probe.
+# Opportunistically use /opt/sagemaker or /opt/dlami/nvme if present.
 # See: https://github.com/aws-samples/awsome-distributed-training/issues/127
 #
 # Docker workdir doesn't like Lustre. Tried with storage driver overlay2, fuse-overlayfs, & vfs.
 if [[ $(mount | grep /opt/sagemaker) ]]; then
     cat <<EOL >> /etc/docker/daemon.json
-{
-    "data-root": "/opt/sagemaker/docker/data-root"
-}
+{"data-root": "/opt/sagemaker/docker/data-root"}
 EOL
-
     sed -i \
         's|^\[Service\]$|[Service]\nEnvironment="DOCKER_TMPDIR=/opt/sagemaker/docker/tmp"|' \
         /usr/lib/systemd/system/docker.service
 elif [[ $(mount | grep /opt/dlami/nvme) ]]; then
     cat <<EOL >> /etc/docker/daemon.json
-{
-    "data-root": "/opt/dlami/nvme/docker/data-root"
-}
+{"data-root": "/opt/dlami/nvme/docker/data-root"}
 EOL
-
     sed -i \
         's|^\[Service\]$|[Service]\nEnvironment="DOCKER_TMPDIR=/opt/dlami/nvme/docker/tmp"|' \
         /usr/lib/systemd/system/docker.service


### PR DESCRIPTION
Removes the version pinning for nvidia-container-toolkit (previously locked to 1.17.6-1) to allow installation of the latest version. This resolves the compatibility issue when installing DCGM exporter.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
