### PR TITLE
Fixing DCGM exporter container failure

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
@@ -33,8 +33,18 @@ chmod g+s $(which docker)
 systemctl enable docker.service
 systemctl start docker.service
 
-# install nvidia docker toolkit, pinning to version 1.17.6-1 due to known issue https://github.com/NVIDIA/nvidia-container-toolkit/issues/1093
-export NVIDIA_CONTAINER_TLK_VERSION="1.17.6-1"
+# Detect pre-installed nvidia-container-toolkit-base version or use default
+if dpkg -s nvidia-container-toolkit-base &> /dev/null; then
+    DETECTED_VERSION=$(dpkg -l nvidia-container-toolkit-base | awk '/^ii/ {print $3}')
+    echo "Detected pre-installed nvidia-container-toolkit-base version: ${DETECTED_VERSION}"
+    export NVIDIA_CONTAINER_TLK_VERSION="${DETECTED_VERSION}"
+else
+    # Fallback to pinned version if not pre-installed (due to known issue https://github.com/NVIDIA/nvidia-container-toolkit/issues/1093)
+    export NVIDIA_CONTAINER_TLK_VERSION="1.18.1-1"
+    echo "No pre-installed nvidia-container-toolkit-base found, using default version: ${NVIDIA_CONTAINER_TLK_VERSION}"
+fi
+
+# Install nvidia container toolkit with all dependencies at consistent version
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \


### PR DESCRIPTION
*Description of changes:*

Fixing DCGM exporter container failure by detecting right version of nvidia-container-toolkit from pre-installed nvidia-container-toolkit-base.

HyperPod Slurm AMI now pre-installs nvidia-container-toolkit-base 1.18.1-1, but the lifecycle script was downgrading it to 1.17.6-1, that caused DCGM exporter container execution error. With this Pull Request we are automatically detecting the version of nvidia-container-toolkit to install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
