### PR TITLE
Terraform Updates for HyperPod Inference Operator v2 Official EKS addon

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/README.md
@@ -500,6 +500,14 @@ Set the following parameters to `true` in your `custom.tfvars` file to enable op
 | `create_hyperpod_inference_operator_module`  | Installs the [HyperPod inference operator addon](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-model-deployment-setup.html) for deployment and management of machine learning inference endpoints |
 | `create_observability_module` | Installs the [HyperPod Observability addon](https://docs.aws.amazon.com/sagemaker/latest/dg/hyperpod-observability-addon-setup.html) to publish key metrics to Amazon Managed Service for Prometheus and displays them in Amazon Managed Grafana dashboards | 
 
+The HyperPod training and inference operators both require the [cert-manager](https://cert-manager.io/) EKS addon to be installed as a prerequisite. The variable `enable_cert_manager` is set to `true` by default, so that when `create_hyperpod_training_operator_module` or `create_hyperpod_inference_operator_module` are also set to `true`, cert-manager will be installed as a dependency of the operators. In other words, this stack will not install cert-manager as a standalone component, but it can be disabled if you already have it installed on an existing EKS cluster and wish to use one of the HyperPod operators. 
+
+The HyperPod inference operator also has the following additional dependencies: 
+  - The [Amazon FSx for Lustre CSI driver](https://github.com/kubernetes-sigs/aws-fsx-csi-driver): This EKS addon is installed by default as part of the FSx for Lustre module. Set `create_fsx_module = false` if you already have it installed on an existing EKS cluster. 
+  - The [Mountpoint for Amazon S3 CSI Driver](https://github.com/awslabs/mountpoint-s3-csi-driver): This EKS addon is bundled with the Hyperpod inference operator module and is enabled by default. Set `enable_s3_csi_driver = false` if you already have it installed on an existing EKS cluster.
+  - The [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller): This is bundled with the HyperPod inference operator EKS addon and is enabled by default. Set `enable_alb_controller = false` if you already have it installed on an existing EKS cluster.
+  - The [KEDA (Kubernetes Event-driven Autoscaling) Operator](https://keda.sh/): This is bundled with the HyperPod inference operator EKS addon and is enabled by default. Set `enable_keda = false` if you already have it installed on an existing EKS cluster.
+
 ---
 ### Advanced Observability Metrics Configuration
 In addition to enabling the [HyperPod Observability addon](https://docs.aws.amazon.com/sagemaker/latest/dg/hyperpod-observability-addon-setup.html) by setting `create_observability_module = true`, you can also configure the following metrics that you wish to collect on your cluster: 

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/custom.tfvars
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/custom.tfvars
@@ -2,13 +2,13 @@ kubernetes_version    = "1.33"
 eks_cluster_name      = "tf-eks-cluster"
 hyperpod_cluster_name = "tf-hp-cluster"
 resource_name_prefix  = "tf-eks-test"
-aws_region            = "us-east-2"
+aws_region            = "us-east-1"
 instance_groups = [
     {
         name                      = "accelerated-instance-group-1"
         instance_type             = "ml.g5.8xlarge",
         instance_count            = 2,
-        availability_zone_id      = "use2-az3",
+        availability_zone_id      = "use1-az2",
         ebs_volume_size_in_gb     = 100,
         threads_per_core          = 1,
         enable_stress_check       = false,

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/eks_cluster/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/eks_cluster/main.tf
@@ -1,9 +1,5 @@
 data "aws_region" "current" {}
 
-data "aws_vpc" "selected" {
-  id = var.vpc_id
-}
-
 data "aws_availability_zones" "available" {
   state = "available"
   filter {
@@ -19,7 +15,7 @@ locals {
 
 resource "aws_subnet" "private" {
   count             = var.create_eks_subnets ? length(var.private_subnet_cidrs) : 0
-  vpc_id            = data.aws_vpc.selected.id
+  vpc_id            = var.vpc_id
   cidr_block        = var.private_subnet_cidrs[count.index]
   availability_zone = data.aws_availability_zones.available.names[count.index]
 
@@ -32,7 +28,7 @@ resource "aws_subnet" "private" {
 
 resource "aws_route_table" "eks_private" {
   count  = var.create_eks_subnets ? length(var.private_subnet_cidrs) : 0
-  vpc_id = data.aws_vpc.selected.id
+  vpc_id = var.vpc_id
 
   tags = {
     Name = "${var.resource_name_prefix}-EKS-Private-RT-${count.index + 1}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the `hyperpod_inference_operator` to leverage the new `amazon-sagemaker-hyperpod-inference` EKS addon instead of the legacy Helm chart deployment. 

Deployment verification:
```

# HPIO EKS Addon
kubectl get all -n hyperpod-inference-system
NAME                                                        READY   STATUS    RESTARTS      AGE
pod/hyperpod-inference-alb-5f655d5f97-7rvzk                 1/1     Running   0             10m
pod/hyperpod-inference-alb-5f655d5f97-s5lvt                 1/1     Running   0             10m
pod/hyperpod-inference-controller-manager-6885bb776-j45mm   1/1     Running   0             10m
pod/keda-admission-webhooks-686f6f9c64-mxhcn                1/1     Running   0             10m
pod/keda-operator-5fc4b88dbb-rj9ts                          1/1     Running   1 (10m ago)   10m
pod/keda-operator-metrics-apiserver-694685d8bd-ksgj5        1/1     Running   0             10m

NAME                                                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
service/alb-webhook-service                                     ClusterIP   172.20.172.204   <none>        443/TCP            10m
service/hyperpod-inference-controller-manager-metrics-service   ClusterIP   172.20.125.203   <none>        8443/TCP           10m
service/hyperpod-inference-conversion-webhook                   ClusterIP   172.20.136.39    <none>        443/TCP            10m
service/keda-admission-webhooks                                 ClusterIP   172.20.30.94     <none>        443/TCP            10m
service/keda-operator                                           ClusterIP   172.20.98.231    <none>        9666/TCP           10m
service/keda-operator-metrics-apiserver                         ClusterIP   172.20.230.120   <none>        443/TCP,8080/TCP   10m

NAME                                                    READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/hyperpod-inference-alb                  2/2     2            2           10m
deployment.apps/hyperpod-inference-controller-manager   1/1     1            1           10m
deployment.apps/keda-admission-webhooks                 1/1     1            1           10m
deployment.apps/keda-operator                           1/1     1            1           10m
deployment.apps/keda-operator-metrics-apiserver         1/1     1            1           10m

NAME                                                              DESIRED   CURRENT   READY   AGE
replicaset.apps/hyperpod-inference-alb-5f655d5f97                 2         2         2       10m
replicaset.apps/hyperpod-inference-controller-manager-6885bb776   1         1         1       10m
replicaset.apps/keda-admission-webhooks-686f6f9c64                1         1         1       10m
replicaset.apps/keda-operator-5fc4b88dbb                          1         1         1       10m
replicaset.apps/keda-operator-metrics-apiserver-694685d8bd        1         1         1       10m

# FSxL CSI Driver
kubectl get all -l app=fsx-csi-controller -n kube-system
NAME                                      READY   STATUS    RESTARTS   AGE
pod/fsx-csi-controller-55bc879f94-cbkjn   4/4     Running   0          26m
pod/fsx-csi-controller-55bc879f94-nxdbp   4/4     Running   0          26m

NAME                                            DESIRED   CURRENT   READY   AGE
replicaset.apps/fsx-csi-controller-55bc879f94   2         2         2       26m

# S3 CSI Driver
kubectl get all -l app=s3-csi-node -n kube-system
NAME                    READY   STATUS    RESTARTS   AGE
pod/s3-csi-node-ccb6v   3/3     Running   0          28m
pod/s3-csi-node-qxl7k   3/3     Running   0          28m

# Metrics Server
kubectl get all -l app.kubernetes.io/name=metrics-server -n kube-system
NAME                                  READY   STATUS    RESTARTS   AGE
pod/metrics-server-6cdc4574fb-d7t59   1/1     Running   0          30m
pod/metrics-server-6cdc4574fb-djn97   1/1     Running   0          30m

NAME                     TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
service/metrics-server   ClusterIP   172.20.138.85   <none>        443/TCP   30m

NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/metrics-server   2/2     2            2           30m

NAME                                        DESIRED   CURRENT   READY   AGE
replicaset.apps/metrics-server-6cdc4574fb   2         2         2       30m

# Cert Manager
kubectl get all -n cert-manager
NAME                                           READY   STATUS    RESTARTS   AGE
pod/cert-manager-7657f9b596-nfssj              1/1     Running   0          32m
pod/cert-manager-cainjector-78d6749d66-6ztd8   1/1     Running   0          32m
pod/cert-manager-webhook-777dbb5b86-h5jd5      1/1     Running   0          32m

NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
service/cert-manager              ClusterIP   172.20.184.240   <none>        9402/TCP           32m
service/cert-manager-cainjector   ClusterIP   172.20.70.94     <none>        9402/TCP           32m
service/cert-manager-webhook      ClusterIP   172.20.66.73     <none>        443/TCP,9402/TCP   32m

NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/cert-manager              1/1     1            1           32m
deployment.apps/cert-manager-cainjector   1/1     1            1           32m
deployment.apps/cert-manager-webhook      1/1     1            1           32m

NAME                                                 DESIRED   CURRENT   READY   AGE
replicaset.apps/cert-manager-7657f9b596              1         1         1       32m
replicaset.apps/cert-manager-cainjector-78d6749d66   1         1         1       32m
replicaset.apps/cert-manager-webhook-777dbb5b86      1         1         1       32m

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
