### PR TITLE
Rolling back FSDP requirements to fix llama example

### DIFF
--- a/3.test_cases/pytorch/FSDP/src/requirements.txt
+++ b/3.test_cases/pytorch/FSDP/src/requirements.txt
@@ -1,6 +1,6 @@
---extra-index-url https://download.pytorch.org/whl/cu128
+--extra-index-url https://download.pytorch.org/whl/cu124
 datasets
-torch==2.7.1
-torchaudio==2.7.1
-torchvision==0.22.1
-transformers==4.53.0
+torch==2.5.1
+torchaudio==2.5.1
+torchvision==0.20.1
+transformers==4.50.3


### PR DESCRIPTION
Llama FSDP example is broken due to `hyperpod-elastic-agent` requirement of `torch` < 2.7.0 as described in issue #944 . Hence, rolling back to 2.5.1 (previous tested version) to satisfy this criteria. This change has been tested successfully. We will remain in this version until `hyperpod-elastic-agent` upgrade is available with support for `tprch` > 2.7.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
