### PR TITLE
Add observability support for HyperPod Slurm login nodes

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_observability.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_observability.py
@@ -79,7 +79,20 @@ def install_observability(node_type, prometheus_remote_write_url, advanced=False
         subprocess.run( ["bash", "./install_otel_collector.sh"], env=env_vars )
 
     elif node_type=="login":
-        pass
+
+        os.makedirs("/etc/otel", exist_ok=True)
+        create_file_from_template(
+            "./otel_config/config-login-template.yaml",
+            "/etc/otel/config.yaml",
+            {
+                "REGION": region,
+                "AMPREMOTEWRITEURL": prometheus_remote_write_url,
+                "HOSTNAME": hostname
+            }
+        )
+
+        subprocess.run( ["bash", "./install_node_exporter.sh"], env=env_vars )
+        subprocess.run( ["bash", "./install_otel_collector.sh"], env=env_vars )
 
 
 if __name__ == "__main__":

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/otel_config/config-login-template.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/otel_config/config-login-template.yaml
@@ -1,0 +1,38 @@
+## Login Node OTEL Config
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+        evaluation_interval: 15s
+      scrape_configs:
+        - job_name: 'node_exporter'
+          static_configs:
+            - targets: ['localhost:9100']
+          relabel_configs:
+            - target_label: instance
+              replacement: '{HOSTNAME}'
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+exporters:
+  prometheusremotewrite:
+    endpoint: {AMPREMOTEWRITEURL}
+    auth:
+      authenticator: sigv4auth
+
+extensions:
+  sigv4auth:
+    region: {REGION}
+    service: aps
+
+service:
+  extensions: [sigv4auth]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [prometheusremotewrite]

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/stop_observability.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/stop_observability.py
@@ -21,7 +21,9 @@ def stop_observability(node_type):
         subprocess.run( ["docker", "stop", "otel-collector"] )
 
     elif node_type=="login":
-        pass
+
+        subprocess.run( ["docker", "stop", "node-exporter"] )
+        subprocess.run( ["docker", "stop", "otel-collector"] )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Login nodes were not covered by the HyperPod Slurm observability setup -- the `install_observability.py` and `stop_observability.py` login branches were no-ops (`pass`), so no CPU/memory metrics were collected from login nodes when `enable_observability` was enabled.
- This PR adds a login-specific OTEL Collector config template (`config-login-template.yaml`) that scrapes `node_exporter` on `localhost:9100` and remote-writes to AMP, and wires up `install_observability.py` and `stop_observability.py` to install/stop the `node_exporter` and `otel-collector` containers on login nodes.
- No changes needed in `lifecycle_script.py` or `config.py` -- the existing code already passes `--node-type login` to `install_observability.py` for login nodes.

## Test plan

- [x] Deploy a HyperPod Slurm cluster with `enable_observability = True` and a login node group configured
- [x] Verify `node-exporter` and `otel-collector` Docker containers are running on the login node (`docker ps`)
- [x] Confirm `node_*` metrics (CPU, memory, disk, network) from the login node appear in AMP / Grafana
