### PR TITLE
Update NCCL to v2.27.7-1 and aws-ofi-nccl to v1.16.3 in cluster-vanilla.yaml

### DIFF
--- a/1.architectures/2.aws-parallelcluster/cluster-templates/cluster-vanilla.yaml
+++ b/1.architectures/2.aws-parallelcluster/cluster-templates/cluster-vanilla.yaml
@@ -28,8 +28,8 @@ HeadNode:
         - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/docker/postinstall.sh'
         - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/nccl/postinstall.sh'
           Args:
-            - v2.26.6-1 # NCCL version
-            - v1.14.2   # AWS OFI NCCL version
+            - v2.27.7-1 # NCCL version
+            - v1.16.3   # AWS OFI NCCL version
         - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/pyxis/postinstall.sh'
   Imds:
     Secured: false
@@ -74,8 +74,8 @@ Scheduling:
             - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/docker/postinstall.sh'
             - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/nccl/postinstall.sh'
               Args:
-                - v2.26.6-1 # NCCL version
-                - v1.14.2   # AWS OFI NCCL version
+                - v2.27.7-1 # NCCL version
+                - v1.16.3   # AWS OFI NCCL version
         OnNodeStart:
           Sequence:
             - Script: 'https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/main/pyxis/postinstall.sh'


### PR DESCRIPTION
## Summary
- Update NCCL version from v2.26.6-1 to v2.27.7-1
- Update AWS OFI NCCL version from v1.14.2 to v1.16.3
- Updates both HeadNode and ComputeNode post-install script arguments

## Test plan
- [ ] Verify ParallelCluster deployment with updated versions
- [ ] Run NCCL tests to confirm compatibility