### PR TITLE
Fix critical bugs and add ECC/pre-flight checks to gpu-healthcheck

### DIFF
--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/checks/5-nccl-allreduce.sh
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/checks/5-nccl-allreduce.sh
@@ -109,7 +109,7 @@ run_check() {
         if [[ -n "${nvlink_test_output}" ]]; then
             echo "${nvlink_test_output}" > "${RESULTS_DIR}/nccl-nvlink-only.txt"
             local nvlink_busbw
-            nvlink_busbw=$(echo "${nvlink_test_output}" | grep -E "^\s+[0-9]" | awk '{print $NF}' \
+            nvlink_busbw=$(echo "${nvlink_test_output}" | grep -E "^\s+[0-9]" | awk '{print $(NF-1)}' \
                 | sort -n | tail -1 || echo "0")
 
             if [[ "${nvlink_only_threshold}" -gt 0 ]]; then
@@ -154,7 +154,7 @@ run_check() {
             if [[ -n "${efa_test_output}" ]]; then
                 echo "${efa_test_output}" > "${RESULTS_DIR}/nccl-efa-only.txt"
                 local efa_busbw
-                efa_busbw=$(echo "${efa_test_output}" | grep -E "^\s+[0-9]" | awk '{print $NF}' \
+                efa_busbw=$(echo "${efa_test_output}" | grep -E "^\s+[0-9]" | awk '{print $(NF-1)}' \
                     | sort -n | tail -1 || echo "0")
 
                 if [[ "${min_expected}" -gt 0 ]]; then
@@ -229,10 +229,11 @@ run_check() {
             "EFA provider not confirmed in NCCL output -- performance may be degraded"
     fi
 
-    # Extract maximum bus bandwidth from results
-    # Format: size  count  type  redop  root  time  algbw  busbw  ...
+    # Extract maximum bus bandwidth from results.
+    # NCCL output format: ... algbw  busbw  #wrong  time  algbw  busbw  #wrong
+    # $(NF-1) gets the last busbw column (second-to-last field, before #wrong).
     local max_busbw
-    max_busbw=$(echo "${nccl_output}" | grep -E "^\s+[0-9]" | awk '{print $NF}' \
+    max_busbw=$(echo "${nccl_output}" | grep -E "^\s+[0-9]" | awk '{print $(NF-1)}' \
         | sort -n | tail -1 || echo "0")
 
     log_info "Maximum bus bandwidth: ${max_busbw} GB/s"

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/examples/cron-rolling-sweep.sh
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/examples/cron-rolling-sweep.sh
@@ -55,7 +55,7 @@ while IFS= read -r node; do
         --time=00:20:00 \
         --output="${SWEEP_RESULTS}/${node}-%j.out" \
         --error="${SWEEP_RESULTS}/${node}-%j.err" \
-        --export="HEALTHCHECK_DIR=${HEALTHCHECK_DIR},RESULTS_BASE=${SWEEP_RESULTS}" \
+        --export=ALL,HEALTHCHECK_DIR=${HEALTHCHECK_DIR},RESULTS_BASE=${SWEEP_RESULTS} \
         "${HEALTHCHECK_DIR}/slurm/sbatch-lightweight.sh" \
         2>&1 | grep -oE "[0-9]+" || true)
 

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/gpu-healthcheck.sh
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/gpu-healthcheck.sh
@@ -283,6 +283,12 @@ main() {
     detect_instance_type > /dev/null 2>&1 || true
     load_instance_profile || true
 
+    # Pre-flight: verify critical dependencies (python3) and log versions
+    if ! preflight_checks; then
+        log_error "Pre-flight checks failed -- cannot continue"
+        exit 1
+    fi
+
     log_info "GPU Health Check Suite"
     log_info "Host: $(hostname) | Instance: ${INSTANCE_TYPE:-unknown}"
     log_info "Results: ${RESULTS_DIR}"

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/slurm/sbatch-lightweight.sh
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/slurm/sbatch-lightweight.sh
@@ -54,6 +54,9 @@ echo "════════════════════════�
 # Run health checks on each node via srun
 export HEALTHCHECK_DIR SKIP_DCGM
 
+# Disable set -e around srun so that node failures don't prevent aggregation.
+# The exit code is captured explicitly and propagated at the end.
+set +e
 srun --ntasks-per-node=1 bash -c '
     set -euo pipefail
     HOSTNAME=$(hostname)
@@ -72,8 +75,8 @@ srun --ntasks-per-node=1 bash -c '
     echo "[${HOSTNAME}] Completed with exit code: ${EXIT_CODE}"
     exit ${EXIT_CODE}
 '
-
 SRUN_EXIT=$?
+set -e
 
 # Aggregate results
 echo ""


### PR DESCRIPTION
Bug fixes:
- Fix set -e + srun in sbatch scripts so aggregation reports are generated even when nodes fail (the tool is most needed when things fail)
- Fix --export in cron sweep to preserve PATH/LD_LIBRARY_PATH (was stripping entire environment, causing jobs to fail)
- Fix Xid code extraction regex to skip PCI bus parenthetical and correctly extract the error code number
- Fix NCCL bandwidth extraction to use $(NF-1) instead of $NF, which was reading the #wrong column instead of busbw
- Fix exit code arithmetic in sbatch-intensive.sh to use boolean instead of addition (which could produce reserved exit codes >125)

New features:
- Add pre-flight checks: verify python3 (hard dependency), log NVIDIA driver and DCGM versions for diagnostics
- Add GPU ECC and retired pages check (Step 6 in check 0): detects DBE (double-bit errors), pending page retirements, uncorrected volatile errors, and SBE retired pages approaching the NVIDIA 64-page limit

My testing:
All fixes verified against the current repo code on `health-check-revision`
| Fix | Tests | Result |
|-----|-------|--------|
| **Fix 1:** `set -e` + srun aggregation | 5 tests | All pass -- old pattern exits early, new pattern reaches aggregation, boolean exit code stays <=1 |
| **Fix 2:** `--export=ALL` in cron sweep | Code inspection | Confirmed `--export=ALL,...` in source (requires Slurm to run) |
| **Fix 3:** Xid regex | 10 tests | All pass -- new regex extracts correct Xid code; regression test proves old regex returned `0000` |
| **Fix 4:** NCCL bandwidth column | 6 tests | All pass -- `$(NF-1)` returns `205.62` (busbw); regression test proves old `$NF` returned `0` (#wrong) |
| **Fix 5:** Pre-flight checks | 3 tests | All pass -- python3 detected, missing python3 fails, nvidia-smi absence tolerated |
| **Fix 6:** ECC/retired pages | 14 tests | All pass -- DBE→ISOLATE, pending→REBOOT, volatile→RESET, SBE→MONITOR, N/A→skip, mixed→highest wins, severity ordering correct |

## Purpose

<!-- Link related issues using "Fixes #123" or "Relates to #123" -->

## Changes

<!-- Summarize the changes made in this PR -->

-

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:
- Instance type:
- Number of nodes:

**Test commands:**
```bash

```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/aws-samples/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
