### PR TITLE
Fix GrafanWorkspaceURL typo in CloudFormation templates and scripts

### DIFF
--- a/4.validation_and_observability/4.prometheus-grafana/1click-dashboards-deployment/cluster-observability.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/1click-dashboards-deployment/cluster-observability.yaml
@@ -67,7 +67,7 @@ Outputs:
     Value: !Join ["" , [ !GetAtt APSWorkspace.PrometheusEndpoint , "api/v1/remote_write" ]]
   AMPEndPointUrl:
     Value: !GetAtt APSWorkspace.PrometheusEndpoint
-  GrafanWorkspaceURL:
+  GrafanaWorkspaceURL:
     Value: !Join ["" , [ "https://", !GetAtt AmazonGrafanaWorkspace.Endpoint ]]
-  GrafanWorkspaceId:
+  GrafanaWorkspaceId:
     Value: !GetAtt AmazonGrafanaWorkspace.Id

--- a/4.validation_and_observability/4.prometheus-grafana/1click-dashboards-deployment/managed-cluster-observability-pc.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/1click-dashboards-deployment/managed-cluster-observability-pc.yaml
@@ -53,8 +53,8 @@ Resources:
         Variables:
           REGION: !Ref AWS::Region
           PROMETHEUS_URL: !GetAtt GrafanaPrometheus.Outputs.AMPEndPointUrl
-          GRAFANA_WORKSPACE_ID: !GetAtt GrafanaPrometheus.Outputs.GrafanWorkspaceId
-          GRAFANA_WORKSPACE_URL: !GetAtt GrafanaPrometheus.Outputs.GrafanWorkspaceURL
+          GRAFANA_WORKSPACE_ID: !GetAtt GrafanaPrometheus.Outputs.GrafanaWorkspaceId
+          GRAFANA_WORKSPACE_URL: !GetAtt GrafanaPrometheus.Outputs.GrafanaWorkspaceURL
       Handler: create_ml_dashboards.lambda_handler
       Runtime: python3.13
       Role: !GetAtt GrafanaLambdaRole.Arn

--- a/4.validation_and_observability/4.prometheus-grafana/cluster-observability.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/cluster-observability.yaml
@@ -202,7 +202,7 @@ Outputs:
       - ''
       - - !GetAtt APSWorkspace.PrometheusEndpoint
         - api/v1/remote_write
-  GrafanWorkspaceURL:
+  GrafanaWorkspaceURL:
     Condition: CreateGrafanaWorkspace
     Value: !Join
       - ''

--- a/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/README.md
+++ b/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/README.md
@@ -167,7 +167,7 @@ export AMP_ENDPOINT=$(aws cloudformation describe-stacks \
 
 export GRAFANA_WORKSPACE_URL=$(aws cloudformation describe-stacks \
   --stack-name $STACK_NAME \
-  --query 'Stacks[0].Outputs[?OutputKey==`GrafanWorkspaceURL`].OutputValue' \
+  --query 'Stacks[0].Outputs[?OutputKey==`GrafanaWorkspaceURL`].OutputValue' \
   --output text \
   --region $AWS_REGION_AMGP)
 

--- a/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/cluster-observability.yaml
+++ b/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/cluster-observability.yaml
@@ -67,7 +67,7 @@ Outputs:
     Value: !Join ["" , [ !GetAtt APSWorkspace.PrometheusEndpoint , "api/v1/remote_write" ]]
   AMPEndPointUrl:
     Value: !GetAtt APSWorkspace.PrometheusEndpoint
-  GrafanWorkspaceURL:
+  GrafanaWorkspaceURL:
     Value: !Join ["" , [ "https://", !GetAtt AmazonGrafanaWorkspace.Endpoint ]]
-  GrafanWorkspaceId:
+  GrafanaWorkspaceId:
     Value: !GetAtt AmazonGrafanaWorkspace.Id

--- a/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/deploy-obs.sh
+++ b/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/deploy-obs.sh
@@ -86,7 +86,7 @@ export AMP_QUERY_ENDPOINT=$(aws cloudformation describe-stacks \
 
 export GRAFANA_WORKSPACE_URL=$(aws cloudformation describe-stacks \
   --stack-name $STACK_NAME \
-  --query 'Stacks[0].Outputs[?OutputKey==`GrafanWorkspaceURL`].OutputValue' \
+  --query 'Stacks[0].Outputs[?OutputKey==`GrafanaWorkspaceURL`].OutputValue' \
   --output text \
   --region $AWS_REGION_AMGP)
 


### PR DESCRIPTION
# Fix GrafanWorkspaceURL typo in CloudFormation templates and scripts

## Purpose
Fixes #979

## Changes
- Rename `GrafanWorkspaceURL` to `GrafanaWorkspaceURL` and `GrafanWorkspaceId` to `GrafanaWorkspaceId` across all 6 affected files (CloudFormation templates, deploy script, and README)
- The issue listed 3 files, but the typo also appears in `1click-dashboards-deployment/cluster-observability.yaml`, `1click-dashboards-deployment/managed-cluster-observability-pc.yaml`, and `eks-managed-observability/cluster-observability.yaml` — all fixed together to keep cross-stack references consistent

## Test Plan
Verified all `GrafanWorkspace*` occurrences are replaced. CloudFormation output keys, `!GetAtt` cross-stack references, CLI `--query` filters, and documentation all reference the same corrected names.

## Checklist
- [x] I have read the contributing guidelines.
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] A README is included or updated with prerequisites, instructions, and known issues.
