### PR TITLE
Fix FSDP README documentation errors (#970, #971, #972)

### DIFF
--- a/3.test_cases/pytorch/FSDP/kubernetes/README.md
+++ b/3.test_cases/pytorch/FSDP/kubernetes/README.md
@@ -81,7 +81,7 @@ For this example, we'll be using the [allenai/c4](https://huggingface.co/dataset
 
 **For this dataset, we will need a Hugging Face access token**. First, create a [Hugging Face account](https://huggingface.co/welcome). Then [generate your access token with read permissions](https://huggingface.co/docs/hub/en/security-tokens). We will use this token and set it in our environment variables in the next step.
 
-If you'd like to instead use your own dataset, you can do so by [formatting it as a HuggingFace dataset](https://huggingface.co/docs/datasets/create_dataset), and passing its location to the `--dataset_path` argument.
+If you'd like to instead use your own dataset, you can do so by [formatting it as a HuggingFace dataset](https://huggingface.co/docs/datasets/create_dataset), and passing its location to the `--dataset` argument.
 
 ## 4. Launch Llama 3.1 8B training job
 
@@ -129,7 +129,7 @@ EFA level variables are available for adjustment in fsdp.yaml-template
 Keep FI_* values commented out for non-efa instances (G5, G4d, P3) or P5
 Uncomment FI_* values for P4d instances
 
-You can also adjust the training parameters in `TRAINING_ARGS` (for example, to train Llama 3.1 70B). Additional parameters can be found in `model/arguments.py`. Note that we use the same directory for both `--checkpoint_dir` and `--resume_from_checkpoint`. If there are multiple checkpoints, `--resume_from_checkpoint` will automatically select the most recent one. This way if our training is interupted for any reason, it will automatically pick up the most recent checkpoint.
+You can also adjust the training parameters in `TRAINING_ARGS` (for example, to train Llama 3.1 70B). Additional parameters can be found in `src/model_utils/arguments.py`. Note that we use the same directory for both `--checkpoint_dir` and `--resume_from_checkpoint`. If there are multiple checkpoints, `--resume_from_checkpoint` will automatically select the most recent one. This way if our training is interupted for any reason, it will automatically pick up the most recent checkpoint.
 
 ## 5. Monitor training job
 

--- a/3.test_cases/pytorch/FSDP/slurm/README.md
+++ b/3.test_cases/pytorch/FSDP/slurm/README.md
@@ -52,7 +52,7 @@ For this example, we'll be using the [allenai/c4](https://huggingface.co/dataset
 export HF_TOKEN=<YOUR HF ACCESS TOKEN>
 ```
 
-If you'd like to instead use your own dataset, you can do so by [formatting it as a HuggingFace dataset](https://huggingface.co/docs/datasets/create_dataset), and passing its location to the `--dataset_path` argument.
+If you'd like to instead use your own dataset, you can do so by [formatting it as a HuggingFace dataset](https://huggingface.co/docs/datasets/create_dataset), and passing its location to the `--dataset` argument.
 
 ## Launch Training
 
@@ -69,7 +69,7 @@ If you are using non-EFA enabled instances, such as G4dn, or single GPU g5 nodes
 
 Also, under `User Variables` make sure to adjust `GPUS_PER_NODE` to match the number of GPUs on your instance type (8 for P4d(e)/P5/P6-B200), 4 for G5.12xlarge, 1 for G5.xlarge).
 
-You can also adjust the training parameters in `TRAINING_ARGS` (for example, to increase batch size). Additional parameters can be found in `model/arguments.py`. Note that we use the same directory for both `--checkpoint_dir` and `--resume_from_checkpoint`. If there are multiple checkpoints, `--resume_from_checkpoint` will automatically select the most recent one. This way if our training is interupted for any reason, it will automatically pick up the most recent checkpoint.
+You can also adjust the training parameters in `TRAINING_ARGS` (for example, to increase batch size). Additional parameters can be found in `src/model_utils/arguments.py`. Note that we use the same directory for both `--checkpoint_dir` and `--resume_from_checkpoint`. If there are multiple checkpoints, `--resume_from_checkpoint` will automatically select the most recent one. This way if our training is interupted for any reason, it will automatically pick up the most recent checkpoint.
 
 ### Llama 3.1 8B training
 
@@ -158,7 +158,7 @@ Then you will need to create a [user access token](https://huggingface.co/docs/h
 Once created you will need to define it in your environment:
 
 ```bash
-export HF_TOKEN=>YOUR TOKEN>
+export HF_TOKEN=<YOUR TOKEN>
 ```
 
 You are now ready to launch your training for Mathstral 7B with the following command:


### PR DESCRIPTION
## Purpose
Fixes #970, Fixes #971, Fixes #972

## Changes
- Replace incorrect `model/arguments.py` path with `src/model_utils/arguments.py` in both FSDP Slurm and Kubernetes READMEs
- Fix malformed `export HF_TOKEN=>YOUR TOKEN>` to `export HF_TOKEN=<YOUR TOKEN>` in the FSDP Slurm README Mathstral section
- Replace non-existent `--dataset_path` argument with `--dataset` in both FSDP Slurm and Kubernetes READMEs

## Test Plan
Documentation-only changes. Verified corrected paths and arguments match actual source code in `src/model_utils/arguments.py`.

## Checklist
- [x] I have read the contributing guidelines.
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] A README is included or updated with prerequisites, instructions, and known issues.
