### PR TITLE
fix: update aws-samples to awslabs org in LifecycleScripts

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_docker.sh
@@ -63,7 +63,7 @@ sudo usermod -aG docker ubuntu
 
 
 # Opportunistically use /opt/sagemaker or /opt/dlami/nvme if present. Let's be extra careful in the probe.
-# See: https://github.com/aws-samples/awsome-distributed-training/issues/127
+# See: https://github.com/awslabs/awsome-distributed-training/issues/127
 #
 # Docker workdir doesn't like Lustre. Tried with storage driver overlay2, fuse-overlayfs, & vfs.
 if [[ $(mount | grep /opt/sagemaker) ]]; then

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
@@ -119,7 +119,7 @@ while true; do
     ELAPSED_TIME=$((ELAPSED_TIME + CHECK_INTERVAL))
 
     if [[ $ELAPSED_TIME -ge $MAX_WAIT_TIME ]]; then
-        echo "WARN: Timeout reached: dlami-nvme.service did not become active and successful, it is possible enroot default path is /opt/sagemaker. When training larger models, dragons be here. See https://github.com/aws-samples/awsome-distributed-training/issues/427 for corrective actions"
+        echo "WARN: Timeout reached: dlami-nvme.service did not become active and successful, it is possible enroot default path is /opt/sagemaker. When training larger models, dragons be here. See https://github.com/awslabs/awsome-distributed-training/issues/427 for corrective actions"
         break
     fi
 


### PR DESCRIPTION
## Summary
- Update self-referencing GitHub URLs from `aws-samples/awsome-distributed-training` to `awslabs/awsome-distributed-training` in LifecycleScripts after the repository transfer to the `awslabs` org
- **2 files changed:**
  - `install_docker.sh`: issue #127 URL
  - `install_enroot_pyxis.sh`: issue #427 URL

## Test plan
- [ ] Verify the updated URLs resolve correctly
- [ ] Confirm no other `aws-samples/awsome-distributed-training` references remain in LifecycleScripts