### PR TITLE
fix: update aws-samples to awslabs org references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/about-codeowners/
 
 
-# Enforces that a member of the @aws-samples/sagemaker-hyperpod-dev team for HyperPod lifecycle scripts
+# Enforces that a member of the @awslabs/sagemaker-hyperpod-dev team for HyperPod lifecycle scripts
 # They must approve any PRs that modify files under either base-config directory,
 # including all nested subdirectories and files.
 /1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config     @awslabs/hyperpod-lcs-dev

--- a/.github/ISSUE_TEMPLATE/200-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/200-bug-report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        #### Before submitting a bug report, please make sure you have searched [existing issues](https://github.com/aws-samples/awsome-distributed-training/issues).
+        #### Before submitting a bug report, please make sure you have searched [existing issues](https://github.com/awslabs/awsome-distributed-training/issues).
 
 
         **IMPORTANT:** Please redact any access keys, secret keys, session tokens,

--- a/.github/ISSUE_TEMPLATE/300-ci-failure.yml
+++ b/.github/ISSUE_TEMPLATE/300-ci-failure.yml
@@ -24,7 +24,7 @@ body:
     attributes:
       label: GitHub Actions Run URL
       description: Link to the failing GitHub Actions run.
-      placeholder: https://github.com/aws-samples/awsome-distributed-training/actions/runs/...
+      placeholder: https://github.com/awslabs/awsome-distributed-training/actions/runs/...
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/400-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/400-feature-request.yml
@@ -8,7 +8,7 @@ body:
       value: >
         Thank you for suggesting a feature! For major changes that affect the project's
         architecture or direction, please consider using the
-        [RFC template](https://github.com/aws-samples/awsome-distributed-training/issues/new?template=600-RFC.yml) instead.
+        [RFC template](https://github.com/awslabs/awsome-distributed-training/issues/new?template=600-RFC.yml) instead.
   - type: textarea
     id: description
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,7 @@
 
 ## Checklist
 
-- [ ] I have read the [contributing guidelines](https://github.com/aws-samples/awsome-distributed-training/blob/main/CONTRIBUTING.md).
+- [ ] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
 - [ ] I am working against the latest `main` branch.
 - [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
 - [ ] The contribution is self-contained with documentation and scripts.

--- a/1.architectures/2.aws-parallelcluster/README.md
+++ b/1.architectures/2.aws-parallelcluster/README.md
@@ -55,7 +55,7 @@ These tools are essential for following the deployment steps in this guide and m
 First, clone the repository and move to this directory:
 
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/1.architectures/2.aws-parallelcluster
 ```
 

--- a/1.architectures/5.sagemaker-hyperpod/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/README.md
@@ -10,7 +10,7 @@ SageMaker HyperPod clusters provide the ability to create customized clusters, t
 
 The example that follows describes the process of setting up a SageMaker HyperPod cluster with an attached FSX for Lustre volume.
 
-**Note: For a guided set-up experience, check out the [HyperPod automation script](https://github.com/aws-samples/awsome-distributed-training/tree/main/1.architectures/5.sagemaker-hyperpod/automate-smhp-slurm/README.md).**
+**Note: For a guided set-up experience, check out the [HyperPod automation script](https://github.com/awslabs/awsome-distributed-training/tree/main/1.architectures/5.sagemaker-hyperpod/automate-smhp-slurm/README.md).**
 
 
 ## 2. Prerequisites

--- a/1.architectures/5.sagemaker-hyperpod/automate-smhp-slurm/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/automate-smhp-slurm/README.md
@@ -27,7 +27,7 @@ This demo gif showcases the step-by-step process of creating and setting up a Sa
 
 1. Clone this repository:
    ```bash
-   git clone https://github.com/aws-samples/awsome-distributed-training.git
+   git clone https://github.com/awslabs/awsome-distributed-training.git
    cd 1.architectures/5.sagemaker-hyperpod/automate-smhp-slurm
    ```
 

--- a/1.architectures/5.sagemaker-hyperpod/automate-smhp-slurm/automate-cluster-creation.sh
+++ b/1.architectures/5.sagemaker-hyperpod/automate-smhp-slurm/automate-cluster-creation.sh
@@ -114,14 +114,14 @@ clone_adt() {
             echo -e "${YELLOW}Removing existing directory...${NC}"
             rm -rf "$REPO_NAME"
             echo -e "${BLUE}Cloning repository...${NC}"
-            git clone --depth=1 https://github.com/aws-samples/awsome-distributed-training/
+            git clone --depth=1 https://github.com/awslabs/awsome-distributed-training/
             echo -e "${GREEN}✅ Repository cloned successfully${NC}"
         else
             echo -e "${BLUE}Using existing directory...${NC}"
         fi
     else
         echo -e "${BLUE}Cloning repository $REPO_NAME...${NC}"
-        git clone --depth=1 https://github.com/aws-samples/awsome-distributed-training/
+        git clone --depth=1 https://github.com/awslabs/awsome-distributed-training/
         echo -e "${GREEN}✅ Repository cloned successfully${NC}"
     fi
 }
@@ -251,7 +251,7 @@ multi_headnode() {
             
             if [[ $error_output == *"EntityAlreadyExists"* ]]; then
                 echo -e "\n${YELLOW}If the error you received is that the policy already exists, you can either:${NC}" 
-                echo -e "\n${GREEN}     1. Continue the script with the existing policy (make sure the permissions match the ones in https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/5.sagemaker-hyperpod/1.AmazonSageMakerClustersExecutionRolePolicy.json) and manually attach it to your role ${SLURM_EXECUTION_ROLE}, or${NC}" 
+                echo -e "\n${GREEN}     1. Continue the script with the existing policy (make sure the permissions match the ones in https://github.com/awslabs/awsome-distributed-training/blob/main/1.architectures/5.sagemaker-hyperpod/1.AmazonSageMakerClustersExecutionRolePolicy.json) and manually attach it to your role ${SLURM_EXECUTION_ROLE}, or${NC}" 
                 echo -e "\n${GREEN}     2. You can create a new policy with a name different than 'AmazonSageMakerExecutionPolicy' manually and attach it to your 'AmazonSageMakerExecutionRole' with the following command. Once you do that, you can continue with the rest of the script:${NC}"
 
                 echo -e "\n${YELLOW} Creating an IAM policy (required for option 2 above)${NC}"
@@ -885,7 +885,7 @@ validate_cluster_config() {
     echo "Validating your cluster configuration..."
     # TODO: MAKE SURE PACKAGES ARE INSTALLED HERE!!
 
-    curl -O https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/main/1.architectures/5.sagemaker-hyperpod/validate-config.py
+    curl -O https://raw.githubusercontent.com/awslabs/awsome-distributed-training/main/1.architectures/5.sagemaker-hyperpod/validate-config.py
 
     # check config for known issues
     python3 validate-config.py --cluster-config cluster-config.json --provisioning-parameters provisioning_parameters.json --region $AWS_REGION

--- a/1.architectures/5.sagemaker-hyperpod/slurm-studio/studio-slurm.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/slurm-studio/studio-slurm.yaml
@@ -146,7 +146,7 @@ Resources:
           # Download and execute script
           export TEMP_SCRIPT="/tmp/slurm_setup.sh"
           curl -sL \
-              "https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/refs/heads/main/1.architectures/5.sagemaker-hyperpod/slurm-studio/slurm_lifecycle.sh" \
+              "https://raw.githubusercontent.com/awslabs/awsome-distributed-training/refs/heads/main/1.architectures/5.sagemaker-hyperpod/slurm-studio/slurm_lifecycle.sh" \
               -o "\$TEMP_SCRIPT"
 
           chmod +x "\$TEMP_SCRIPT"
@@ -213,7 +213,7 @@ Resources:
           # Download and execute script
           export TEMP_SCRIPT="/tmp/slurm_setup.sh"
           curl -sL \
-              "https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/refs/heads/main/1.architectures/5.sagemaker-hyperpod/slurm-studio/slurm_lifecycle.sh" \
+              "https://raw.githubusercontent.com/awslabs/awsome-distributed-training/refs/heads/main/1.architectures/5.sagemaker-hyperpod/slurm-studio/slurm_lifecycle.sh" \
               -o "\$TEMP_SCRIPT"
 
           chmod +x "\$TEMP_SCRIPT"

--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/README.md
@@ -17,7 +17,7 @@ The Terraform modules create:
 
 1. **Clone and Navigate**
    ```bash
-   git clone https://github.com/aws-samples/awsome-distributed-training.git
+   git clone https://github.com/awslabs/awsome-distributed-training.git
    cd awsome-distributed-training/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf
    ```
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/README.md
@@ -9,7 +9,7 @@ If you plan to use this script to **deploy the same infrastructure multiple time
 
 ## What the Helper Script Does
 
-In this section, we provide you with a [helper script](https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/hyperpod-eks-cluster-creation.sh) that will walk you through the following:
+In this section, we provide you with a [helper script](https://github.com/awslabs/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/hyperpod-eks-cluster-creation.sh) that will walk you through the following:
 
 1. Installing the right packages in your environment (e.g. aws cli, helm, kubectl, eksctl) 
     - Optionally creating a [SageMaker Studio Code Editor](https://docs.aws.amazon.com/sagemaker/latest/dg/code-editor.html) environment for you to use. 
@@ -18,7 +18,7 @@ In this section, we provide you with a [helper script](https://github.com/aws-sa
     - A Private Subnet in the availability zone where your accelerated compute capacity resides. 
     - A Security Group configured for FSx for Lustre and Elastic Fabric Adapter (EFA) communication. 
     - An EKS Cluster to use as the control interface for your HyperPod cluster. 
-    - An S3 Bucket with with the [on_create.sh](https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh) lifecycle script auto-uploaded. 
+    - An S3 Bucket with with the [on_create.sh](https://github.com/awslabs/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh) lifecycle script auto-uploaded. 
     - An IAM Role which allows the HyperPod cluster to run and communicate with other AWS resource on your behalf. 
 3. Configuring and deploying your HyperPod cluster with the option to add multiple instance groups.
 4. Configuring your EKS cluster, including:
@@ -35,8 +35,8 @@ The following diagram depicts the high-level workflow of how the helper script d
 
 1. When you run the helper script, you will be prompted to answer a series of questions in order to dynamically configure the cloud resources to fit your needs. 
 2. The helper script references an AWS managed S3 bucket to pull down CloudFormation stack templates. 
-3. Optionally, the helper script will use the [`sagemaker-studio-stack.yaml`](https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/sagemaker-studio-stack.yaml) file to deploy a [SageMaker Studio Code Editor](https://docs.aws.amazon.com/sagemaker/latest/dg/code-editor.html) environment for you. 
-4. The helper script will then use the [`main-stack.yaml`](https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/main-stack.yaml) file to deploy the remaining components of the workshop infrastructure. This includes a series of nested Cloudformation stacks that will be pulled from the AWS managed S3 bucket. 
+3. Optionally, the helper script will use the [`sagemaker-studio-stack.yaml`](https://github.com/awslabs/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/sagemaker-studio-stack.yaml) file to deploy a [SageMaker Studio Code Editor](https://docs.aws.amazon.com/sagemaker/latest/dg/code-editor.html) environment for you. 
+4. The helper script will then use the [`main-stack.yaml`](https://github.com/awslabs/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/main-stack.yaml) file to deploy the remaining components of the workshop infrastructure. This includes a series of nested Cloudformation stacks that will be pulled from the AWS managed S3 bucket. 
 5. AWS CloudFormation will deploy the configured workshop infrastructure, including VPC, Private Subnet, Security Group, S3 Bucket, IAM Role, and EKS Cluster resources. See [Deploy HyperPod Infrastructure using CloudFormation](./cfn-templates/README.md) for details. 
 6. Finally the helper script walks you through a series of prompts to configure and deploy a HyperPod cluster using the AWS CLI. 
 
@@ -49,13 +49,13 @@ Prerequisites
 - Bash shell environment
 - AWS account with appropriate permissions
 
-To run the helper script, clone the [awsome-distributed-training](https://github.com/aws-samples/awsome-distributed-training) repository, or directly download the script (as shown below) and run it on your local (Linux/macOS) terminal. It is recommended to run this script from your own directory, rather than running `cd` into the cloned repository directory. Make sure you've configured the AWS CLI with the IAM principal (user or role) you wish to use before running the script.
+To run the helper script, clone the [awsome-distributed-training](https://github.com/awslabs/awsome-distributed-training) repository, or directly download the script (as shown below) and run it on your local (Linux/macOS) terminal. It is recommended to run this script from your own directory, rather than running `cd` into the cloned repository directory. Make sure you've configured the AWS CLI with the IAM principal (user or role) you wish to use before running the script.
 
 ```bash
 # Clone the repository
 mkdir hyperpod-eks && cd hyperpod-eks
 
-curl -O https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/refs/heads/main/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/hyperpod-eks-cluster-creation.sh
+curl -O https://raw.githubusercontent.com/awslabs/awsome-distributed-training/refs/heads/main/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/hyperpod-eks-cluster-creation.sh
 
 # Make the script executable 
 chmod +x hyperpod-eks-cluster-creation.sh

--- a/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/automate-eks-cluster-creation.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/automate-eks-cluster-creation.sh
@@ -297,14 +297,14 @@ clone_adt() {
             echo -e "${YELLOW}Removing existing directory...${NC}"
             rm -rf "$REPO_NAME"
             echo -e "${BLUE}Cloning repository...${NC}"
-            git clone --depth=1 https://github.com/aws-samples/awsome-distributed-training/
+            git clone --depth=1 https://github.com/awslabs/awsome-distributed-training/
             echo -e "${GREEN}✅ Repository cloned successfully${NC}"
         else
             echo -e "${BLUE}Using existing directory...${NC}"
         fi
     else
         echo -e "${BLUE}Cloning repository $REPO_NAME...${NC}"
-        git clone --depth=1 https://github.com/aws-samples/awsome-distributed-training/
+        git clone --depth=1 https://github.com/awslabs/awsome-distributed-training/
         echo -e "${GREEN}✅ Repository cloned successfully${NC}"
     fi
 }

--- a/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/hyperpod-eks-cluster-creation.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/hyperpod-eks-cluster-creation.sh
@@ -361,14 +361,14 @@ clone_adt() {
             echo -e "${YELLOW}Removing existing directory...${NC}"
             rm -rf "$REPO_NAME"
             echo -e "${BLUE}Cloning repository...${NC}"
-            git clone --depth=1 https://github.com/aws-samples/awsome-distributed-training/
+            git clone --depth=1 https://github.com/awslabs/awsome-distributed-training/
             echo -e "${GREEN}✅ Repository cloned successfully${NC}"
         else
             echo -e "${BLUE}Using existing directory...${NC}"
         fi
     else
         echo -e "${BLUE}Cloning repository $REPO_NAME...${NC}"
-        git clone --depth=1 https://github.com/aws-samples/awsome-distributed-training/
+        git clone --depth=1 https://github.com/awslabs/awsome-distributed-training/
         echo -e "${GREEN}✅ Repository cloned successfully${NC}"
     fi
 }

--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/README.md
@@ -202,7 +202,7 @@ Note: If you opt to disable the S3BucketStack, please use the S3BucketName param
 
 <details>
 <summary>LifeCycleScriptStack</summary>
-This stack deploys an AWS Lambda function that creates a [default lifecycle script](https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh) and stores it in the referenced S3 bucket.
+This stack deploys an AWS Lambda function that creates a [default lifecycle script](https://github.com/awslabs/awsome-distributed-training/blob/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh) and stores it in the referenced S3 bucket.
 
 <sp></sp>
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/lifecycle-script-stack.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/lifecycle-script-stack.yaml
@@ -48,7 +48,7 @@ Resources:
       Environment: 
         Variables:
           BUCKET_NAME: !Ref S3BucketName
-          GITHUB_FOLDER_URL: 'https://github.com/aws-samples/awsome-distributed-training/tree/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config'
+          GITHUB_FOLDER_URL: 'https://github.com/awslabs/awsome-distributed-training/tree/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config'
       Handler: index.lambda_handler
       Role: !GetAtt S3CustomResourceRole.Arn
       Runtime: python3.12

--- a/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/Docker-Build-README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/Docker-Build-README.md
@@ -4,7 +4,7 @@ This build includes Python 3.12.8 + PyTorch 2.6.0 + CUDA 12.6 + NCCL 2.23.4 + EF
 
 Clone the AWSome Distributed Training repo:
 ```
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/
 
 ```

--- a/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm/README.md
@@ -47,7 +47,7 @@ Deploy the [HyperPod EKS CloudFormation Stack](https://catalog.workshops.aws/sag
 
 #### <u>Clone the AWSome Distributed Training Repo</u> 
 ```
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cp -r awsome-distributed-training/1.architectures/7.sagemaker-hyperpod-eks/slinky-slurm .
 cd slinky-slurm 
 ```
@@ -68,7 +68,7 @@ Curl the `main-stack.yaml` template and issue an `aws cloudformation create-stac
 ```
 export AWS_REGION=<your-region-here> # e.g. us-west-2
 
-curl -O https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/refs/heads/main/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/main-stack.yaml 
+curl -O https://raw.githubusercontent.com/awslabs/awsome-distributed-training/refs/heads/main/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/main-stack.yaml 
 
 aws cloudformation create-stack \
 --stack-name  hp-eks-slinky-stack \
@@ -83,7 +83,7 @@ export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output tex
 
 export STACK_ID=hp-eks-slinky-stack
 
-curl -O https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/refs/heads/main/1.architectures/7.sagemaker-hyperpod-eks/create_config.sh 
+curl -O https://raw.githubusercontent.com/awslabs/awsome-distributed-training/refs/heads/main/1.architectures/7.sagemaker-hyperpod-eks/create_config.sh 
 
 chmod +x create_config.sh
 
@@ -866,7 +866,7 @@ apt install -y vim
 vim --version
 
 cd /fsx
-git clone https://github.com/aws-samples/awsome-distributed-training/
+git clone https://github.com/awslabs/awsome-distributed-training/
 cd awsome-distributed-training/3.test_cases/pytorch/FSDP/slurm
 
 mkdir -p checkpoints

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/README.md
@@ -9,7 +9,7 @@ The diagram below depicts the Terraform modules that have been bundled into a si
 ## Get the Modules
 Clone the AWSome Distributed Training repository and navigate to the terraform-modules directory:
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf
 ```
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/lifecycle_script/variables.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/lifecycle_script/variables.tf
@@ -14,7 +14,7 @@ variable "script_urls" {
   description = "List of raw URLs of the script files to upload"
   type        = list(string)
   default = [
-    "https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh",
-    "https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create_main.sh"
+    "https://raw.githubusercontent.com/awslabs/awsome-distributed-training/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create.sh",
+    "https://raw.githubusercontent.com/awslabs/awsome-distributed-training/main/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create_main.sh"
   ]
 }

--- a/2.ami_and_containers/containers/pytorch/0.nvcr-pytorch-aws.dockerfile
+++ b/2.ami_and_containers/containers/pytorch/0.nvcr-pytorch-aws.dockerfile
@@ -29,7 +29,7 @@ ENV AWS_OFI_NCCL_VERSION=1.12.1-aws
 ENV NCCL_TESTS_VERSION=master
 
 ## Uncomment below when this Dockerfile builds a container image with efa-installer<1.29.1 and
-# nccl>=2.19.0. See https://github.com/aws-samples/awsome-distributed-training/tree/main/1.architectures/efa-cheatsheet.md
+# nccl>=2.19.0. See https://github.com/awslabs/awsome-distributed-training/tree/main/1.architectures/efa-cheatsheet.md
 #ENV FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 
 RUN apt-get update -y

--- a/3.test_cases/23.SMHP-esm2/README.md
+++ b/3.test_cases/23.SMHP-esm2/README.md
@@ -10,7 +10,7 @@
 ESM-2 is a powerful pLM. We will demonstrate how to use QLoRA to fine-tune ESM-2 on g5.24xlarge instances. We will use ESM-2 to predict [subcellular localization](https://academic.oup.com/nar/article/50/W1/W228/6576357?login=false). Understanding where proteins appear in cells can help us understand their role in disease and find new drug targets.
 
 ## 0. Prerequisites
-You will need to set up a SageMaker Hyperpod cluster using 2 g5.24xlarge instances with a shared parallel filesystem such as [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/getting-started.html).  See the sagemaker-hyperpod section in the [Sagemaker Hyperpod](https://github.com/aws-samples/awsome-distributed-training/tree/main/1.architectures/5.sagemaker-hyperpod) folder for setup instructions.  
+You will need to set up a SageMaker Hyperpod cluster using 2 g5.24xlarge instances with a shared parallel filesystem such as [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/getting-started.html).  See the sagemaker-hyperpod section in the [Sagemaker Hyperpod](https://github.com/awslabs/awsome-distributed-training/tree/main/1.architectures/5.sagemaker-hyperpod) folder for setup instructions.  
 
 ## 1. Install conda
 

--- a/3.test_cases/megatron/bionemo/README.md
+++ b/3.test_cases/megatron/bionemo/README.md
@@ -59,7 +59,7 @@ export DATASET_PATH=/fsx/
 
 ```bash
 cd /apps/
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cp -r /apps/awsome-distributed-training/3.test_cases/14.bionemo/* ./apps/
 ```
 

--- a/3.test_cases/megatron/nemo/kubernetes/README.md
+++ b/3.test_cases/megatron/nemo/kubernetes/README.md
@@ -69,8 +69,8 @@ This implementation leverages Kubernetes on AWS infrastructure to orchestrate di
 Before you begin, ensure you have the following:
 
 - **Kubernetes Cluster**: An EKS cluster or SageMaker HyperPod EKS cluster
-  - For SageMaker HyperPod EKS: Follow [this workshop](https://catalog.workshops.aws/sagemaker-hyperpod-eks/en-US/00-setup) or [this repository](https://github.com/aws-samples/awsome-distributed-training/tree/main/1.architectures/7.sagemaker-hyperpod-eks)
-  - For standard EKS: Follow [these instructions](https://github.com/aws-samples/awsome-distributed-training/tree/main/1.architectures/4.amazon-eks)
+  - For SageMaker HyperPod EKS: Follow [this workshop](https://catalog.workshops.aws/sagemaker-hyperpod-eks/en-US/00-setup) or [this repository](https://github.com/awslabs/awsome-distributed-training/tree/main/1.architectures/7.sagemaker-hyperpod-eks)
+  - For standard EKS: Follow [these instructions](https://github.com/awslabs/awsome-distributed-training/tree/main/1.architectures/4.amazon-eks)
     
     **Additional Setup for Standard EKS (Non-HyperPod):**
     

--- a/3.test_cases/megatron/nemo/slurm/README.md
+++ b/3.test_cases/megatron/nemo/slurm/README.md
@@ -19,7 +19,7 @@ Make sure that your current directory is under a shared filesystem such as `/fsx
 
   ```bash
   cd ~
-  git clone https://github.com/aws-samples/awsome-distributed-training/
+  git clone https://github.com/awslabs/awsome-distributed-training/
   cd awsome-distributed-training/3.test_cases/22.nemo-run/slurm
   ```
 

--- a/3.test_cases/megatron/nemo1.0/EKS/README.md
+++ b/3.test_cases/megatron/nemo1.0/EKS/README.md
@@ -5,7 +5,7 @@
 In this work we will present a step by step guide to run distributed training workloads on an [Amazon EKS](https://aws.amazon.com/eks/) cluster.
 
 ## 0. Prerequisites
-We require that to run this workload, you have a 2 node P4de or P5 cluster available with EFA enabled and a [Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) mounted on that cluster. You can follow the steps at [4.amazon-eks](https://github.com/aws-samples/awsome-distributed-training/tree/1.architectures/4.amazon-eks) to create a EFA enabled EKS cluster with P4de nodes. To this end, we provide the cluster creation config in `p4de-cluster-config.yaml`.
+We require that to run this workload, you have a 2 node P4de or P5 cluster available with EFA enabled and a [Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) mounted on that cluster. You can follow the steps at [4.amazon-eks](https://github.com/awslabs/awsome-distributed-training/tree/1.architectures/4.amazon-eks) to create a EFA enabled EKS cluster with P4de nodes. To this end, we provide the cluster creation config in `p4de-cluster-config.yaml`.
 
 This config will create 2 managed node groups, one for the system node `c5.2xlarge` and one `p4de.24xlarge`. Managed node groups will use EKS optimized AMIs.
 
@@ -225,7 +225,7 @@ docker cp -a <container-id>: /opt/NeMo-Megatron-Launcher/${LAUNCHER_SCRIPTS_PATH
 Run the following to install the necessary dependencies to run NeMo.
 
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd ./awsome-distributed-training/3.test_cases/2.nemo-launcher/EKS/
 pip install -r requirements.txt
 ```
@@ -279,7 +279,7 @@ FILE_NUMBERS="0-5" # Number of files to be downloaded out of the 30 files. With 
 Run the following next to substitute the environment variables in the yaml file and place it in the right location:
 
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/3.test_cases/2.nemo-launcher/EKS/launcher_scripts/conf
 
 envsubst < ./config.yaml > ${LAUNCHER_SCRIPTS_PATH}/launcher_scripts/conf/config.yaml

--- a/3.test_cases/pytorch/FSDP/kubernetes/README.md
+++ b/3.test_cases/pytorch/FSDP/kubernetes/README.md
@@ -27,7 +27,7 @@ arn:aws:eks:us-west-1:xxxxxxxxxxxx:cluster/xxx-eks-cluster
 Clone this repo. 
 
 ```
-git clone https://github.com/aws-samples/awsome-distributed-training/
+git clone https://github.com/awslabs/awsome-distributed-training/
 cd awsome-distributed-training/3.test_cases/pytorch/FSDP/kubernetes
 ```
 
@@ -54,7 +54,7 @@ docker build -f Dockerfile -t ${REGISTRY}fsdp:pytorch2.7.1 .
 popd
 ```
 
-The PyTorch FSDP container uses the [nccl-tests](https://github.com/aws-samples/awsome-distributed-training/blob/main/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile) container as base.
+The PyTorch FSDP container uses the [nccl-tests](https://github.com/awslabs/awsome-distributed-training/blob/main/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile) container as base.
 
 ## 2. Push container image to Amazon ECR
 

--- a/3.test_cases/pytorch/FSDP/slurm/README.md
+++ b/3.test_cases/pytorch/FSDP/slurm/README.md
@@ -11,7 +11,7 @@ On your cluster head node,
 
 ```bash
 cd /fsx
-git clone https://github.com/aws-samples/awsome-distributed-training/
+git clone https://github.com/awslabs/awsome-distributed-training/
 cd awsome-distributed-training/3.test_cases/pytorch/FSDP/slurm
 ```
 

--- a/3.test_cases/pytorch/distillation/README.md
+++ b/3.test_cases/pytorch/distillation/README.md
@@ -25,7 +25,7 @@ First, prepare your container image with all necessary dependencies:
 ```bash
 # Clone the repository
 cd ~
-git clone https://github.com/aws-samples/awsome-distributed-training/
+git clone https://github.com/awslabs/awsome-distributed-training/
 cd awsome-distributed-training/3.test_cases/pytorch/distillation
 
 # Set up environment variables

--- a/3.test_cases/pytorch/mosaicml-composer/stable-diffusion/README.md
+++ b/3.test_cases/pytorch/mosaicml-composer/stable-diffusion/README.md
@@ -186,7 +186,7 @@ More details on this can be found here: https://pytorch.org/blog/accelerated-dif
 
 ### 2.1 Multi-Node Training with Slurm
 
-For the multi-node training we've created a [Dockerfile](https://github.com/aws-samples/awsome-distributed-training/blob/multi-node/3.test_cases/6.stable-diffusion/multi-node/1.Dockerfile), and Slurm submit script to submit the training job. To get started please follow the guide [AWS ParallelCluster Distributed Training](../../1.architectures/2.aws-parallelcluster). Before starting this section make sure you have the following setup:
+For the multi-node training we've created a [Dockerfile](https://github.com/awslabs/awsome-distributed-training/blob/multi-node/3.test_cases/6.stable-diffusion/multi-node/1.Dockerfile), and Slurm submit script to submit the training job. To get started please follow the guide [AWS ParallelCluster Distributed Training](../../1.architectures/2.aws-parallelcluster). Before starting this section make sure you have the following setup:
 
 * AWS ParallelCluster >= 3.7.0
 * Pyxis
@@ -196,7 +196,7 @@ For the multi-node training we've created a [Dockerfile](https://github.com/aws-
 1. To get started, clone this repo and cd into the multi-node directory:
 
 ```
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/6.stable-diffusion/multi-node
 ```
 
@@ -240,7 +240,7 @@ rain          Epoch   0:  100%|████████████████�
 
 ### 2.2 Multi-Node Training with Amazon EKS
 
-Next we will show how to train stable diffusion with Mosaic ML's [composer](https://github.com/mosaicml/composer/tree/dev) on [Amazon EKS](https://aws.amazon.com/eks/). To start we have created an EKS cluster following the steps [here](https://github.com/aws-samples/awsome-distributed-training/tree/main/1.architectures/4.amazon-eks). You can follow these steps to add a nodegroup of `p5.48xlarge` instances. First export these environment variables. 
+Next we will show how to train stable diffusion with Mosaic ML's [composer](https://github.com/mosaicml/composer/tree/dev) on [Amazon EKS](https://aws.amazon.com/eks/). To start we have created an EKS cluster following the steps [here](https://github.com/awslabs/awsome-distributed-training/tree/main/1.architectures/4.amazon-eks). You can follow these steps to add a nodegroup of `p5.48xlarge` instances. First export these environment variables. 
 
 ```bash
 export AWS_REGION=us-west-2
@@ -391,7 +391,7 @@ cd /eks/deployment/kubeflow/training-operator
 
 #### 2.2.6 Now we can start training
 
-We provide a template YAML file for submitting the stable diffusion distributed training job in [3.stable-diffusion-eks.yaml-template](https://github.com/aws-samples/awsome-distributed-training/blob/stable-diffusion-eks/3.test_cases/6.stable-diffusion/multi-node/3.stable-diffusion-eks.yaml-template). You can substitute the environment variables in the template manifest as:
+We provide a template YAML file for submitting the stable diffusion distributed training job in [3.stable-diffusion-eks.yaml-template](https://github.com/awslabs/awsome-distributed-training/blob/stable-diffusion-eks/3.test_cases/6.stable-diffusion/multi-node/3.stable-diffusion-eks.yaml-template). You can substitute the environment variables in the template manifest as:
 
 ```bash
 cat 3.mosaicml-sd-eks.yaml-template | envsubst > mosaicml-sd-eks.yaml

--- a/3.test_cases/pytorch/optimum-neuron/llama3/slurm/fine-tuning/README.md
+++ b/3.test_cases/pytorch/optimum-neuron/llama3/slurm/fine-tuning/README.md
@@ -22,7 +22,7 @@ Begin by downloading the training scripts from the aws-awesome-distributed repo:
 
 ```bash
 cd ~/
-git clone https://github.com/aws-samples/awsome-distributed-training
+git clone https://github.com/awslabs/awsome-distributed-training
 
 cd ~/awsome-distributed-training/3.test_cases/pytorch/optimum-neuron/llama3/slurm/fine-tuning
 ```

--- a/3.test_cases/pytorch/verl/hyperpod-eks/rlvr/README.md
+++ b/3.test_cases/pytorch/verl/hyperpod-eks/rlvr/README.md
@@ -30,7 +30,7 @@ The example was tested on versions:
 
 ### Clone this repo
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git 
+git clone https://github.com/awslabs/awsome-distributed-training.git 
 cd awsome-distributed-training/3.test_cases/pytorch/verl/hyperpod-eks/rlvr
 ```
 

--- a/3.test_cases/pytorch/verl/kubernetes/rlvr/README.md
+++ b/3.test_cases/pytorch/verl/kubernetes/rlvr/README.md
@@ -30,7 +30,7 @@ The example was tested on versions:
 
 ### Clone this repo
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git 
+git clone https://github.com/awslabs/awsome-distributed-training.git 
 cd awsome-distributed-training/3.test_cases/pytorch/verl/kubernetes/rlvr
 ```
 

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/README.md
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/README.md
@@ -21,7 +21,7 @@ The suite provides two operational modes: **lightweight checks** for regular use
 
 ```bash
 # Clone the repository
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/4.validation_and_observability/2.gpu-cluster-healthcheck
 
 # Make all scripts executable

--- a/4.validation_and_observability/3.efa-node-exporter/EKS/README.md
+++ b/4.validation_and_observability/3.efa-node-exporter/EKS/README.md
@@ -20,7 +20,7 @@ export LOCAL_PORT=9000 # Local port to curl prometheus metrics
 To build the Docker image:
 
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/4.validation_and_observability/3.efa-node-exporter/
 
 docker build -t ${REGISTRY}${IMAGE}${TAG} -f Dockerfile .

--- a/4.validation_and_observability/3.efa-node-exporter/README.md
+++ b/4.validation_and_observability/3.efa-node-exporter/README.md
@@ -7,7 +7,7 @@ Scripted fork of the [Prometheus Node Exporter](https://github.com/prometheus/no
 To create the docker image run:
 
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/4.validation_and_observability/3.efa-node-exporter
 make
 ```

--- a/4.validation_and_observability/4.prometheus-grafana/README.md
+++ b/4.validation_and_observability/4.prometheus-grafana/README.md
@@ -32,16 +32,16 @@ If you are using an environment which does not allow to use IAM Identity Center 
 ![observability_architecture](./assets/observability_architecture.png)
 
 
-The solution uses SageMaker HyperPod [Lifecycle Scripts](https://github.com/aws-samples/awsome-distributed-training/tree/main/1.architectures/5.sagemaker-hyperpod#31-lifecycle-scripts), to bootstrap your cluster with the following open-source exporter services: 
+The solution uses SageMaker HyperPod [Lifecycle Scripts](https://github.com/awslabs/awsome-distributed-training/tree/main/1.architectures/5.sagemaker-hyperpod#31-lifecycle-scripts), to bootstrap your cluster with the following open-source exporter services: 
 
 | Name                                                               | Script Deployment Target | Metrics Description                                             |
 | ------------------------------------------------------------------ | -------- | --------------------------------------------------- |
 | [`0.Prometheus Slurm Exporter`](https://github.com/SckyzO/slurm_exporter)                                   | controller-node  | SLURM Accounting metrics (sinfo, sacct)                                |
-| [`1.EFA-Node-Exporter`](https://github.com/aws-samples/awsome-distributed-training/tree/main/4.validation_and_observability/3.efa-node-exporter)                 | cluster-nodes  | Fork of Node exporter to include metrics from emitted from EFA         |
+| [`1.EFA-Node-Exporter`](https://github.com/awslabs/awsome-distributed-training/tree/main/4.validation_and_observability/3.efa-node-exporter)                 | cluster-nodes  | Fork of Node exporter to include metrics from emitted from EFA         |
 | [`2.NVIDIA-DCGM-Exporter`](https://github.com/NVIDIA/dcgm-exporter) | cluster-nodes  | Nvidia DCGM Metrics about Nvidia Enabled GPUs |
 
 ### Prerequisites 
-To enable these exporter services, modify the [config.py](https://github.com/aws-samples/awsome-distributed-training/blob/main/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/config.py) file to configure `enable_observability = True`. Save this file, and [upload it to the s3 bucket path](https://catalog.workshops.aws/sagemaker-hyperpod/en-US/01-cluster/03-s3) referenced in your [`cluster-config.json`](https://catalog.workshops.aws/sagemaker-hyperpod/en-US/01-cluster/04-create-cluster#create-cluster) file. By modifying `config.py` and uploading to S3, this will ensure that any new nodes added or replaced in the HyperPod cluster will also be created with the metric exporter scripts running  
+To enable these exporter services, modify the [config.py](https://github.com/awslabs/awsome-distributed-training/blob/main/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/config.py) file to configure `enable_observability = True`. Save this file, and [upload it to the s3 bucket path](https://catalog.workshops.aws/sagemaker-hyperpod/en-US/01-cluster/03-s3) referenced in your [`cluster-config.json`](https://catalog.workshops.aws/sagemaker-hyperpod/en-US/01-cluster/04-create-cluster#create-cluster) file. By modifying `config.py` and uploading to S3, this will ensure that any new nodes added or replaced in the HyperPod cluster will also be created with the metric exporter scripts running  
 
 If you have already created your HyperPod cluster, you can follow [these instructions](https://catalog.workshops.aws/sagemaker-hyperpod/en-US/06-observability/09-update) to update your existing HyperPod cluster with Observability. 
 

--- a/4.validation_and_observability/5.nsight/README.md
+++ b/4.validation_and_observability/5.nsight/README.md
@@ -4,9 +4,9 @@
 
 We will show how to profile and analyze:
 
-1. [NCCL Tests](https://github.com/aws-samples/awsome-distributed-training/tree/main/micro-benchmarks/nccl-tests/slurm)
-2. [Distributed training run with NeMo](https://github.com/aws-samples/awsome-distributed-training/tree/main/3.test_cases/2.nemo-launcher)
-3. [Distributed training run with FSDP](https://github.com/aws-samples/awsome-distributed-training/tree/main/3.test_cases/10.FSDP)
+1. [NCCL Tests](https://github.com/awslabs/awsome-distributed-training/tree/main/micro-benchmarks/nccl-tests/slurm)
+2. [Distributed training run with NeMo](https://github.com/awslabs/awsome-distributed-training/tree/main/3.test_cases/2.nemo-launcher)
+3. [Distributed training run with FSDP](https://github.com/awslabs/awsome-distributed-training/tree/main/3.test_cases/10.FSDP)
 4. Setup Nsight on an EKS cluster
 
 # 0. Prerequisities
@@ -144,7 +144,7 @@ if batch_idx == args.nsys_end_step and global_rank == 0:
 
 
 # 4. Profiling NCCL tests
-In this section we will show how to generate Nsight reports for NCCL tests. Follow the instructions [here](https://github.com/aws-samples/awsome-distributed-training/tree/main/4.validation_and_observability/0.nccl-tests) to setup NCCL tests and generate the Enroot image `nccl.sqsh`. The `0.nsight_nccl.sbatch` script shows an example on how to profile the NCCL run with Nsight and collect EFA metrics. Key differences between `0.nsight_nccl.sbatch` and [this](https://github.com/aws-samples/awsome-distributed-training/blob/main/4.validation_and_observability/0.nccl-tests/1.nccl-tests.sbatch) are:
+In this section we will show how to generate Nsight reports for NCCL tests. Follow the instructions [here](https://github.com/awslabs/awsome-distributed-training/tree/main/4.validation_and_observability/0.nccl-tests) to setup NCCL tests and generate the Enroot image `nccl.sqsh`. The `0.nsight_nccl.sbatch` script shows an example on how to profile the NCCL run with Nsight and collect EFA metrics. Key differences between `0.nsight_nccl.sbatch` and [this](https://github.com/awslabs/awsome-distributed-training/blob/main/4.validation_and_observability/0.nccl-tests/1.nccl-tests.sbatch) are:
 
 1. `/fsx` needs to be mounted to the container as this is where our Nsight binaries are located.
 2. The `0.nsight_nccl.sbatch` script references the executable `nsys-slurm-exec` which is given below and should exist in `/fsx`

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Micro-benchmarks for evaluating network and communication performance are under 
 
 Thanks to all the contributors for building, reviewing and testing.
 
-[![Contributors](https://contrib.rocks/image?repo=aws-samples/awsome-distributed-training)](https://github.com/aws-samples/awsome-distributed-training/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=awslabs/awsome-distributed-training)](https://github.com/awslabs/awsome-distributed-training/graphs/contributors)
 
 ## 7. Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=aws-samples/awsome-distributed-training&type=Date)](https://star-history.com/#aws-samples/awsome-distributed-training&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/awsome-distributed-training&type=Date)](https://star-history.com/#awslabs/awsome-distributed-training&Date)

--- a/micro-benchmarks/nccl-tests/aws-batch/README.md
+++ b/micro-benchmarks/nccl-tests/aws-batch/README.md
@@ -7,7 +7,7 @@
 2. Next you can deploy the AWS Batch template included in this PR, where `cr-1234567890` is the id of your capacity block and `aws-batch-vpc` is the name of the vpc stack you created above.
 
 ```bash
-git clone https://github.com/aws-samples/awsome-distributed-training.git
+git clone https://github.com/awslabs/awsome-distributed-training.git
 cd awsome-distributed-training/1.architectures/3.aws-batch
 aws cloudformation create-stack --stack-name aws-batch-p5 \
                                 --template-body file://0.aws-batch-distributed-training-p5.yaml \

--- a/micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/README.md
+++ b/micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/README.md
@@ -97,8 +97,8 @@ The file will be stored in the `/fsxl` directory.
 
 ### Slurm with container
 
-clone the awesome-distributed-training repo on your head node
-`git clone https://github.com/aws-samples/awesome-distributed-training.git`
+clone the awsome-distributed-training repo on your head node
+`git clone https://github.com/awslabs/awsome-distributed-training.git`
 
 
 Navigate to the topology-aware-nccl-tests directory:


### PR DESCRIPTION
## Summary
- Update all self-referencing URLs and team mentions from `aws-samples/awsome-distributed-training` to `awslabs/awsome-distributed-training` after the repository transfer to the `awslabs` org
- Update CODEOWNERS team refs (`@aws-samples/hyperpod-lcs-dev` -> `@awslabs/hyperpod-lcs-dev`, `@aws-samples/sagemaker-hyperpod-dev` -> `@awslabs/sagemaker-hyperpod-dev`)
- Fix typo: `awesome-distributed-training` -> `awsome-distributed-training` in topology-aware-nccl-tests README
- **41 files changed** across docs, scripts, configs, templates, and Dockerfiles
- References to other `aws-samples/*` repos (aws-do-eks, aws-efa-eks, etc.) are intentionally unchanged

## Test plan
- [ ] `grep -r 'aws-samples/awsome-distributed-training'` outside LifecycleScripts returns zero matches
- [ ] `grep '@aws-samples/' .github/CODEOWNERS` returns zero matches
- [ ] Verify remaining `aws-samples/` references are only for other repos
- [ ] Spot-check updated URLs resolve correctly