### PR TITLE
docs: update ParallelCluster reference architecture to v3.14.2

### DIFF
--- a/1.architectures/2.aws-parallelcluster/README.md
+++ b/1.architectures/2.aws-parallelcluster/README.md
@@ -65,7 +65,7 @@ Then create a directory under home directory to store cluster config files:
 # For example
 export AWS_REGION=ap-northeast-1
 export CLUSTER_NAME=ml-cluster
-export PCLUSTER_VERSION=3.13.1
+export PCLUSTER_VERSION=3.14.2
 export CONFIG_DIR="${HOME}/${CLUSTER_NAME}_${AWS_REGION}_${PCLUSTER_VERSION}"
 
 mkdir -p ${CONFIG_DIR}
@@ -333,7 +333,7 @@ cat  ${CONFIG_DIR}/config.yaml
 # Example values - these will vary by environment
 CLUSTER_NAME: ml-cluster
 AWS_REGION: eu-west-2
-PCLUSTER_VERSION: 3.13.1
+PCLUSTER_VERSION: 3.14.2
 CAPACITY_RESERVATION_ID: cr-XXXXXXXXXXXXXXXXX
 AZ: eu-west-2c
 NUM_INSTANCES: "16"
@@ -410,7 +410,7 @@ You should see output similar to:
     "cloudformationStackStatus": "CREATE_IN_PROGRESS",
     "cloudformationStackArn": "arn:aws:cloudformation:ap-northeast-1:123456789012:stack/ml-cluster/abcd1234-...",
     "region": "ap-northeast-1",
-    "version": "3.13.0",
+    "version": "3.14.2",
     "clusterStatus": "CREATE_IN_PROGRESS",
     "scheduler": {
       "type": "slurm"


### PR DESCRIPTION
## Purpose

Fixes #983

## Changes

Update AWS ParallelCluster version from v3.13.1 to v3.14.2 in the reference architecture documentation.

- Updated `PCLUSTER_VERSION` export from `3.13.1` to `3.14.2`
- Updated example config YAML value from `3.13.1` to `3.14.2`
- Fixed inconsistent version in example JSON output (was `3.13.0`, now `3.14.2`)

### Security Impact

This version update includes a security fix for [CVE-2026-25506](https://github.com/dun/munge/security/advisories/GHSA-r9cr-jf4v-75gh) (munge upgraded from 0.5.16 to 0.5.18). Users following the README will now install a version that includes this security patch.

## Test Plan

**Environment:**
- AWS Service: Documentation only - no runtime testing required
- Instance type: N/A
- Number of nodes: N/A

**Test commands:**
```bash
# Verified version string changes in README.md
grep -n "3.14.2" 1.architectures/2.aws-parallelcluster/README.md
# Lines 68, 336, 413 show updated version

# Confirmed no remaining references to old version
grep -n "3.13" 1.architectures/2.aws-parallelcluster/README.md
# No results
```

## Test Results

Documentation-only change. Verified all three occurrences of the version number were updated correctly and no stale references remain.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure). (N/A - documentation fix only)