### PR TITLE
Updating setup_efa_fsx_client function to run in a subshell

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create_main.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config/on_create_main.sh
@@ -138,8 +138,10 @@ fi
 
 
 # ===== EFA FSx LUSTRE CLIENT SETUP =====
+# NOTE: This function runs in a subshell to prevent cd from leaking into the caller's working directory.
+# The EXIT trap ensures cleanup on all exit paths (success, error, or signal).
 
-setup_efa_fsx_client() {
+setup_efa_fsx_client() (
     logger "[INFO] Starting EFA FSx client setup"
 
     # Step 1: OS compatibility check
@@ -178,8 +180,13 @@ setup_efa_fsx_client() {
 
     logger "[INFO] EFA detected - configuring for FSx Lustre"
 
-    # Step 3: Download and setup
-    cd /tmp || { logger "[ERROR] Cannot access /tmp directory"; return 1; }
+    # Step 3: Download and setup in isolated temp directory
+    WORKDIR=$(mktemp -d /tmp/efa-fsx-setup.XXXXXX) || { logger "[ERROR] Cannot create temp directory"; return 1; }
+    trap 'rm -rf "$WORKDIR"' EXIT
+    cd "$WORKDIR" || {
+        logger "[ERROR] Cannot enter temp directory"
+        return 1
+    }
 
     logger "[INFO] Downloading EFA FSx client setup..."
     if ! curl --fail --silent --show-error --max-time 30 -o efa-setup.zip \
@@ -191,13 +198,11 @@ setup_efa_fsx_client() {
     logger "[INFO] Extracting setup files..."
     if ! unzip -q efa-setup.zip; then
         logger "[ERROR] Extract failed"
-        rm -f efa-setup.zip
         return 1
     fi
 
     if [[ ! -f "configure-efa-fsx-lustre-client/setup.sh" ]]; then
         logger "[ERROR] Setup script not found in package"
-        rm -rf configure-efa-fsx-lustre-client* efa-setup.zip
         return 1
     fi
 
@@ -208,14 +213,12 @@ setup_efa_fsx_client() {
         logger "[SUCCESS] EFA FSx client configured successfully"
     else
         logger "[ERROR] EFA FSx client setup failed"
-        rm -rf configure-efa-fsx-lustre-client* efa-setup.zip
         return 1
     fi
 
-    # Cleanup
-    rm -rf configure-efa-fsx-lustre-client* efa-setup.zip
+    # Cleanup handled by EXIT trap in Step 3
     return 0
-}
+)
 
 # Load Lustre modules
 load_lustre_modules() {


### PR DESCRIPTION
Updating setup_efa_fsx_client function to run in a subshell to avoid "cd /tmp" pitfall

## Purpose

<!-- Link related issues using "Fixes #123" or "Relates to #123" -->

## Changes

Updating setup_efa_fsx_client function to run in a subshell to avoid "cd /tmp" pitfall

<!-- Summarize the changes made in this PR -->

-

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:
- Instance type:
- Number of nodes:

**Test commands:**
```bash

```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
