### PR TITLE
Fix PyTorch 2.7.1 positional argument requirement for checkpoint APIs

### DIFF
--- a/3.test_cases/pytorch/FSDP/src/model_utils/checkpoint.py
+++ b/3.test_cases/pytorch/FSDP/src/model_utils/checkpoint.py
@@ -30,11 +30,8 @@ def save_checkpoint(model, optimizer, scheduler, user_content, root_dir, sub_dir
     
     # Get sharded state dicts (DTensor format)
     model_state_dict = get_model_state_dict(model)
-    optimizer_state_dict = get_optimizer_state_dict(
-        model=model,
-        optimizer=optimizer,
-    )
-    
+    optimizer_state_dict = get_optimizer_state_dict(model, optimizer)
+
     state_dict = {
         "model": model_state_dict,
         "optim": optimizer_state_dict,
@@ -102,22 +99,15 @@ def load_checkpoint(model, optimizer, scheduler, checkpoint_dir, model_type, dev
     )
     
     # Load model state dict
-    set_model_state_dict(
-        model=model,
-        model_state_dict=state_dict["model"],
-    )
-    
+    set_model_state_dict(model, state_dict["model"])
+
     if dist.get_rank() == 0:
         logger.info("Loaded model state from disk")
         logger.info("Loading optimizer state from disk")
     
     # Load optimizer state dict
-    set_optimizer_state_dict(
-        model=model,
-        optimizer=optimizer,
-        optim_state_dict=state_dict["optim"],
-    )
-    
+    set_optimizer_state_dict(model, optimizer, state_dict["optim"])
+
     # Load scheduler state
     scheduler.load_state_dict(state_dict["scheduler"])
     


### PR DESCRIPTION
## Purpose

Fixes the PyTorch 2.7.1 API change that breaks checkpoint save/load in FSDP training.  

## Related Issues

Closes #996 

## Changes

- Updated `checkpoint.py` to use **positional arguments**:

```python
optimizer_state_dict = get_optimizer_state_dict(model, optimizer)
set_model_state_dict(model, state_dict["model"])
set_optimizer_state_dict(model, optimizer, state_dict["optim"])
```

## Testing

- A minimal local test file `validate_checkpoint_api_test.py` was created that initializes a small FSDP model and optimizer, calls the checkpoint APIs, and confirms that all `get/set` state dict operations succeed. The test fails before the fix (TypeError) and passes after applying positional arguments, validating the change.

```shell
> python3 validate_checkpoint_api_test.py 
Initializing distributed...
Testing get_model_state_dict...
Testing get_optimizer_state_dict...
Testing set_model_state_dict...
Testing set_optimizer_state_dict...
All checkpoint API calls succeeded.
```
