### PR TITLE
feat: Add NCCL Inspector metrics support to HyperPod lifecycle scripts

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/config.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/config.py
@@ -50,6 +50,14 @@ class ObservabilityConfig:
     # Set true if you want to collect advanced metrics
     advanced_metrics = False
 
+    # NCCL Inspector metrics via node_exporter textfile collector.
+    # Requires the NCCL Inspector profiler plugin (.so) to be pre-built and installed on compute nodes.
+    # Build from NCCL source (post-v2.28.3): plugins/profiler/inspector/
+    # See: https://github.com/NVIDIA/nccl/tree/master/plugins/profiler/inspector
+    nccl_metrics_enabled = False
+    nccl_metrics_dump_interval_seconds = 30
+    nccl_profiler_plugin_path = "/opt/nccl-inspector/libnccl-profiler-inspector.so"
+
 
 # Configuration parameters for ActiveDirectory/LDAP/SSSD
 class SssdConfig:

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/lifecycle_script.py
@@ -238,7 +238,17 @@ def main(args):
             except Exception as e:
                 print(f"[WARN] fsx_auto_detect.sh failed: {e}. Continuing without mount-based home directory setup.")
 
-        ExecuteBashScript("./start_slurm.sh").run(node_type, ",".join(controllers))
+        nccl_metrics_flag = "0"
+        nccl_dump_interval = "30"
+        nccl_plugin_path = ""
+        if Config.enable_observability:
+            from config import ObservabilityConfig
+            if ObservabilityConfig.nccl_metrics_enabled:
+                nccl_metrics_flag = "1"
+                nccl_dump_interval = str(ObservabilityConfig.nccl_metrics_dump_interval_seconds)
+                nccl_plugin_path = ObservabilityConfig.nccl_profiler_plugin_path
+
+        ExecuteBashScript("./start_slurm.sh").run(node_type, ",".join(controllers), nccl_metrics_flag, nccl_dump_interval, nccl_plugin_path)
         
         # Setup user associations for Slurm accounting (only on controller nodes)
         if node_type == SlurmNodeType.HEAD_NODE:
@@ -262,6 +272,9 @@ def main(args):
 
             if ObservabilityConfig.advanced_metrics:
                 cmd += ["--advanced"]
+
+            if ObservabilityConfig.nccl_metrics_enabled:
+                cmd += ["--nccl-metrics"]
             
             subprocess.run(cmd, cwd="./observability", check=True)
         

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_node_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_node_exporter.sh
@@ -54,15 +54,25 @@ while [ $attempt -lt $MAX_RETRIES ]; do
     fi
 done
 
+# Add textfile collector for NCCL metrics if the inspector directory exists
+NCCL_VOLUME=""
+NCCL_FLAGS=""
+if [ -d "/var/lib/node_exporter/nccl_inspector" ]; then
+    NCCL_VOLUME="-v /var/lib/node_exporter:/var/lib/node_exporter:ro"
+    NCCL_FLAGS="--collector.textfile --collector.textfile.directory=/var/lib/node_exporter/nccl_inspector"
+fi
+
 # Run the Docker container with appropriate configurations
 if sudo docker run -d --restart always \
     --name=$CONTAINER_NAME \
     --net="host" \
     --pid="host" \
     -v "/:/host:ro,rslave" \
+    $NCCL_VOLUME \
     $IMAGE \
     --path.rootfs=/host \
-    $ADDITIONAL_FLAGS; then
+    $ADDITIONAL_FLAGS \
+    $NCCL_FLAGS; then
     echo "Successfully started Node Exporter on node"
     exit 0
 else

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_observability.py
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_observability.py
@@ -28,7 +28,7 @@ def create_file_from_template(template_path, output_path, replacements):
         output_file.write(content)
 
 
-def install_observability(node_type, prometheus_remote_write_url, advanced=False):
+def install_observability(node_type, prometheus_remote_write_url, advanced=False, nccl_metrics=False):
 
     region = get_region_from_resource_config()
     hostname = socket.gethostname()
@@ -36,6 +36,11 @@ def install_observability(node_type, prometheus_remote_write_url, advanced=False
     env_vars = os.environ.copy()
     env_vars["REGION"] = region
     env_vars["ADVANCED"] = "1" if advanced else "0"
+
+    if nccl_metrics and node_type == "compute":
+        path = "/var/lib/node_exporter/nccl_inspector"
+        os.makedirs(path, exist_ok=True)
+        os.chmod(path, 0o777)
 
     if node_type=="controller":
 
@@ -101,13 +106,14 @@ if __name__ == "__main__":
     argparser.add_argument('--node-type', action="store", required=True, help='Node type (controller, login, compute)')
     argparser.add_argument('--prometheus-remote-write-url', action="store", required=True, help='Prometheus remote write URL (e.g. https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-e37c0ee4-7f7f-4f65-b72b-5455852d0c23/api/v1/remote_write)')
     argparser.add_argument('--advanced', action="store_true", default=False, help='Advanced setup (default: False)')
+    argparser.add_argument('--nccl-metrics', action="store_true", default=False, help='Enable NCCL metrics collection (default: False)')
     args = argparser.parse_args()
 
     assert args.node_type in ["controller", "login", "compute"]
 
     print("Starting observability installation")
 
-    install_observability(args.node_type, args.prometheus_remote_write_url, args.advanced)
+    install_observability(args.node_type, args.prometheus_remote_write_url, args.advanced, args.nccl_metrics)
 
     print("---")
     print("Finished observability installation")

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/start_slurm.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/start_slurm.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
 # must be run as sudo
-# USAGE: start_slurm.sh <NODE_TYPE> [<CONTOLLER_ADDRESSES>]
+# USAGE: start_slurm.sh <NODE_TYPE> [<CONTOLLER_ADDRESSES>] [<SMHP_NCCL_METRICS>] [<SMHP_NCCL_DUMP_INTERVAL_SECONDS>] [<SMHP_NCCL_PLUGIN_PATH>]
 # - Where NODE_TYPE is one of follow values: controller, compute, login
+# - SMHP_NCCL_METRICS is "1" to enable NCCL Inspector task prolog
+# - SMHP_NCCL_DUMP_INTERVAL_SECONDS is the dump interval in seconds (default: 30)
+# - SMHP_NCCL_PLUGIN_PATH is the path to the NCCL Inspector .so plugin
 
 set -ex
 
 LOG_FILE="/var/log/provision/provisioning.log"
 CONTROLLER_IP_VALUES=($2)
+SMHP_NCCL_METRICS=$3
+SMHP_NCCL_DUMP_INTERVAL_SECONDS=${4:-30}
+SMHP_NCCL_PLUGIN_PATH=$5
 
 main() {
   echo "[INFO] START: Starting Slurm daemons"
@@ -36,6 +42,26 @@ main() {
       fi
   done
 
+  # Create NCCL Inspector task prolog script on all nodes before starting daemons
+  if [[ "$SMHP_NCCL_METRICS" == "1" ]]; then
+    echo "[INFO] Creating NCCL metrics task prolog script..."
+    DUMP_INTERVAL_MICROSECONDS=$((SMHP_NCCL_DUMP_INTERVAL_SECONDS * 1000000))
+
+    cat > /opt/slurm/etc/task_prolog.sh << EOF
+#!/bin/bash
+if [ ! -f ${SMHP_NCCL_PLUGIN_PATH} ]; then
+  echo "[WARN] NCCL Inspector plugin not found at ${SMHP_NCCL_PLUGIN_PATH}, skipping NCCL metrics" >&2
+  exit 0
+fi
+echo "export NCCL_PROFILER_PLUGIN=${SMHP_NCCL_PLUGIN_PATH}"
+echo "export NCCL_INSPECTOR_ENABLE=1"
+echo "export NCCL_INSPECTOR_PROM_DUMP=1"
+echo "export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=${DUMP_INTERVAL_MICROSECONDS}"
+echo "export NCCL_INSPECTOR_DUMP_DIR=/var/lib/node_exporter/nccl_inspector/"
+EOF
+    chmod +x /opt/slurm/etc/task_prolog.sh
+  fi
+
   if [[ $1 == "controller" ]]; then
     echo "[INFO] This is a Controller node. Start slurm controller daemon..."
 
@@ -47,6 +73,12 @@ main() {
     echo "Prolog=${SLURM_SCRIPTS_DIR}/prolog.sh"  >> /opt/slurm/etc/slurm.conf
     echo "Epilog=${SLURM_SCRIPTS_DIR}/epilog.sh"  >> /opt/slurm/etc/slurm.conf
     echo "[INFO] Added Prolog and Epilog to /opt/slurm/etc/slurm.conf"
+
+    # Configure NCCL Inspector slurm.conf on controller
+    if [[ "$SMHP_NCCL_METRICS" == "1" ]]; then
+      echo "[INFO] Adding TaskProlog to slurm.conf..."
+      echo "TaskProlog=/opt/slurm/etc/task_prolog.sh" >> /opt/slurm/etc/slurm.conf
+    fi
 
     systemctl enable --now slurmctld
 


### PR DESCRIPTION
## Summary

Add support for collecting NCCL communication metrics via NCCL Inspector and exposing them through node_exporter's textfile collector for Prometheus scraping.

## Changes

- **config.py**: Add `nccl_metrics_enabled`, `nccl_metrics_dump_interval_seconds`, and `nccl_profiler_plugin_path` to `ObservabilityConfig` (defaults: `False`, `30`, `/opt/nccl-inspector/libnccl-profiler-inspector.so`)
- **lifecycle_script.py**: Pass NCCL metrics flags to `start_slurm.sh` and `--nccl-metrics` to `install_observability.py`, gated on both `enable_observability` and `nccl_metrics_enabled`
- **start_slurm.sh**: Create Slurm `TaskProlog` on all nodes (controller + compute) to inject NCCL Inspector env vars into task environments. Add `TaskProlog` directive to `slurm.conf` on controller. Gracefully skips if the `.so` plugin is not installed.
- **install_observability.py**: Create `/var/lib/node_exporter/nccl_inspector/` directory (mode 777) on compute nodes when NCCL metrics enabled
- **install_node_exporter.sh**: Mount nccl_inspector directory and enable textfile collector if the directory exists

## How it works

1. When a Slurm task starts, the `TaskProlog` outputs `export VAR=value` lines to stdout, which Slurm injects into the task environment — setting NCCL Inspector to write Prometheus `.prom` files to `/var/lib/node_exporter/nccl_inspector/`
2. NCCL Inspector writes bounded `.prom` files per GPU device (filename: `nccl_inspector_metrics_<GPU_UUID>.prom`), rewritten each dump interval
3. node_exporter's textfile collector picks up these `.prom` files and exposes them as Prometheus metrics
4. OTel collector scrapes node_exporter and remote-writes to AMP

Metrics exposed: `nccl_algorithm_bandwidth_gbs`, `nccl_bus_bandwidth_gbs`, `nccl_collective_exec_time_microseconds` with labels for `comm_id`, `collective`, `hostname`, `rank`, `slurm_job_id`, `gpu_device_id`, `message_size`, etc.

## Design decisions

- **No TaskEpilog**: `.prom` files are bounded (rewritten, not appended) and per-GPU, so no cleanup needed. Stale files from completed jobs are harmless and get overwritten by the next job on the same GPU.
- **Prolog on all nodes**: `TaskProlog` scripts are created on both controller and compute nodes because `slurmd` executes them locally on the compute node where the task runs.
- **Graceful degradation**: If the NCCL Inspector `.so` plugin is not installed, the prolog warns to stderr and exits 0 — jobs run normally without metrics.

## Testing

Verified end-to-end on SageMaker HyperPod Slurm cluster (ml.g5.4xlarge compute nodes, 2 nodes):

| Check | Status |
|-------|--------|
| TaskProlog in slurm.conf (no TaskEpilog) | ✅ |
| task_prolog.sh content and permissions | ✅ |
| Env var propagation to tasks via stdout | ✅ |
| nccl_inspector directory (777) on compute | ✅ |
| node_exporter textfile collector configured | ✅ |
| .prom files generated per GPU during nccl-tests | ✅ |
| nccl_* metrics served by node_exporter | ✅ |
| OTel scraping node_exporter | ✅ |

Requires NCCL Inspector plugin built from NCCL master branch (`plugins/profiler/inspector/`) — the Prometheus `.prom` output support (`NCCL_INSPECTOR_PROM_DUMP`) is not available in v2.28.3 or earlier releases.
