### PR TITLE
feat: add script to delete specific HyperPod nodes and sync Terraform state

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/scripts/delete-hyperpod-nodes.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/scripts/delete-hyperpod-nodes.sh
@@ -469,10 +469,18 @@ fi
 # ─── Terraform Apply ─────────────────────────────────────────────────────────
 
 TF_DIR="$(dirname "$TFVARS_FILE")"
+TFVARS_BASENAME="$(basename "$TFVARS_FILE")"
+
+# Terraform auto-loads terraform.tfvars and *.auto.tfvars — no -var-file needed.
+# For any other filename, we must pass -var-file explicitly.
+VAR_FILE_FLAG=()
+if [[ "$TFVARS_BASENAME" != "terraform.tfvars" && "$TFVARS_BASENAME" != *.auto.tfvars ]]; then
+    VAR_FILE_FLAG=(-var-file="$TFVARS_BASENAME")
+fi
 
 if [[ "$AUTO_APPLY" == true ]]; then
-    log_info "Running terraform apply -auto-approve in $TF_DIR..."
-    (cd "$TF_DIR" && terraform apply -auto-approve) || {
+    log_info "Running terraform apply -auto-approve ${VAR_FILE_FLAG[*]} in $TF_DIR..."
+    (cd "$TF_DIR" && terraform apply -auto-approve "${VAR_FILE_FLAG[@]}") || {
         log_error "terraform apply failed. Check the output above."
         log_error "Your tfvars file has already been updated. You may need to run terraform apply manually."
         exit 1
@@ -486,8 +494,13 @@ else
     echo "║  Run the following to sync Terraform state:             ║"
     echo "║                                                         ║"
     printf "║    cd %-49s ║\n" "$TF_DIR"
-    echo "║    terraform plan     # verify no unexpected changes    ║"
-    echo "║    terraform apply                                      ║"
+    if [[ ${#VAR_FILE_FLAG[@]} -gt 0 ]]; then
+        printf "║    terraform plan %-37s ║\n" "${VAR_FILE_FLAG[*]}  # verify no unexpected changes"
+        printf "║    terraform apply %-36s ║\n" "${VAR_FILE_FLAG[*]}"
+    else
+        echo "║    terraform plan     # verify no unexpected changes    ║"
+        echo "║    terraform apply                                      ║"
+    fi
     echo "╚══════════════════════════════════════════════════════════╝"
 fi
 


### PR DESCRIPTION
## Summary
- Adds `delete-hyperpod-nodes.sh` to the HyperPod EKS Terraform scripts directory
- Wraps the `BatchDeleteClusterNodes` API to allow targeted removal of specific EC2 instances from a HyperPod instance group (by instance ID), instead of letting AWS choose randomly during scale-down
- After deletion, patches `instance_count` in `terraform.tfvars` to prevent Terraform from re-provisioning removed nodes on the next apply

## Motivation
The `awscc_sagemaker_cluster` Terraform resource (and the underlying `UpdateCluster` API) only accepts a target `instance_count` — AWS decides which nodes to remove. There is no way to specify which individual instances to terminate. The `BatchDeleteClusterNodes` API supports this, but has no Terraform resource. This script bridges the gap.

## Usage
```bash
./scripts/delete-hyperpod-nodes.sh \
  --cluster-name ml-cluster \
  --instance-group-name workers \
  --node-ids i-0abc1234def56789a,i-0def5678abc12345b \
  --tfvars-file /path/to/terraform.tfvars \
  [--region us-west-2] \
  [--auto-apply] \
  [--yes]
```

## What the script does
1. Validates inputs, prerequisites (`aws`, `jq`), and node ID format
2. Confirms the cluster is `InService` and the node IDs exist in the target instance group
3. Prompts for confirmation (skippable with `--yes`)
4. Calls `BatchDeleteClusterNodes` and reports successes/failures
5. Waits for the cluster to stabilize (polls `DescribeCluster`, 5min timeout)
6. Patches `instance_count` in the specified `terraform.tfvars` (scoped to the correct instance group block via line-range `sed`)
7. Optionally runs `terraform apply -auto-approve` (`--auto-apply`) or prints next steps