### PR TITLE
fix: guard otel targets.json writes in prolog/epilog for clusters without observability

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/epilog.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/epilog.sh
@@ -44,7 +44,11 @@ fi
 
 log "Mapping directory contents: $(ls "$JOB_ID_MAP_DIR" 2>&1)"
 
-log Rmeoving the otel collector target.json
-cat > /etc/otel/targets.json <<EOF
+if [ -d /etc/otel ]; then
+    log "Removing the otel collector target.json"
+    cat > /etc/otel/targets.json <<EOF
 [{"targets": ["localhost:9100"], "labels": {}}, {"targets": ["localhost:9109"], "labels": {}}]
 EOF
+else
+    log "Skipping otel target cleanup — /etc/otel not found (observability not installed)"
+fi

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/prolog.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/prolog.sh
@@ -42,7 +42,11 @@ fi
 
 log "Mapping directory contents: $(ls "$JOB_ID_MAP_DIR" 2>&1)"
 
-log Updating the otel collector target.json
-cat > /etc/otel/targets.json <<EOF
+if [ -d /etc/otel ]; then
+    log "Updating the otel collector target.json"
+    cat > /etc/otel/targets.json <<EOF
 [{"targets": ["localhost:9100"], "labels": {"slurm_job_id": "${SLURM_JOB_ID}"}},{"targets": ["localhost:9109"], "labels": {"slurm_job_id": "${SLURM_JOB_ID}"}}]
 EOF
+else
+    log "Skipping otel target update — /etc/otel not found (observability not installed)"
+fi


### PR DESCRIPTION
## Purpose

Fix a regression from #1007 where `prolog.sh` and `epilog.sh` unconditionally write to `/etc/otel/targets.json`, which fails on clusters without the observability stack deployed.

## Problem

After #1007 was merged, **all Slurm jobs fail** on HyperPod clusters that don't have the observability add-on installed:

```
srun: error: Task launch for StepId=1.0 failed on node ip-10-1-246-28: Job prolog failed
srun: error: Application launch failed: Job prolog failed
```

From `slurmd.log`:
```
error: prolog failed: rc:1 output:/opt/slurm/etc/scripts/prolog.sh: line 46: /etc/otel/targets.json: No such file or directory
error: epilog failed: rc:1 output:/opt/slurm/etc/scripts/epilog.sh: line 48: /etc/otel/targets.json: No such file or directory
```


## Changes

1. Wrap the `targets.json` writes in both `prolog.sh` and `epilog.sh` with a `[ -d /etc/otel ]` check
2. Log a clear skip message when observability is not installed
3. Fix typo "Rmeoving" → "Removing" in epilog.sh log message

## Test Plan

**Environment:**
- AWS Service: SageMaker HyperPod (Slurm)
- Reproduces on: Any cluster using default lifecycle scripts without observability

**Verification:**
- [ ] On a cluster **without** observability: `srun hostname` succeeds (no prolog error)
- [ ] On a cluster **with** observability: `srun` still writes `targets.json` as before
- [ ] Prolog/epilog logs show appropriate skip/update message

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.