### PR TITLE
Standardize training config to use NUM_NODES

### DIFF
--- a/3.test_cases/pytorch/FSDP/kubernetes/fsdp.yaml-template
+++ b/3.test_cases/pytorch/FSDP/kubernetes/fsdp.yaml-template
@@ -6,7 +6,7 @@ spec:
   elasticPolicy:
     rdzvBackend: c10d
     minReplicas: 1
-    maxReplicas: $MAX_NODES
+    maxReplicas: $NUM_NODES
     maxRestarts: 100
     metrics:
       - type: Resource
@@ -17,7 +17,7 @@ spec:
             averageUtilization: 90
   pytorchReplicaSpecs:
     Worker:
-      replicas: $MAX_NODES
+      replicas: $NUM_NODES
       restartPolicy: OnFailure
       template:
         metadata:
@@ -94,7 +94,7 @@ spec:
               command: 
                 - /usr/local/bin/torchrun
                 - --nproc_per_node=$GPU_PER_NODE
-                - --nnodes=$MIN_NODES:$MAX_NODES
+                - --nnodes=1:$NUM_NODES
                 - /fsdp/train.py
                 - --max_context_width=4096
                 - --num_key_value_heads=32


### PR DESCRIPTION
Replace MAX_NODES/MIN_NODES variables with NUM_NODES for consistency across maxReplicas, replicas, and --nnodes torchrun argument

# Purpose

Relates to standardizing variable naming in the FSDP Kubernetes training configuration.

## Changes

- Replaced $MAX_NODES with $NUM_NODES in maxReplicas and replicas fields
- Replaced $MIN_NODES:$MAX_NODES with 1:$NUM_NODES in --nnodes torchrun argument
- Simplifies configuration by requiring only a single NUM_NODES variable instead of two separate MIN_NODES/MAX_NODES variables

## Test Plan

Environment:
- AWS Service: Amazon EKS
- Instance type: g5.8xlarge
- Number of nodes: 8

Test commands:
bash
source env_vars
envsubst < fsdp.yaml-template > fsdp.yaml
kubectl apply -f fsdp.yaml
kubectl get pytorchjob



## Test Results

Training job launches successfully with NUM_NODES set to 8. Workers initialize and training progresses normally.

## Directory Structure

3.test_cases/
└── pytorch/
    └── FSDP/
        ├── Dockerfile
        ├── README.md
        ├── slurm/
        └── kubernetes/
            └── fsdp.yaml-template


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest main branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no latest).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [x] New test cases follow the [expected directory structure](#directory-structure).
