### PR TITLE
Updating hyperpod-elastic-agent (HPEA) to v1.1.2 to support torch v2.6+

### DIFF
--- a/3.test_cases/pytorch/FSDP/Dockerfile
+++ b/3.test_cases/pytorch/FSDP/Dockerfile
@@ -15,6 +15,12 @@ FROM base AS hpto
 
 # Install HPEA from test.pypi without deps first (test.pypi has a broken
 # 'FASTAPI' package that shadows the real fastapi), then resolve deps from PyPI.
-RUN pip install "fastapi>=0.113.0" "uvicorn[standard]>=0.30.6" "pip<25.3" psutil \
+# v1.1.2 now declares psutil in pyproject.toml — we verify via pip check, then
+# install any remaining missing deps.
+RUN pip install "fastapi>=0.113.0" "uvicorn[standard]>=0.30.6" "pip<25.3" \
     && pip install --no-deps --index-url https://test.pypi.org/simple/ \
-        --extra-index-url https://pypi.org/simple/ hyperpod-elastic-agent==1.1.1
+        --extra-index-url https://pypi.org/simple/ hyperpod-elastic-agent==1.1.2 \
+    && echo "=== pip check (expect psutil missing) ===" \
+    && pip check 2>&1; pip install psutil \
+    && echo "=== pip check (should pass now) ===" \
+    && pip check

--- a/3.test_cases/pytorch/FSDP/Dockerfile
+++ b/3.test_cases/pytorch/FSDP/Dockerfile
@@ -13,11 +13,6 @@ WORKDIR /fsdp
 # HyperPod-specific image with elastic agent
 FROM base AS hpto
 
-# Install HPEA from test.pypi without deps first (test.pypi has a broken
-# 'FASTAPI' package that shadows the real fastapi), then resolve deps from PyPI.
-# v1.1.2 now declares psutil in pyproject.toml — verified via pip check.
-RUN pip install "fastapi>=0.113.0" "uvicorn[standard]>=0.30.6" "pip<25.3" \
-    && pip install --no-deps --index-url https://test.pypi.org/simple/ \
-        --extra-index-url https://pypi.org/simple/ hyperpod-elastic-agent==1.1.2 \
-    && pip install psutil \
+RUN pip install "pip<25.3" \
+    && pip install hyperpod-elastic-agent==1.1.2 \
     && (pip check 2>&1 | grep -v pygobject || true)

--- a/3.test_cases/pytorch/FSDP/Dockerfile
+++ b/3.test_cases/pytorch/FSDP/Dockerfile
@@ -13,6 +13,4 @@ WORKDIR /fsdp
 # HyperPod-specific image with elastic agent
 FROM base AS hpto
 
-RUN pip install "pip<25.3" \
-    && pip install hyperpod-elastic-agent==1.1.2 \
-    && (pip check 2>&1 | grep -v pygobject || true)
+RUN pip install hyperpod-elastic-agent==1.1.2

--- a/3.test_cases/pytorch/FSDP/Dockerfile
+++ b/3.test_cases/pytorch/FSDP/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /fsdp
 # HyperPod-specific image with elastic agent
 FROM base AS hpto
 
-RUN pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ hyperpod-elastic-agent==1.1.1
+RUN pip install --extra-index-url https://test.pypi.org/simple/ hyperpod-elastic-agent==1.1.1

--- a/3.test_cases/pytorch/FSDP/Dockerfile
+++ b/3.test_cases/pytorch/FSDP/Dockerfile
@@ -15,6 +15,6 @@ FROM base AS hpto
 
 # Install HPEA from test.pypi without deps first (test.pypi has a broken
 # 'FASTAPI' package that shadows the real fastapi), then resolve deps from PyPI.
-RUN pip install "fastapi>=0.113.0" "uvicorn[standard]>=0.30.6" "pip<25.3" \
+RUN pip install "fastapi>=0.113.0" "uvicorn[standard]>=0.30.6" "pip<25.3" psutil \
     && pip install --no-deps --index-url https://test.pypi.org/simple/ \
         --extra-index-url https://pypi.org/simple/ hyperpod-elastic-agent==1.1.1

--- a/3.test_cases/pytorch/FSDP/Dockerfile
+++ b/3.test_cases/pytorch/FSDP/Dockerfile
@@ -15,12 +15,9 @@ FROM base AS hpto
 
 # Install HPEA from test.pypi without deps first (test.pypi has a broken
 # 'FASTAPI' package that shadows the real fastapi), then resolve deps from PyPI.
-# v1.1.2 now declares psutil in pyproject.toml — we verify via pip check, then
-# install any remaining missing deps.
+# v1.1.2 now declares psutil in pyproject.toml — verified via pip check.
 RUN pip install "fastapi>=0.113.0" "uvicorn[standard]>=0.30.6" "pip<25.3" \
     && pip install --no-deps --index-url https://test.pypi.org/simple/ \
         --extra-index-url https://pypi.org/simple/ hyperpod-elastic-agent==1.1.2 \
-    && echo "=== pip check (expect psutil missing) ===" \
-    && pip check 2>&1; pip install psutil \
-    && echo "=== pip check (should pass now) ===" \
-    && pip check
+    && pip install psutil \
+    && (pip check 2>&1 | grep -v pygobject || true)

--- a/3.test_cases/pytorch/FSDP/Dockerfile
+++ b/3.test_cases/pytorch/FSDP/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /fsdp
 # HyperPod-specific image with elastic agent
 FROM base AS hpto
 
-RUN pip install hyperpod-elastic-agent
+RUN pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ hyperpod-elastic-agent==1.1.1

--- a/3.test_cases/pytorch/FSDP/Dockerfile
+++ b/3.test_cases/pytorch/FSDP/Dockerfile
@@ -13,4 +13,8 @@ WORKDIR /fsdp
 # HyperPod-specific image with elastic agent
 FROM base AS hpto
 
-RUN pip install --extra-index-url https://test.pypi.org/simple/ hyperpod-elastic-agent==1.1.1
+# Install HPEA from test.pypi without deps first (test.pypi has a broken
+# 'FASTAPI' package that shadows the real fastapi), then resolve deps from PyPI.
+RUN pip install "fastapi>=0.113.0" "uvicorn[standard]>=0.30.6" "pip<25.3" \
+    && pip install --no-deps --index-url https://test.pypi.org/simple/ \
+        --extra-index-url https://pypi.org/simple/ hyperpod-elastic-agent==1.1.1

--- a/3.test_cases/pytorch/FSDP/kubernetes/README.md
+++ b/3.test_cases/pytorch/FSDP/kubernetes/README.md
@@ -2,7 +2,7 @@
 
 These scripts provide an easy way to get started with multinode [FSDP](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html) training on EKS. It is designed to be as simple as possible, requires no data preparation, and uses a container image. If you would like to run FSDP with SLURM, please refer to [README.md](../slurm/README.md).
 
-This document will run you through how to run Llama 3.1 8B model training with FSDP. You will also find in this folder manifests to run Llama 2(7B, 13B, 70B), Llama 3.1(8B, 70B), Llama 3.2(1B, 3B),  Mistral 8x7b and Mistral Mathstral.
+This document will run you through how to run Llama 3.1 8B model training with FSDP. You will also find in this folder manifests to run Llama 2(7B, 13B, 70B), Llama 3.1(8B, 70B), Llama 3.2(1B, 3B),  Mistral 8x7b and Mistral Mathstral. For SageMaker HyperPod EKS clusters, `HyperPodPyTorchJob` (HPTO) manifests are also available for Llama 3.1 8B and Llama 3.2 1B (see [section 4a](#4a-launch-llama-32-1b-training-with-hyperpod-hpto)).
 
 ## 0. Prerequisites
 
@@ -130,6 +130,74 @@ Keep FI_* values commented out for non-efa instances (G5, G4d, P3) or P5
 Uncomment FI_* values for P4d instances
 
 You can also adjust the training parameters in `TRAINING_ARGS` (for example, to train Llama 3.1 70B). Additional parameters can be found in `src/model_utils/arguments.py`. Note that we use the same directory for both `--checkpoint_dir` and `--resume_from_checkpoint`. If there are multiple checkpoints, `--resume_from_checkpoint` will automatically select the most recent one. This way if our training is interupted for any reason, it will automatically pick up the most recent checkpoint.
+
+## 4a. Launch Llama 3.2 1B training with HyperPod (HPTO)
+
+This section describes how to run a lightweight Llama 3.2 1B FSDP training job using a `HyperPodPyTorchJob` (HPTO) manifest. This is suitable for smaller GPU instances (e.g., g5.8xlarge) and requires a **SageMaker HyperPod EKS cluster**.
+
+### Prerequisites
+
+- A SageMaker HyperPod EKS cluster (the HPTO manifest uses the `sagemaker.amazonaws.com/v1` API group which is not available on vanilla EKS)
+- The container image must be built using the `hpto` target of the Dockerfile, which includes `hyperpod-elastic-agent==1.1.2`:
+
+``` bash
+pushd ../
+docker build -f Dockerfile --target hpto -t ${REGISTRY}fsdp:pytorch2.7.1-hpto .
+popd
+```
+
+Push this image to ECR following the same steps in section 2.
+
+### Launch the training job
+
+Create environment variables:
+
+``` bash
+cat << EOF > env_vars
+export IMAGE_URI=${REGISTRY}fsdp:pytorch2.7.1-hpto
+export NUM_NODES=<NUMBER OF NODES>
+export GPU_PER_NODE=<NUMBER OF GPUS PER NODE>
+export EFA_PER_NODE=<NUMBER OF EFA PER NODE>
+export HF_TOKEN=<YOUR HF ACCESS TOKEN>
+EOF
+```
+
+For reference, this manifest was validated on 8 x ml.g5.8xlarge instances (1 GPU, 1 EFA per node):
+
+``` bash
+cat << EOF > env_vars
+export IMAGE_URI=${REGISTRY}fsdp:pytorch2.7.1-hpto
+export NUM_NODES=8
+export GPU_PER_NODE=1
+export EFA_PER_NODE=1
+export HF_TOKEN=<YOUR HF ACCESS TOKEN>
+EOF
+```
+
+Source variables and apply:
+
+``` bash
+source env_vars
+envsubst < llama3_2_1b-fsdp-hpto.yaml | kubectl apply -f -
+```
+
+> **Note:** The manifest sets `FI_EFA_USE_DEVICE_RDMA=0` because g5 instances do not support GPUDirect RDMA. If you adapt this manifest for p4d/p5 instances, set this value to `1`.
+
+### Monitor and stop
+
+Monitor the HPTO job:
+
+``` bash
+kubectl get hyperpodpytorchjob
+kubectl get pods
+kubectl logs -f llama3-2-1b-fsdp-hpto-pods-0
+```
+
+Stop the job:
+
+``` bash
+envsubst < llama3_2_1b-fsdp-hpto.yaml | kubectl delete -f -
+```
 
 ## 5. Monitor training job
 

--- a/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
+++ b/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
@@ -41,6 +41,14 @@ spec:
                     matchLabels:
                       job-name: llama3-2-1b-fsdp-hpto
                   topologyKey: kubernetes.io/hostname
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: sagemaker.amazonaws.com/node-health-status
+                        operator: In
+                        values:
+                          - Schedulable
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname
@@ -65,7 +73,7 @@ spec:
                 - name: FI_PROVIDER
                   value: efa
                 - name: FI_EFA_USE_DEVICE_RDMA
-                  value: '0'
+                  value: '0' # g5 instances do not support GPUDirect RDMA; set to '1' for p4d/p5
                 - name: FI_EFA_FORK_SAFE
                   value: '1'
                 - name: FI_EFA_ENABLE_SHM_TRANSFER

--- a/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
+++ b/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
@@ -67,11 +67,19 @@ spec:
               resources:
                 requests:
                   nvidia.com/gpu: $GPU_PER_NODE
+                  vpc.amazonaws.com/efa: $EFA_PER_NODE
                 limits:
                   nvidia.com/gpu: $GPU_PER_NODE
+                  vpc.amazonaws.com/efa: $EFA_PER_NODE
               env:
                 - name: LOGLEVEL
                   value: INFO
+                - name: FI_PROVIDER
+                  value: efa
+                - name: FI_EFA_USE_DEVICE_RDMA
+                  value: '1'
+                - name: FI_EFA_FORK_SAFE
+                  value: '1'
                 - name: TORCH_DISTRIBUTED_DEBUG
                   value: DETAIL
                 - name: TORCH_NCCL_ENABLE_MONITORING

--- a/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
+++ b/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
@@ -9,7 +9,7 @@ spec:
     restartPolicy:
       numRestartBeforeFullJobRestart: 3
       evalPeriodSeconds: 21600
-      maxFullJobRestarts: 3
+      maxFullJobRestarts: 1
     cleanPodPolicy: All
     logMonitoringConfiguration:
       - name: JobStart
@@ -41,18 +41,6 @@ spec:
                     matchLabels:
                       job-name: llama3-2-1b-fsdp-hpto
                   topologyKey: kubernetes.io/hostname
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: sagemaker.amazonaws.com/node-health-status
-                        operator: In
-                        values:
-                          - Schedulable
-                      - key: node.kubernetes.io/instance-type
-                        operator: In
-                        values:
-                          - '${INSTANCE_TYPE}'
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname
@@ -79,6 +67,8 @@ spec:
                 - name: FI_EFA_USE_DEVICE_RDMA
                   value: '0'
                 - name: FI_EFA_FORK_SAFE
+                  value: '1'
+                - name: FI_EFA_ENABLE_SHM_TRANSFER
                   value: '1'
                 - name: TORCH_DISTRIBUTED_DEBUG
                   value: DETAIL

--- a/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
+++ b/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
@@ -49,7 +49,7 @@ spec:
                         operator: In
                         values:
                           - Schedulable
-                      - key: sagemaker.amazonaws.com/compute-type
+                      - key: node.kubernetes.io/instance-type
                         operator: In
                         values:
                           - '${INSTANCE_TYPE}'

--- a/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
+++ b/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
@@ -9,7 +9,7 @@ spec:
     restartPolicy:
       numRestartBeforeFullJobRestart: 3
       evalPeriodSeconds: 21600
-      maxFullJobRestarts: 1
+      maxFullJobRestarts: 3
     cleanPodPolicy: All
     logMonitoringConfiguration:
       - name: JobStart
@@ -77,7 +77,7 @@ spec:
                 - name: FI_PROVIDER
                   value: efa
                 - name: FI_EFA_USE_DEVICE_RDMA
-                  value: '1'
+                  value: '0'
                 - name: FI_EFA_FORK_SAFE
                   value: '1'
                 - name: TORCH_DISTRIBUTED_DEBUG

--- a/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
+++ b/3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml
@@ -1,0 +1,125 @@
+apiVersion: sagemaker.amazonaws.com/v1
+kind: HyperPodPyTorchJob
+metadata:
+  name: llama3-2-1b-fsdp-hpto
+spec:
+  nprocPerNode: "$GPU_PER_NODE"
+  runPolicy:
+    jobMaxRetryCount: 10
+    restartPolicy:
+      numRestartBeforeFullJobRestart: 3
+      evalPeriodSeconds: 21600
+      maxFullJobRestarts: 1
+    cleanPodPolicy: All
+    logMonitoringConfiguration:
+      - name: JobStart
+        logPattern: '.*Loss:.*'
+        expectedStartCutOffInSeconds: 240
+      - name: JobHangingDetection
+        logPattern: '.*Loss:.*'
+        expectedRecurringFrequencyInSeconds: 600
+  replicaSpecs:
+    - name: pods
+      replicas: $NUM_NODES
+      template:
+        metadata:
+          labels:
+            job-name: llama3-2-1b-fsdp-hpto
+            replica-type: pods
+        spec:
+          volumes:
+            - name: shmem
+              hostPath:
+                path: /dev/shm
+            - name: local
+              hostPath:
+                path: /mnt/k8s-disks/0
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      job-name: llama3-2-1b-fsdp-hpto
+                  topologyKey: kubernetes.io/hostname
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: sagemaker.amazonaws.com/node-health-status
+                        operator: In
+                        values:
+                          - Schedulable
+                      - key: sagemaker.amazonaws.com/compute-type
+                        operator: In
+                        values:
+                          - '${INSTANCE_TYPE}'
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  job-name: llama3-2-1b-fsdp-hpto
+          containers:
+            - name: pytorch
+              image: ${IMAGE_URI}
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: $GPU_PER_NODE
+                limits:
+                  nvidia.com/gpu: $GPU_PER_NODE
+              env:
+                - name: LOGLEVEL
+                  value: INFO
+                - name: TORCH_DISTRIBUTED_DEBUG
+                  value: DETAIL
+                - name: TORCH_NCCL_ENABLE_MONITORING
+                  value: '1'
+                - name: TORCH_NCCL_TRACE_BUFFER_SIZE
+                  value: '20000'
+                - name: TORCH_NCCL_DUMP_ON_TIMEOUT
+                  value: '1'
+                - name: TORCH_NCCL_DEBUG_INFO_TEMP_FILE
+                  value: /local/nccl_trace_rank_
+                - name: PYTORCH_CUDA_ALLOC_CONF
+                  value: 'expandable_segments:True'
+                - name: NCCL_DEBUG
+                  value: INFO
+                - name: NCCL_SOCKET_IFNAME
+                  value: ^lo
+                - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+                  value: '1'
+                - name: HF_TOKEN
+                  value: '${HF_TOKEN}'
+              command:
+                - hyperpodrun
+                - '--tee=3'
+                - '--log_dir=/tmp/hyperpod'
+                - '--nproc_per_node=$GPU_PER_NODE'
+                - '--nnodes=$NUM_NODES'
+                - /fsdp/train.py
+                - '--max_context_width=8192'
+                - '--num_key_value_heads=2'
+                - '--intermediate_size=8192'
+                - '--hidden_width=2048'
+                - '--num_layers=16'
+                - '--num_heads=32'
+                - '--model_type=llama_v3'
+                - '--tokenizer=hf-internal-testing/llama-tokenizer'
+                - '--checkpoint_freq=50'
+                - '--validation_freq=25'
+                - '--max_steps=100'
+                - '--checkpoint_dir=./checkpoints'
+                - '--dataset=allenai/c4'
+                - '--dataset_config_name=en'
+                - '--resume_from_checkpoint=./checkpoints'
+                - '--train_batch_size=1'
+                - '--val_batch_size=1'
+                - '--sharding_strategy=full'
+                - '--offload_activations=1'
+              volumeMounts:
+                - name: shmem
+                  mountPath: /dev/shm
+                - name: local
+                  mountPath: /local


### PR DESCRIPTION
## Purpose

- Pins `hyperpod-elastic-agent` to v1.1.2 in the FSDP Dockerfile, which resolves compatibility issues with PyTorch 2.6+ (tested and confirmed working on PyTorch 2.7.1)
- Adds a new HyperPodPyTorchJob (HPTO) manifest for Llama 3.2 1B as a lightweight training example suitable for smaller GPU instances (e.g., g5.8xlarge)

Resolves #944 

## Changes

#### Dockerfile: Pin HPEA v1.1.2

The hpto stage of 3.test_cases/pytorch/FSDP/Dockerfile is updated from:
`RUN pip install hyperpod-elastic-agent`
to:
`RUN pip install hyperpod-elastic-agent==1.1.2`

HPEA v1.1.0 (the previously available release) did not support PyTorch 2.6+, blocking adoption of more recent PyTorch versions — particularly on newer hardware such as Blackwell where PyTorch 2.9+ and CUDA 12.8 are required. v1.1.2 restores compatibility with PyTorch 2.6+. Pinning the version ensures reproducible builds.

#### New manifest: Llama 3.2 1B HPTO

3.test_cases/pytorch/FSDP/kubernetes/llama3_2_1b-fsdp-hpto.yaml is a new `HyperPodPyTorchJob` manifest for Llama 3.2 1B FSDP training. It complements the existing 8B manifest and is parameterized with envsubst variables (`$IMAGE_URI`, `$NUM_NODES`, `$GPU_PER_NODE`, `$EFA_PER_NODE`, `$HF_TOKEN`) for portability across cluster configurations.

## Test Plan and Results

Validated end-to-end on a SageMaker HyperPod EKS cluster (8x ml.g5.8xlarge, 1 GPU + 1 EFA per node):
- HPEA v1.1.2 installed cleanly from production PyPI with no workarounds
- Llama 3.2 1B FSDP training ran 100 steps successfully (~2.19 samples/sec)
- Checkpointing verified at steps 50 and 100
- No NCCL or EFA errors during training

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [x] New test cases follow the [expected directory structure](#directory-structure).
