### PR TITLE
Add NVRx resiliency testing for distributed training on Amazon EKS

### DIFF
--- a/3.test_cases/pytorch/nvrx/.gitignore
+++ b/3.test_cases/pytorch/nvrx/.gitignore
@@ -1,0 +1,4 @@
+env_vars
+*.log
+__pycache__/
+*.pyc

--- a/3.test_cases/pytorch/nvrx/Dockerfile
+++ b/3.test_cases/pytorch/nvrx/Dockerfile
@@ -1,0 +1,56 @@
+# Use AWS PyTorch DLC with EFA support as base
+# PyTorch 2.9.0 with CUDA 13.0
+# AWS_REGION controls which regional ECR to pull the DLC from.
+# Override at build time: docker build --build-arg AWS_REGION=us-east-2 ...
+ARG AWS_REGION=us-west-2
+FROM 763104351884.dkr.ecr.${AWS_REGION}.amazonaws.com/pytorch-training:2.9.0-gpu-py312-ec2
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies (git for datasets, no CUDA toolkit needed for PyPI install)
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+# Note: torch is already in the base DLC image, but requirements.txt pins
+# the version for reproducibility across environments
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install NVRx from PyPI (includes async_ckpt, local_ckpt, inprocess modules)
+# The PyPI wheel comes pre-compiled with CUPTI extension -- no CUDA headers needed
+RUN pip install --no-cache-dir nvidia-resiliency-ext==0.4.1
+
+# flash_attn (from base DLC image) was compiled against CUDA 12 and requires
+# libcudart.so.12, but the base image ships CUDA 13.0. Install CUDA 12 runtime
+# for binary compatibility.
+RUN pip install --no-cache-dir nvidia-cuda-runtime-cu12 && \
+    ln -sf /usr/local/lib/python3.12/site-packages/nvidia/cuda_runtime/lib/libcudart.so.12 /usr/local/cuda/lib64/libcudart.so.12 && \
+    ldconfig 2>/dev/null || true
+
+# Verify NVRx installation and check available modules
+RUN python -c "\
+from nvidia_resiliency_ext.checkpointing.async_ckpt.torch_ckpt import TorchAsyncCheckpoint; \
+print('Async checkpoint module: OK'); \
+from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import LocalCheckpointManager; \
+print('Local checkpoint module: OK'); \
+from nvidia_resiliency_ext.inprocess import Wrapper; \
+print('In-process restart module: OK'); \
+"
+
+# Copy training code and utilities
+COPY src/ /app/src/
+COPY prepare_dataset.py /app/
+
+# Set environment variables
+ENV PYTHONPATH=/app
+ENV NCCL_DEBUG=INFO
+ENV NVIDIA_RESILIENCY_EXT_VERSION=0.4.1
+# Note: FI_EFA_USE_DEVICE_RDMA=1 is only for P5 instances (GPUDirect RDMA).
+# For P4de, do NOT set it -- the EFA plugin will use non-RDMA transport.
+# Set it in the K8s manifest env section if using P5.
+
+# Default command (overridden by K8s manifests)
+CMD ["bash"]

--- a/3.test_cases/pytorch/nvrx/README.md
+++ b/3.test_cases/pytorch/nvrx/README.md
@@ -1,0 +1,128 @@
+# NVRx Resiliency Testing for Distributed Training
+
+This test case benchmarks [NVIDIA Resiliency Extension (NVRx)](https://github.com/NVIDIA/nvidia-resiliency-ext) features for PyTorch distributed training on AWS. NVRx provides fault tolerance and resiliency primitives for large-scale training, integrating as a simple `pip install` layer on top of standard PyTorch -- no custom CUDA builds or kernel modifications required.
+
+## NVRx Features Tested
+
+| Feature | Training Script | Description | Tested On |
+|---------|----------------|-------------|-----------|
+| Async Checkpointing | `src/train_async_ckpt.py` | Non-blocking checkpoint saves that overlap with training | LLaMA-3.1-8B on p4de, p5 |
+| In-Process Restart | `src/train_inprocess.py` | Recover from faults without restarting the container | GPT-2 on g5; LLaMA-3.1-8B on p4de, p5 |
+| ft_launcher (In-Job Restart) | `src/train_ft_launcher.py` | Automatic fault detection and worker respawn | GPT-2 on g5; LLaMA-3.1-8B on p5 |
+| ft_launcher + In-Process | `src/train_ft_launcher.py --inprocess` | Combined: in-process for fast faults, ft_launcher for hard faults | GPT-2 on g5 |
+| Local Checkpointing | `src/train_local_ckpt.py` | Node-local checkpoint storage for faster writes | GPT-2 on g5 |
+| Baseline (K8s restart) | `src/train_inprocess.py --disable_nvrx_wrapper` | No NVRx -- relies on K8s container restart for comparison | GPT-2 on g5; LLaMA-3.1-8B on p4de, p5 |
+
+> **Note:** Local checkpointing with NVRx `LocalCheckpointManager` has been tested with GPT-2 on g5 instances only. FSDP sharded state dicts (ShardedTensor) are not yet compatible with NVRx `BasicTensorAwareStateDict` on larger models.
+
+## Parallelism Support
+
+All training scripts support both **FSDP** and **DDP** via the `--parallel_strategy` argument:
+- `--parallel_strategy=fsdp` (default) -- Full Sharded Data Parallel, recommended for large models (LLaMA-3.1-8B)
+- `--parallel_strategy=ddp` -- Distributed Data Parallel, suitable for smaller models (GPT-2)
+
+## Model Support
+
+| Model | Recommended Instances | Parallelism | Notes |
+|-------|----------------------|-------------|-------|
+| **GPT-2 (124M)** | g5.8xlarge (A10G) | DDP or FSDP | Fast iteration for testing NVRx features. Small model, single GPU per node. |
+| **LLaMA-3.1-8B** | p4de.24xlarge (A100), p5.48xlarge (H100) | FSDP | Realistic distributed training workload. FSDP across 16+ GPUs with EFA. |
+
+Set the model via `MODEL_NAME` in `env_vars` (e.g., `MODEL_NAME=gpt2` or `MODEL_NAME=meta-llama/Llama-3.1-8B`).
+
+## Fault Injection
+
+The test case includes a configurable fault injection framework (`src/failure_simulator.py`) that simulates real-world training failures:
+
+- **Exception faults** -- `RuntimeError` caught by NVRx in-process Wrapper for sub-second recovery
+- **Hang faults** -- Simulates NCCL deadlocks, detected by ft_launcher heartbeat timeout
+
+Two injection modes are supported:
+- **Deterministic** (recommended for benchmarks): `--fault_count=5 --fault_seed=42` injects exactly N faults at pre-determined steps for reproducible, apples-to-apples comparisons across recovery mechanisms
+- **Stochastic** (for exploratory testing): `--fault_probability=0.005` injects faults randomly per step per rank
+
+## Prerequisites
+
+To run these tests, you need a training cluster with GPU nodes and shared storage. Instructions for creating a cluster can be found in [1.architectures](../../../1.architectures), the [aws-do-eks](https://bit.ly/do-eks) project, or [EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints).
+
+## 1. Build Container Image
+
+From the `nvrx/` directory, build a container image with PyTorch 2.9, NVRx 0.4.1, and the training scripts:
+
+```bash
+cd 3.test_cases/pytorch/nvrx
+
+export AWS_REGION=$(aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]')
+export ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+export REGISTRY=${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+
+docker build -f Dockerfile -t ${REGISTRY}/nvrx-fsdp-training:latest .
+```
+
+## 2. Push Container Image to Amazon ECR
+
+```bash
+# Create registry if needed
+REGISTRY_COUNT=$(aws ecr describe-repositories | grep \"nvrx-fsdp-training\" | wc -l)
+if [ "$REGISTRY_COUNT" == "0" ]; then
+    aws ecr create-repository --repository-name nvrx-fsdp-training
+fi
+
+# Login and push
+aws ecr get-login-password | docker login --username AWS --password-stdin $REGISTRY
+docker image push ${REGISTRY}/nvrx-fsdp-training:latest
+```
+
+Alternatively, use the provided `build_and_push.sh` script which handles ECR login, repository creation, and pushing in one step:
+
+```bash
+cp env_vars.template env_vars
+# Edit env_vars with your settings
+source env_vars
+./build_and_push.sh
+```
+
+Set `BUILD_HOST` in `env_vars` to build remotely via SSH (e.g., on an EC2 instance with Docker). Leave it empty for local builds.
+
+## 3. Prepare Dataset (Optional)
+
+Training scripts support two dataset modes:
+
+**Option A: Stream from HuggingFace Hub (default)** -- No setup required. Works well for experiments without frequent restarts.
+
+**Option B: Pre-download to local storage (recommended for fault recovery experiments)** -- Eliminates HuggingFace API rate limiting (429 errors) during rapid restarts:
+
+```bash
+# Run inside the training container on your cluster
+python prepare_dataset.py --output_path /checkpoints/c4_subset --num_samples 100000
+```
+
+This downloads 100K samples (~227 MB) in about 20 seconds. Then add `--dataset_path=/checkpoints/c4_subset` to the training script arguments. See the platform-specific README for detailed instructions on running this on your cluster.
+
+## Platform-Specific Instructions
+
+- **Amazon EKS**: See [kubernetes/README.md](kubernetes/README.md)
+- **Slurm**: Coming soon
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| `src/train_inprocess.py` | In-process restart with NVRx Wrapper + baseline mode (`--disable_nvrx_wrapper`) |
+| `src/train_ft_launcher.py` | ft_launcher in-job restart + combined mode (`--inprocess`) |
+| `src/train_async_ckpt.py` | Async vs sync checkpointing comparison (`--use_async_checkpoint`) |
+| `src/train_local_ckpt.py` | Local checkpointing comparison (GPT-2 on g5 only) |
+| `src/distributed_utils.py` | Shared utilities: model creation, FSDP/DDP wrapping, DCP checkpoint save/load |
+| `src/failure_simulator.py` | Configurable fault injection framework (deterministic + stochastic) |
+| `src/fsdp_config.py` | FSDP configuration for GPT-2 and LLaMA models |
+| `src/metrics_collector.py` | Training metrics collection and JSON persistence |
+| `prepare_dataset.py` | One-time dataset download utility |
+
+## References
+
+- [NVIDIA Resiliency Extension (NVRx) GitHub](https://github.com/NVIDIA/nvidia-resiliency-ext)
+- [NVRx Documentation](https://nvidia.github.io/nvidia-resiliency-ext/)
+- [NVRx on PyPI](https://pypi.org/project/nvidia-resiliency-ext/)
+- [PyTorch FSDP Tutorial](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html)
+- [Amazon EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguide/)
+- [AWS EFA Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html)

--- a/3.test_cases/pytorch/nvrx/build_and_push.sh
+++ b/3.test_cases/pytorch/nvrx/build_and_push.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# build_and_push.sh -- Build and push the Docker image to ECR.
+#
+# Requires env_vars to be sourced first:
+#   source env_vars
+#   ./build_and_push.sh
+#
+# If BUILD_HOST is set in env_vars, builds happen remotely via SSH.
+# Otherwise, builds happen locally (requires Docker + ECR access).
+
+set -euo pipefail
+
+# Verify required variables
+for var in AWS_REGION ACCOUNT REGISTRY IMAGE_URI IMAGE_TAG; do
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: $var is not set. Run 'source env_vars' first."
+    exit 1
+  fi
+done
+
+REPO_NAME="nvrx-fsdp-training"
+DLC_REGISTRY="763104351884.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+echo "============================================"
+echo "NVRx Docker Build & Push"
+echo "============================================"
+echo "Region:    ${AWS_REGION}"
+echo "Account:   ${ACCOUNT}"
+echo "Image:     ${IMAGE_URI}"
+echo "Build host: ${BUILD_HOST:-local}"
+echo "============================================"
+
+# Create ECR repository if it doesn't exist
+REPO_EXISTS=$(aws ecr describe-repositories --repository-names ${REPO_NAME} --region ${AWS_REGION} 2>/dev/null | grep -c "${REPO_NAME}" || true)
+if [ "${REPO_EXISTS}" == "0" ]; then
+  echo "Creating ECR repository: ${REPO_NAME}"
+  aws ecr create-repository --repository-name ${REPO_NAME} --region ${AWS_REGION}
+fi
+
+if [ -n "${BUILD_HOST:-}" ]; then
+  # ---- Remote build via SSH ----
+  echo ""
+  echo "Building remotely on ${BUILD_HOST}..."
+  BUILD_DIR="${BUILD_DIR:-~/nvrx-build}"
+
+  # Ensure remote build directory structure exists
+  ssh ${BUILD_HOST} "mkdir -p ${BUILD_DIR}/src"
+
+  # SCP source files, Dockerfile, and requirements.txt
+  echo "Copying source files to ${BUILD_HOST}:${BUILD_DIR}/..."
+  scp Dockerfile requirements.txt prepare_dataset.py ${BUILD_HOST}:${BUILD_DIR}/
+  scp src/*.py ${BUILD_HOST}:${BUILD_DIR}/src/
+
+  # Build and push on remote host
+  echo "Building and pushing image on ${BUILD_HOST}..."
+  ssh ${BUILD_HOST} "cd ${BUILD_DIR} && \
+    aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${REGISTRY} && \
+    aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${DLC_REGISTRY} && \
+    docker build --build-arg AWS_REGION=${AWS_REGION} -t ${IMAGE_URI} . && \
+    docker push ${IMAGE_URI}"
+
+else
+  # ---- Local build ----
+  echo ""
+  echo "Building locally..."
+
+  # ECR login
+  aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${REGISTRY}
+  aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${DLC_REGISTRY}
+
+  # Build and push
+  docker build --build-arg AWS_REGION=${AWS_REGION} -t ${IMAGE_URI} .
+  docker push ${IMAGE_URI}
+fi
+
+echo ""
+echo "============================================"
+echo "Done! Image pushed: ${IMAGE_URI}"
+echo "============================================"

--- a/3.test_cases/pytorch/nvrx/env_vars.template
+++ b/3.test_cases/pytorch/nvrx/env_vars.template
@@ -1,0 +1,100 @@
+#!/bin/bash
+# env_vars.template -- Copy to env_vars and customize for your environment.
+# env_vars is .gitignored and should NEVER be committed.
+#
+# Usage:
+#   cp env_vars.template env_vars
+#   vim env_vars          # fill in manual fields below
+#   source env_vars
+#
+# Then deploy with (from the kubernetes/ directory):
+#   ./deploy.sh <manifest>.yaml
+#   ./deploy.sh --dry-run <manifest>.yaml  # preview
+#   ./deploy.sh --delete <manifest>.yaml   # teardown
+
+# ============================================================================
+# Auto-detected (no manual entry needed)
+# ============================================================================
+export AWS_REGION=$(aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]')
+export ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+export REGISTRY=${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+export IMAGE_TAG=latest
+export IMAGE_URI=${REGISTRY}/nvrx-fsdp-training:${IMAGE_TAG}
+
+# ============================================================================
+# Model configuration
+# ============================================================================
+# GPT-2 (124M):    Recommended for smaller GPU instances (g5.8xlarge, A10G)
+#   MODEL_NAME=gpt2, MAX_SEQ_LENGTH=512, BATCH_SIZE=4
+#
+# LLaMA-3.1-8B:   Recommended for larger GPU instances (p4de, p5)
+#   MODEL_NAME=meta-llama/Llama-3.1-8B, MAX_SEQ_LENGTH=2048, BATCH_SIZE=1
+export MODEL_NAME=meta-llama/Llama-3.1-8B
+export MAX_SEQ_LENGTH=2048
+export BATCH_SIZE=1
+export LEARNING_RATE=2e-5
+
+# ============================================================================
+# Instance & cluster configuration (edit for your environment)
+# ============================================================================
+# Instance type for nodeSelector (must match your EKS node group labels)
+#
+# g5 profile (small-scale testing):
+#   INSTANCE_TYPE=g5.8xlarge  NODE_TYPE=g5-testing  GPU_PER_NODE=1  EFA_PER_NODE=0
+#   CPU_LIMIT=8  CPU_REQUEST=4  MEMORY_LIMIT=32Gi  MEMORY_REQUEST=16Gi
+#
+# p4de profile:
+#   INSTANCE_TYPE=p4de.24xlarge  NODE_TYPE=p4de-a100  GPU_PER_NODE=8  EFA_PER_NODE=4
+#   CPU_LIMIT=90  CPU_REQUEST=45  MEMORY_LIMIT=1000Gi  MEMORY_REQUEST=500Gi
+#
+# p5 profile:
+#   INSTANCE_TYPE=p5.48xlarge  NODE_TYPE=p5-h100  GPU_PER_NODE=8  EFA_PER_NODE=32
+#   CPU_LIMIT=180  CPU_REQUEST=90  MEMORY_LIMIT=1800Gi  MEMORY_REQUEST=900Gi
+#
+export INSTANCE_TYPE=p5.48xlarge
+export NODE_TYPE=p5-h100
+
+# Number of nodes (pods) in the training job
+export NUM_NODES=2
+
+# GPUs per node:  1 for g5.8xlarge, 8 for p4de/p5
+export GPU_PER_NODE=8
+
+# EFA adapters: 0 for g5, 4 for p4de, 32 for p5
+export EFA_PER_NODE=32
+
+# K8s namespace for training jobs
+export NAMESPACE=nvrx-training
+
+# FSx PVC name (must match name in your fsx-storage.yaml)
+export FSX_PVC_NAME=fsx-checkpoint-pvc
+
+# Node taint toleration value. Set to match your GPU node taints.
+# Leave empty if your GPU nodes have no taints.
+# Example: DEDICATED_TAINT_VALUE=p5 matches taint "dedicated=p5:NoSchedule"
+export DEDICATED_TAINT_VALUE=
+
+# ============================================================================
+# NCCL configuration
+# ============================================================================
+# NCCL auto-detects the best transport (EFA/socket).
+# For g5 (no EFA), NCCL falls back to sockets automatically.
+export NCCL_DEBUG=INFO
+
+# ============================================================================
+# Resource limits (adjust for your instance type -- see profiles above)
+# ============================================================================
+export CPU_LIMIT=180
+export CPU_REQUEST=90
+export MEMORY_LIMIT=1800Gi
+export MEMORY_REQUEST=900Gi
+
+# ============================================================================
+# Build configuration (optional -- for build_and_push.sh)
+# ============================================================================
+# If BUILD_HOST is set, builds happen remotely via SSH.
+# If empty, builds happen locally (requires Docker + ECR access).
+export BUILD_HOST=
+
+# Remote build directory (only used when BUILD_HOST is set)
+export BUILD_DIR="~/nvrx-build"

--- a/3.test_cases/pytorch/nvrx/kubernetes/README.md
+++ b/3.test_cases/pytorch/nvrx/kubernetes/README.md
@@ -1,0 +1,174 @@
+# Run NVRx Resiliency Testing on Amazon EKS
+
+This guide walks you through deploying NVRx resiliency experiments on an Amazon EKS cluster. Before following these steps, complete the common setup (build container, push to ECR) described in the [top-level README](../README.md).
+
+## 0. Prerequisites
+
+### 0.1. EKS Cluster
+
+You need an Amazon EKS cluster with GPU nodes and EFA networking. Instructions for creating a cluster can be found in [1.architectures](../../../../1.architectures), the [aws-do-eks](https://bit.ly/do-eks) project, or [EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints).
+
+Your cluster must have:
+- GPU nodes (g5, p4de, or p5 instances) with [NVIDIA device plugin](https://github.com/NVIDIA/k8s-device-plugin)
+- [EFA device plugin](https://github.com/aws/eks-charts/tree/master/stable/aws-efa-k8s-device-plugin) (for multi-node training on p4de/p5)
+- [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html) filesystem in the same VPC/AZ as your nodes
+- [FSx CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/fsx-csi.html) installed
+
+### 0.2. Connect to Your EKS Cluster
+
+```bash
+aws eks update-kubeconfig --name <EKS_CLUSTER_NAME>
+kubectl config current-context
+```
+
+### 0.3. Envsubst
+
+If the [envsubst](https://github.com/a8m/envsubst) utility is not available in your environment, please install it following the instructions appropriate for your operating system.
+
+### 0.4. Navigate to This Directory
+
+All commands in this README are run from the `kubernetes/` directory:
+
+```bash
+cd 3.test_cases/pytorch/nvrx/kubernetes
+```
+
+## 1. Create Namespace
+
+```bash
+kubectl apply -f namespace.yaml
+```
+
+## 2. Create HuggingFace Token Secret
+
+A HuggingFace access token is required for downloading models (LLaMA) and datasets (C4). Create a [HuggingFace account](https://huggingface.co/welcome) and [generate an access token](https://huggingface.co/docs/hub/en/security-tokens).
+
+```bash
+kubectl create secret generic huggingface-token \
+  --from-literal=token=<YOUR_HF_TOKEN> \
+  -n nvrx-training
+```
+
+## 3. Configure FSx for Lustre Storage
+
+Update `fsx-storage.yaml` with your FSx filesystem details:
+
+```bash
+# Find your FSx filesystem details
+aws fsx describe-file-systems \
+  --query 'FileSystems[*].{Id:FileSystemId,DNS:DNSName,Mount:LustreConfiguration.MountName}'
+```
+
+Replace the placeholder values in `fsx-storage.yaml`:
+- `<YOUR-FSX-FILESYSTEM-ID>` -- e.g., `fs-0123456789abcdef0`
+- `<YOUR-FSX-DNS-NAME>` -- e.g., `fs-0123456789abcdef0.fsx.us-west-2.amazonaws.com`
+- `<YOUR-FSX-MOUNT-NAME>` -- e.g., `abcd1234`
+
+Then apply:
+
+```bash
+kubectl apply -f fsx-storage.yaml
+```
+
+## 4. Configure Environment
+
+```bash
+cp ../env_vars.template env_vars
+```
+
+Edit `env_vars` for your environment. Key settings:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `IMAGE_TAG` | Docker image tag | `latest` |
+| `NODE_TYPE` | K8s node label for nodeSelector | `p5-h100` |
+| `NUM_NODES` | Number of training pods | `2` |
+| `GPU_PER_NODE` | GPUs per node | `8` |
+| `EFA_PER_NODE` | EFA adapters per node (0 for g5) | `32` |
+| `FSX_PVC_NAME` | Name of FSx PVC (from step 3) | `fsx-checkpoint-pvc` |
+| `DEDICATED_TAINT_VALUE` | Node taint value (empty if no taints) | `p5` |
+| `MODEL_NAME` | HuggingFace model name | `meta-llama/Llama-3.1-8B` |
+
+Then source:
+
+```bash
+source env_vars
+```
+
+## 5. Prepare Dataset (Optional)
+
+For fault recovery experiments with frequent restarts, pre-download the dataset to avoid HuggingFace API rate limiting:
+
+```bash
+source env_vars
+
+kubectl run prepare-dataset -n nvrx-training \
+  --image=$IMAGE_URI --restart=Never \
+  --overrides='{"spec":{"nodeSelector":{"node-type":"'$NODE_TYPE'"},
+    "containers":[{"name":"c","image":"'$IMAGE_URI'",
+      "command":["python3","/app/prepare_dataset.py",
+        "--output_path","/checkpoints/c4_subset","--num_samples","100000"],
+      "env":[{"name":"HF_HOME","value":"/checkpoints/.cache"},
+             {"name":"HF_TOKEN","valueFrom":{"secretKeyRef":{"name":"huggingface-token","key":"token"}}}],
+      "volumeMounts":[{"name":"ck","mountPath":"/checkpoints"}],
+      "resources":{"limits":{"nvidia.com/gpu":"1"}}}],
+    "volumes":[{"name":"ck","persistentVolumeClaim":{"claimName":"'$FSX_PVC_NAME'"}}]}}'
+
+# Wait for completion and clean up
+kubectl logs prepare-dataset -n nvrx-training --follow
+kubectl delete pod prepare-dataset -n nvrx-training
+```
+
+Fault recovery manifests already include `--dataset_path=/checkpoints/c4_subset`. For checkpoint experiments (no restarts), streaming mode is used by default.
+
+## 6. Launch Training Jobs
+
+Preview a manifest before deploying:
+
+```bash
+./deploy.sh --dry-run training-job-inprocess.yaml
+```
+
+Deploy:
+
+```bash
+./deploy.sh training-job-inprocess.yaml
+```
+
+### Available Manifests
+
+| Manifest | NVRx Feature | Fault Injection |
+|----------|-------------|-----------------|
+| `training-job-inprocess.yaml` | In-process restart (NVRx Wrapper) | Yes (exception) |
+| `training-job-inprocess-baseline.yaml` | Baseline (K8s container restart) | Yes (exception + hang) |
+| `training-job-ft-launcher.yaml` | ft_launcher in-job restart | Yes (exception + hang) |
+| `training-job-ft-launcher-inprocess.yaml` | Combined (ft_launcher + in-process) | Yes (exception + sigkill) |
+| `training-job-async-ckpt.yaml` | Async checkpointing (NVRx) | No |
+| `training-job-async-ckpt-baseline.yaml` | Sync checkpointing (torch.save) | No |
+| `training-job-local-ckpt.yaml` | NVRx local checkpointing | No |
+| `training-job-local-ckpt-baseline.yaml` | Standard torch.save baseline | No |
+
+## 7. Monitor Training
+
+```bash
+# Check pod status
+kubectl get pods -n nvrx-training
+
+# Follow training logs
+kubectl logs -f <pod-name> -n nvrx-training
+
+# Check fault injection and recovery events
+kubectl logs <pod-name> -n nvrx-training | grep -E "INJECTING FAULT|Recovery overhead|TRAINING SUMMARY"
+```
+
+## 8. Stop Training
+
+```bash
+./deploy.sh --delete training-job-inprocess.yaml
+```
+
+Or delete directly:
+
+```bash
+kubectl delete job <job-name> -n nvrx-training
+```

--- a/3.test_cases/pytorch/nvrx/kubernetes/deploy.sh
+++ b/3.test_cases/pytorch/nvrx/kubernetes/deploy.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# deploy.sh -- Deploy K8s manifests with envsubst, safely.
+#
+# Uses an explicit variable list so envsubst does NOT clobber runtime
+# shell variables like $HOSTNAME, $RANK, $POD_IP, $MASTER_ADDR, etc.
+# that appear in the bash args blocks of our manifests.
+#
+# Usage:
+#   source env_vars
+#   ./deploy.sh training-job-local-ckpt.yaml
+#   ./deploy.sh training-job-local-ckpt.yaml --dry-run
+#   ./deploy.sh --delete training-job-local-ckpt.yaml
+#
+# Supports:
+#   --dry-run    Show rendered YAML without applying
+#   --delete     Delete resources instead of applying
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Variables to substitute (must match env_vars.template exports)
+# ONLY these variables are replaced; all others ($HOSTNAME, $RANK, etc.) are
+# left untouched for runtime evaluation inside the container.
+# ---------------------------------------------------------------------------
+ENVSUBST_VARS='$IMAGE_URI $NUM_NODES $GPU_PER_NODE $EFA_PER_NODE $NAMESPACE $NODE_TYPE $FSX_PVC_NAME $DEDICATED_TAINT_VALUE $NCCL_DEBUG $CPU_LIMIT $CPU_REQUEST $MEMORY_LIMIT $MEMORY_REQUEST $MODEL_NAME $MAX_SEQ_LENGTH $BATCH_SIZE $LEARNING_RATE'
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+DRY_RUN=false
+DELETE=false
+MANIFEST=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)  DRY_RUN=true ;;
+    --delete)   DELETE=true ;;
+    *)          MANIFEST="$arg" ;;
+  esac
+done
+
+if [ -z "$MANIFEST" ]; then
+  echo "Usage: $0 [--dry-run|--delete] <manifest.yaml>"
+  echo ""
+  echo "Examples:"
+  echo "  $0 training-job-local-ckpt.yaml"
+  echo "  $0 --dry-run training-job-inprocess.yaml"
+  echo "  $0 --delete training-job-ft-launcher.yaml"
+  exit 1
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERROR: Manifest not found: $MANIFEST"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Validate that required env vars are set
+# ---------------------------------------------------------------------------
+MISSING=()
+for var in IMAGE_URI NUM_NODES GPU_PER_NODE EFA_PER_NODE NAMESPACE NODE_TYPE FSX_PVC_NAME NCCL_DEBUG CPU_LIMIT CPU_REQUEST MEMORY_LIMIT MEMORY_REQUEST MODEL_NAME MAX_SEQ_LENGTH BATCH_SIZE LEARNING_RATE; do
+  if [ -z "${!var:-}" ]; then
+    MISSING+=("$var")
+  fi
+done
+# DEDICATED_TAINT_VALUE is optional (empty = no taint toleration)
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "ERROR: Missing environment variables. Run 'source env_vars' first."
+  echo "  Missing: ${MISSING[*]}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Render and apply/delete
+# ---------------------------------------------------------------------------
+RENDERED=$(envsubst "${ENVSUBST_VARS}" < "$MANIFEST")
+
+if [ "$DRY_RUN" = true ]; then
+  echo "# --- Rendered: $MANIFEST ---"
+  echo "$RENDERED"
+  echo "# --- End ---"
+elif [ "$DELETE" = true ]; then
+  echo "Deleting resources from: $MANIFEST"
+  echo "$RENDERED" | kubectl delete -f - --ignore-not-found
+  echo "Done."
+else
+  echo "Deploying: $MANIFEST"
+  echo "  Namespace: ${NAMESPACE}"
+  echo "  Image:     ${IMAGE_URI}"
+  echo "  Nodes:     ${NUM_NODES} x ${GPU_PER_NODE} GPUs (${EFA_PER_NODE} EFA)"
+  echo "  Model:     ${MODEL_NAME}"
+  echo "$RENDERED" | kubectl apply -f -
+  echo "Done."
+fi

--- a/3.test_cases/pytorch/nvrx/kubernetes/fsx-storage.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/fsx-storage.yaml
@@ -1,0 +1,51 @@
+# FSx for Lustre Persistent Volume and Persistent Volume Claim
+#
+# This manifest connects your Kubernetes cluster to an existing FSx for Lustre
+# filesystem for shared checkpoint and dataset storage across training pods.
+#
+# Prerequisites:
+#   1. FSx for Lustre filesystem created in the same VPC/subnet as your nodes
+#   2. FSx CSI Driver installed: https://docs.aws.amazon.com/eks/latest/userguide/fsx-csi.html
+#      helm repo add aws-fsx-csi-driver https://kubernetes-sigs.github.io/aws-fsx-csi-driver
+#      helm install aws-fsx-csi-driver aws-fsx-csi-driver/aws-fsx-csi-driver -n kube-system
+#
+# Update the values below with your FSx filesystem details:
+#   - <YOUR-FSX-FILESYSTEM-ID>: e.g., fs-0123456789abcdef0
+#   - <YOUR-FSX-DNS-NAME>: e.g., fs-0123456789abcdef0.fsx.us-west-2.amazonaws.com
+#   - <YOUR-FSX-MOUNT-NAME>: e.g., abcd1234 (from FSx console > Filesystem > Mount name)
+#
+# Find these values:
+#   aws fsx describe-file-systems --query 'FileSystems[*].{Id:FileSystemId,DNS:DNSName,Mount:LustreConfiguration.MountName}'
+#
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: fsx-checkpoint-pv
+spec:
+  capacity:
+    storage: 1200Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: fsx.csi.aws.com
+    volumeHandle: <YOUR-FSX-FILESYSTEM-ID>
+    volumeAttributes:
+      dnsname: <YOUR-FSX-DNS-NAME>
+      mountname: <YOUR-FSX-MOUNT-NAME>
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-checkpoint-pvc
+  namespace: nvrx-training
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1200Gi
+  volumeName: fsx-checkpoint-pv

--- a/3.test_cases/pytorch/nvrx/kubernetes/namespace.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvrx-training
+  labels:
+    name: nvrx-training

--- a/3.test_cases/pytorch/nvrx/kubernetes/secret-hf-token.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/secret-hf-token.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: huggingface-token
+  namespace: nvrx-training
+type: Opaque
+stringData:
+  # Replace with your actual HF token
+  # kubectl create secret generic huggingface-token \
+  #   --from-literal=token=YOUR_TOKEN_HERE \
+  #   -n nvrx-training
+  token: "REPLACE_WITH_YOUR_TOKEN"

--- a/3.test_cases/pytorch/nvrx/kubernetes/training-job-async-ckpt-baseline.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/training-job-async-ckpt-baseline.yaml
@@ -1,0 +1,171 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-async-ckpt-baseline
+  namespace: ${NAMESPACE}
+spec:
+  parallelism: ${NUM_NODES}
+  completions: ${NUM_NODES}
+  completionMode: Indexed
+  ttlSecondsAfterFinished: 21600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: training-async-ckpt-baseline
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: default
+      containers:
+      - name: training
+        image: ${IMAGE_URI}
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Determine rank from hostname
+            RANK=$(echo $HOSTNAME | grep -o '[0-9]*$')
+            echo "Rank: $RANK"
+            
+            if [ "$RANK" -eq "0" ]; then
+              # Rank 0: Use own IP and start immediately
+              export MASTER_ADDR=$POD_IP
+              export MASTER_PORT=29500
+              echo "Rank 0 - Master address: $MASTER_ADDR:$MASTER_PORT"
+              
+              # Wait a bit for rank 1 to be ready
+              sleep 10
+            else
+              # Rank 1: Wait for rank 0 to be ready
+              echo "Rank 1 - Waiting for rank 0..."
+              sleep 20
+              
+              # Get rank 0's IP from service endpoints (exclude own IP)
+              export MASTER_PORT=29500
+              
+              for i in {1..10}; do
+                MASTER_IP=$(getent hosts training-async-ckpt-baseline.${NAMESPACE}.svc.cluster.local | awk '{print $1}' | grep -v "$POD_IP" | head -1)
+                if [ ! -z "$MASTER_IP" ]; then
+                  echo "Rank 1 - Found rank 0 IP: $MASTER_IP (excluded own IP: $POD_IP)"
+                  export MASTER_ADDR=$MASTER_IP
+                  break
+                fi
+                echo "Rank 1 - Waiting for rank 0 service endpoint... ($i/10)"
+                sleep 5
+              done
+              
+              if [ -z "$MASTER_ADDR" ]; then
+                echo "ERROR: Could not find master address"
+                exit 1
+              fi
+              
+              echo "Rank 1 - Master address: $MASTER_ADDR:$MASTER_PORT"
+            fi
+            
+            # Run training with SYNC checkpointing (baseline for async comparison)
+            echo "Starting SYNC checkpoint baseline training..."
+            python -m torch.distributed.run \
+              --nproc_per_node=${GPU_PER_NODE} \
+              --nnodes=${NUM_NODES} \
+              --node_rank=$RANK \
+              --master_addr=$MASTER_ADDR \
+              --master_port=$MASTER_PORT \
+              /app/src/train_async_ckpt.py \
+              --model_name=${MODEL_NAME} \
+              --max_seq_length=${MAX_SEQ_LENGTH} \
+              --batch_size=${BATCH_SIZE} \
+              --learning_rate=${LEARNING_RATE} \
+              --use_async_checkpoint=false \
+              --max_steps=5000 \
+              --training_duration_minutes=120 \
+              --checkpoint_interval=1000
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_DEBUG
+          value: "${NCCL_DEBUG}"
+        - name: NCCL_SOCKET_IFNAME
+          value: "^docker,lo,veth"
+        - name: NCCL_BUFFSIZE
+          value: "8388608"
+        - name: NCCL_P2P_NET_CHUNKSIZE
+          value: "2097152"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: NCCL_NVLS_ENABLE
+          value: "0"
+        - name: NCCL_TUNER_PLUGIN
+          value: "/opt/amazon/ofi-nccl/lib/libnccl-ofi-tuner.so"
+        - name: RDMAV_FORK_SAFE
+          value: "1"
+        - name: NCCL_NET_GDR_LEVEL
+          value: "5"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: FI_LOG_LEVEL
+          value: "warn"
+        - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+          value: "1"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: HF_HOME
+          value: "/checkpoints/.cache"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: huggingface-token
+              key: token
+        resources:
+          limits:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_LIMIT}"
+            cpu: "${CPU_LIMIT}"
+          requests:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_REQUEST}"
+            cpu: "${CPU_REQUEST}"
+        volumeMounts:
+        - name: checkpoints
+          mountPath: /checkpoints
+        - name: shm
+          mountPath: /dev/shm
+        securityContext:
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: checkpoints
+        persistentVolumeClaim:
+          claimName: ${FSX_PVC_NAME}
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      nodeSelector:
+        node-type: ${NODE_TYPE}
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: ${DEDICATED_TAINT_VALUE}
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-async-ckpt-baseline
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: training-async-ckpt-baseline
+  clusterIP: None
+  ports:
+  - port: 29500
+    targetPort: 29500

--- a/3.test_cases/pytorch/nvrx/kubernetes/training-job-async-ckpt.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/training-job-async-ckpt.yaml
@@ -1,0 +1,171 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-async-ckpt
+  namespace: ${NAMESPACE}
+spec:
+  parallelism: ${NUM_NODES}
+  completions: ${NUM_NODES}
+  completionMode: Indexed
+  ttlSecondsAfterFinished: 21600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: training-async-ckpt
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: default
+      containers:
+      - name: training
+        image: ${IMAGE_URI}
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Determine rank from hostname
+            RANK=$(echo $HOSTNAME | grep -o '[0-9]*$')
+            echo "Rank: $RANK"
+            
+            if [ "$RANK" -eq "0" ]; then
+              # Rank 0: Use own IP and start immediately
+              export MASTER_ADDR=$POD_IP
+              export MASTER_PORT=29500
+              echo "Rank 0 - Master address: $MASTER_ADDR:$MASTER_PORT"
+              
+              # Wait a bit for rank 1 to be ready
+              sleep 10
+            else
+              # Rank 1: Wait for rank 0 to be ready
+              echo "Rank 1 - Waiting for rank 0..."
+              sleep 20
+              
+              # Get rank 0's IP from service endpoints (exclude own IP)
+              export MASTER_PORT=29500
+              
+              for i in {1..10}; do
+                MASTER_IP=$(getent hosts training-async-ckpt.${NAMESPACE}.svc.cluster.local | awk '{print $1}' | grep -v "$POD_IP" | head -1)
+                if [ ! -z "$MASTER_IP" ]; then
+                  echo "Rank 1 - Found rank 0 IP: $MASTER_IP (excluded own IP: $POD_IP)"
+                  export MASTER_ADDR=$MASTER_IP
+                  break
+                fi
+                echo "Rank 1 - Waiting for rank 0 service endpoint... ($i/10)"
+                sleep 5
+              done
+              
+              if [ -z "$MASTER_ADDR" ]; then
+                echo "ERROR: Could not find master address"
+                exit 1
+              fi
+              
+              echo "Rank 1 - Master address: $MASTER_ADDR:$MASTER_PORT"
+            fi
+            
+            # Run training
+            echo "Starting distributed training..."
+            python -m torch.distributed.run \
+              --nproc_per_node=${GPU_PER_NODE} \
+              --nnodes=${NUM_NODES} \
+              --node_rank=$RANK \
+              --master_addr=$MASTER_ADDR \
+              --master_port=$MASTER_PORT \
+              /app/src/train_async_ckpt.py \
+              --model_name=${MODEL_NAME} \
+              --max_seq_length=${MAX_SEQ_LENGTH} \
+              --batch_size=${BATCH_SIZE} \
+              --learning_rate=${LEARNING_RATE} \
+              --use_async_checkpoint=true \
+              --max_steps=5000 \
+              --training_duration_minutes=120 \
+              --checkpoint_interval=1000
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_DEBUG
+          value: "${NCCL_DEBUG}"
+        - name: NCCL_SOCKET_IFNAME
+          value: "^docker,lo,veth"
+        - name: NCCL_BUFFSIZE
+          value: "8388608"
+        - name: NCCL_P2P_NET_CHUNKSIZE
+          value: "2097152"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: NCCL_NVLS_ENABLE
+          value: "0"
+        - name: NCCL_TUNER_PLUGIN
+          value: "/opt/amazon/ofi-nccl/lib/libnccl-ofi-tuner.so"
+        - name: RDMAV_FORK_SAFE
+          value: "1"
+        - name: NCCL_NET_GDR_LEVEL
+          value: "5"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: FI_LOG_LEVEL
+          value: "warn"
+        - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+          value: "1"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: HF_HOME
+          value: "/checkpoints/.cache"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: huggingface-token
+              key: token
+        resources:
+          limits:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_LIMIT}"
+            cpu: "${CPU_LIMIT}"
+          requests:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_REQUEST}"
+            cpu: "${CPU_REQUEST}"
+        volumeMounts:
+        - name: checkpoints
+          mountPath: /checkpoints
+        - name: shm
+          mountPath: /dev/shm
+        securityContext:
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: checkpoints
+        persistentVolumeClaim:
+          claimName: ${FSX_PVC_NAME}
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      nodeSelector:
+        node-type: ${NODE_TYPE}
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: ${DEDICATED_TAINT_VALUE}
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-async-ckpt
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: training-async-ckpt
+  clusterIP: None
+  ports:
+  - port: 29500
+    targetPort: 29500

--- a/3.test_cases/pytorch/nvrx/kubernetes/training-job-ft-launcher-inprocess.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/training-job-ft-launcher-inprocess.yaml
@@ -1,0 +1,198 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-ft-launcher-inprocess
+  namespace: ${NAMESPACE}
+spec:
+  parallelism: ${NUM_NODES}
+  completions: ${NUM_NODES}
+  completionMode: Indexed
+  ttlSecondsAfterFinished: 21600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: training-ft-launcher-inprocess
+    spec:
+      restartPolicy: Never
+      serviceAccountName: default
+      containers:
+      - name: training
+        image: ${IMAGE_URI}
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Determine rank from Job completion index
+            RANK=$(echo $HOSTNAME | grep -o '[0-9]*$')
+            echo "Pod index: $RANK"
+
+            # Rendezvous configuration
+            RDZV_PORT=29500
+
+            if [ "$RANK" -eq "0" ]; then
+              RDZV_HOST=$POD_IP
+              RDZV_CONF="is_host=1"
+              echo "Rank 0 - Rendezvous host: $RDZV_HOST:$RDZV_PORT"
+              sleep 5
+            else
+              echo "Rank 1 - Waiting for rank 0..."
+              sleep 15
+
+              # Discover rank 0 IP from headless service DNS
+              for i in {1..10}; do
+                RDZV_HOST=$(getent hosts training-ft-launcher-inprocess.${NAMESPACE}.svc.cluster.local | awk '{print $1}' | grep -v "$POD_IP" | head -1)
+                if [ ! -z "$RDZV_HOST" ]; then
+                  echo "Rank 1 - Found rank 0 IP: $RDZV_HOST (excluded own IP: $POD_IP)"
+                  break
+                fi
+                echo "Rank 1 - Waiting for rank 0 service endpoint... ($i/10)"
+                sleep 5
+              done
+
+              if [ -z "$RDZV_HOST" ]; then
+                echo "ERROR: Could not find rendezvous host"
+                exit 1
+              fi
+
+              RDZV_CONF="is_host=0"
+              echo "Rank 1 - Rendezvous host: $RDZV_HOST:$RDZV_PORT"
+            fi
+
+            # Required env vars for combined mode
+            # TORCH_NCCL_RETHROW_CUDA_ERRORS=0 lets inprocess.Wrapper catch
+            # NCCL errors instead of crashing the process.
+            export NCCL_NVLS_ENABLE=0
+            export TORCH_CPP_LOG_LEVEL=ERROR
+            export TORCH_NCCL_RETHROW_CUDA_ERRORS=0
+
+            # PG_MASTER_ADDR: rank 0 pod IP for cross-pod process group TCPStore.
+            export PG_MASTER_ADDR=$RDZV_HOST
+
+            # Launch training via ft_launcher with --inprocess flag
+            # Same ft_launcher config as in-job-only, but the training script
+            # additionally wraps the function with inprocess.Wrapper.
+            echo "Starting ft_launcher COMBINED (in-job + in-process) training..."
+            ft_launcher \
+              --nnodes=${NUM_NODES}:${NUM_NODES} \
+              --nproc_per_node=${GPU_PER_NODE} \
+              --max-restarts=5 \
+              --rdzv_backend=c10d \
+              --rdzv_endpoint=$RDZV_HOST:$RDZV_PORT \
+              --rdzv-conf="$RDZV_CONF" \
+              --ft-restart-policy=min-healthy \
+              --ft-rank-heartbeat-timeout=900 \
+              --ft-initial-rank-heartbeat-timeout=1200 \
+              --monitor-interval=5 \
+              /app/src/train_ft_launcher.py \
+                --model_name=${MODEL_NAME} \
+                --max_seq_length=${MAX_SEQ_LENGTH} \
+                --batch_size=${BATCH_SIZE} \
+                --learning_rate=${LEARNING_RATE} \
+                --inprocess \
+                --inject_faults \
+                --fault_count=5 \
+                --fault_seed=42 \
+                --fault_after_step=10 \
+                --fault_types=exception,sigkill \
+                --fault_type_weights=0.7,0.3 \
+                --max_steps=2000 \
+                --training_duration_minutes=120 \
+                --checkpoint_interval=500 \
+                --dataset_path=/checkpoints/c4_subset \
+                --nccl_timeout_seconds=60 \
+                --soft_timeout_seconds=300 \
+                --hard_timeout_seconds=600 \
+                --barrier_timeout_seconds=900
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ENABLE_INPROCESS
+          value: "1"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_DEBUG
+          value: "${NCCL_DEBUG}"
+        - name: NCCL_SOCKET_IFNAME
+          value: "^docker,lo,veth"
+        - name: NCCL_BUFFSIZE
+          value: "8388608"
+        - name: NCCL_P2P_NET_CHUNKSIZE
+          value: "2097152"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: NCCL_NVLS_ENABLE
+          value: "0"
+        - name: NCCL_TUNER_PLUGIN
+          value: "/opt/amazon/ofi-nccl/lib/libnccl-ofi-tuner.so"
+        - name: RDMAV_FORK_SAFE
+          value: "1"
+        - name: NCCL_NET_GDR_LEVEL
+          value: "5"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: FI_LOG_LEVEL
+          value: "warn"
+        - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+          value: "1"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: HF_HOME
+          value: "/checkpoints/.cache"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: huggingface-token
+              key: token
+        resources:
+          limits:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_LIMIT}"
+            cpu: "${CPU_LIMIT}"
+          requests:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_REQUEST}"
+            cpu: "${CPU_REQUEST}"
+        volumeMounts:
+        - name: checkpoints
+          mountPath: /checkpoints
+        - name: shm
+          mountPath: /dev/shm
+        securityContext:
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: checkpoints
+        persistentVolumeClaim:
+          claimName: ${FSX_PVC_NAME}
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      nodeSelector:
+        node-type: ${NODE_TYPE}
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: ${DEDICATED_TAINT_VALUE}
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-ft-launcher-inprocess
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: training-ft-launcher-inprocess
+  clusterIP: None
+  ports:
+  - port: 29500
+    targetPort: 29500

--- a/3.test_cases/pytorch/nvrx/kubernetes/training-job-ft-launcher.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/training-job-ft-launcher.yaml
@@ -1,0 +1,196 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-ft-launcher
+  namespace: ${NAMESPACE}
+spec:
+  parallelism: ${NUM_NODES}
+  completions: ${NUM_NODES}
+  completionMode: Indexed
+  ttlSecondsAfterFinished: 21600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: training-ft-launcher
+    spec:
+      restartPolicy: Never
+      serviceAccountName: default
+      containers:
+      - name: training
+        image: ${IMAGE_URI}
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Determine rank from Job completion index
+            RANK=$(echo $HOSTNAME | grep -o '[0-9]*$')
+            echo "Pod index: $RANK"
+
+            # Rendezvous configuration
+            RDZV_PORT=29500
+
+            if [ "$RANK" -eq "0" ]; then
+              RDZV_HOST=$POD_IP
+              RDZV_CONF="is_host=1"
+              echo "Rank 0 - Rendezvous host: $RDZV_HOST:$RDZV_PORT"
+              sleep 5
+            else
+              echo "Rank 1 - Waiting for rank 0..."
+              sleep 15
+
+              # Discover rank 0 IP from headless service DNS
+              for i in {1..10}; do
+                RDZV_HOST=$(getent hosts training-ft-launcher.${NAMESPACE}.svc.cluster.local | awk '{print $1}' | grep -v "$POD_IP" | head -1)
+                if [ ! -z "$RDZV_HOST" ]; then
+                  echo "Rank 1 - Found rank 0 IP: $RDZV_HOST (excluded own IP: $POD_IP)"
+                  break
+                fi
+                echo "Rank 1 - Waiting for rank 0 service endpoint... ($i/10)"
+                sleep 5
+              done
+
+              if [ -z "$RDZV_HOST" ]; then
+                echo "ERROR: Could not find rendezvous host"
+                exit 1
+              fi
+
+              RDZV_CONF="is_host=0"
+              echo "Rank 1 - Rendezvous host: $RDZV_HOST:$RDZV_PORT"
+            fi
+
+            # Required env vars
+            export NCCL_NVLS_ENABLE=0
+            export TORCH_CPP_LOG_LEVEL=ERROR
+
+            # PG_MASTER_ADDR: rank 0 pod IP for cross-pod process group TCPStore.
+            # ft_launcher sets MASTER_ADDR=localhost (per-pod), so workers need
+            # the actual rank 0 IP for the NCCL process group.
+            export PG_MASTER_ADDR=$RDZV_HOST
+
+            # Launch training via ft_launcher
+            #   --nnodes=2:2          Exactly 2 nodes required
+            #   --nproc_per_node=1    1 GPU per node
+            #   --max-restarts=20     ft_launcher can respawn workers up to 20 times
+            #   --rdzv_backend=c10d   Use c10d TCPStore for rendezvous
+            #   --ft-restart-policy=min-healthy   Only restart when healthy nodes < min
+            #   --ft-rank-heartbeat-timeout=900   Heartbeat timeout (must be > NCCL timeout)
+            #   --ft-initial-rank-heartbeat-timeout=1200   Initial timeout (model loading)
+            echo "Starting ft_launcher IN-JOB ONLY training..."
+            ft_launcher \
+              --nnodes=${NUM_NODES}:${NUM_NODES} \
+              --nproc_per_node=${GPU_PER_NODE} \
+              --max-restarts=20 \
+              --rdzv_backend=c10d \
+              --rdzv_endpoint=$RDZV_HOST:$RDZV_PORT \
+              --rdzv-conf="$RDZV_CONF" \
+              --ft-restart-policy=min-healthy \
+              --ft-rank-heartbeat-timeout=900 \
+              --ft-initial-rank-heartbeat-timeout=1200 \
+              --monitor-interval=5 \
+              /app/src/train_ft_launcher.py \
+                --model_name=${MODEL_NAME} \
+                --max_seq_length=${MAX_SEQ_LENGTH} \
+                --batch_size=${BATCH_SIZE} \
+                --learning_rate=${LEARNING_RATE} \
+                --inject_faults \
+                --fault_count=5 \
+                --fault_seed=42 \
+                --fault_after_step=10 \
+                --fault_types=exception,hang \
+                --fault_type_weights=0.6,0.4 \
+                --max_steps=2000 \
+                --training_duration_minutes=120 \
+                --checkpoint_interval=500 \
+                --dataset_path=/checkpoints/c4_subset \
+                --nccl_timeout_seconds=60
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_DEBUG
+          value: "${NCCL_DEBUG}"
+        - name: NCCL_SOCKET_IFNAME
+          value: "^docker,lo,veth"
+        - name: NCCL_BUFFSIZE
+          value: "8388608"
+        - name: NCCL_P2P_NET_CHUNKSIZE
+          value: "2097152"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: NCCL_NVLS_ENABLE
+          value: "0"
+        - name: NCCL_TUNER_PLUGIN
+          value: "/opt/amazon/ofi-nccl/lib/libnccl-ofi-tuner.so"
+        - name: RDMAV_FORK_SAFE
+          value: "1"
+        - name: NCCL_NET_GDR_LEVEL
+          value: "5"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: FI_LOG_LEVEL
+          value: "warn"
+        - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+          value: "1"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: HF_HOME
+          value: "/checkpoints/.cache"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: huggingface-token
+              key: token
+        resources:
+          limits:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_LIMIT}"
+            cpu: "${CPU_LIMIT}"
+          requests:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_REQUEST}"
+            cpu: "${CPU_REQUEST}"
+        volumeMounts:
+        - name: checkpoints
+          mountPath: /checkpoints
+        - name: shm
+          mountPath: /dev/shm
+        securityContext:
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: checkpoints
+        persistentVolumeClaim:
+          claimName: ${FSX_PVC_NAME}
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      nodeSelector:
+        node-type: ${NODE_TYPE}
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: ${DEDICATED_TAINT_VALUE}
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-ft-launcher
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: training-ft-launcher
+  clusterIP: None
+  ports:
+  - port: 29500
+    targetPort: 29500

--- a/3.test_cases/pytorch/nvrx/kubernetes/training-job-inprocess-baseline.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/training-job-inprocess-baseline.yaml
@@ -1,0 +1,183 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-inprocess-baseline
+  namespace: ${NAMESPACE}
+spec:
+  parallelism: ${NUM_NODES}
+  completions: ${NUM_NODES}
+  completionMode: Indexed
+  ttlSecondsAfterFinished: 21600
+  # Higher backoff: each fault causes rank 1 crash + rank 0 NCCL timeout crash
+  # + potential cascade restarts. ~3-4 failures per fault cycle.
+  backoffLimit: 30
+  template:
+    metadata:
+      labels:
+        app: training-inprocess-baseline
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: default
+      containers:
+      - name: training
+        image: ${IMAGE_URI}
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Determine node rank from hostname (K8s Indexed Job completion index)
+            NODE_RANK=$(echo $HOSTNAME | grep -o '[0-9]*$')
+            echo "Node rank: $NODE_RANK"
+            
+            if [ "$NODE_RANK" -eq "0" ]; then
+              export MASTER_ADDR=$POD_IP
+              export MASTER_PORT=29500
+              echo "Node 0 - Master address: $MASTER_ADDR:$MASTER_PORT"
+              sleep 10
+            else
+              echo "Node $NODE_RANK - Waiting for node 0..."
+              sleep 20
+              
+              export MASTER_PORT=29500
+              
+              for i in {1..10}; do
+                MASTER_IP=$(getent hosts training-inprocess-baseline.${NAMESPACE}.svc.cluster.local | awk '{print $1}' | grep -v "$POD_IP" | head -1)
+                if [ ! -z "$MASTER_IP" ]; then
+                  echo "Node $NODE_RANK - Found node 0 IP: $MASTER_IP (excluded own IP: $POD_IP)"
+                  export MASTER_ADDR=$MASTER_IP
+                  break
+                fi
+                echo "Node $NODE_RANK - Waiting for node 0 service endpoint... ($i/10)"
+                sleep 5
+              done
+              
+              if [ -z "$MASTER_ADDR" ]; then
+                echo "ERROR: Could not find master address"
+                exit 1
+              fi
+              
+              echo "Node $NODE_RANK - Master address: $MASTER_ADDR:$MASTER_PORT"
+            fi
+            
+            # In baseline mode, do NOT set TORCH_NCCL_RETHROW_CUDA_ERRORS=0.
+            # NCCL errors must crash the process so Kubernetes can restart it.
+            
+            # Launch with torchrun for multi-GPU per node.
+            # torchrun sets RANK, WORLD_SIZE, LOCAL_RANK automatically.
+            # Faults crash the container; Kubernetes restarts it via OnFailure.
+            echo "Starting BASELINE training (${GPU_PER_NODE} GPUs per node, no NVRx)..."
+            torchrun \
+              --nnodes=${NUM_NODES} \
+              --nproc_per_node=${GPU_PER_NODE} \
+              --node_rank=$NODE_RANK \
+              --master_addr=$MASTER_ADDR \
+              --master_port=$MASTER_PORT \
+              /app/src/train_inprocess.py \
+              --model_name=${MODEL_NAME} \
+              --max_seq_length=${MAX_SEQ_LENGTH} \
+              --batch_size=${BATCH_SIZE} \
+              --learning_rate=${LEARNING_RATE} \
+              --disable_nvrx_wrapper \
+              --inject_faults \
+              --fault_count=5 \
+              --fault_seed=42 \
+              --fault_after_step=10 \
+              --fault_types=exception,hang \
+              --fault_type_weights=0.6,0.4 \
+              --max_steps=2000 \
+              --training_duration_minutes=120 \
+              --checkpoint_interval=500 \
+              --dataset_path=/checkpoints/c4_subset \
+              --nccl_timeout_seconds=60
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: DISABLE_NVRX_WRAPPER
+          value: "1"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_DEBUG
+          value: "${NCCL_DEBUG}"
+        - name: NCCL_SOCKET_IFNAME
+          value: "^docker,lo,veth"
+        - name: NCCL_BUFFSIZE
+          value: "8388608"
+        - name: NCCL_P2P_NET_CHUNKSIZE
+          value: "2097152"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: NCCL_NVLS_ENABLE
+          value: "0"
+        - name: NCCL_TUNER_PLUGIN
+          value: "/opt/amazon/ofi-nccl/lib/libnccl-ofi-tuner.so"
+        - name: RDMAV_FORK_SAFE
+          value: "1"
+        - name: NCCL_NET_GDR_LEVEL
+          value: "5"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: FI_LOG_LEVEL
+          value: "warn"
+        - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+          value: "1"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: HF_HOME
+          value: "/checkpoints/.cache"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: huggingface-token
+              key: token
+        resources:
+          limits:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_LIMIT}"
+            cpu: "${CPU_LIMIT}"
+          requests:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_REQUEST}"
+            cpu: "${CPU_REQUEST}"
+        volumeMounts:
+        - name: checkpoints
+          mountPath: /checkpoints
+        - name: shm
+          mountPath: /dev/shm
+        securityContext:
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: checkpoints
+        persistentVolumeClaim:
+          claimName: ${FSX_PVC_NAME}
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      nodeSelector:
+        node-type: ${NODE_TYPE}
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: ${DEDICATED_TAINT_VALUE}
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-inprocess-baseline
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: training-inprocess-baseline
+  clusterIP: None
+  ports:
+  - port: 29500
+    targetPort: 29500

--- a/3.test_cases/pytorch/nvrx/kubernetes/training-job-inprocess.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/training-job-inprocess.yaml
@@ -1,0 +1,182 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-inprocess
+  namespace: ${NAMESPACE}
+spec:
+  parallelism: ${NUM_NODES}
+  completions: ${NUM_NODES}
+  completionMode: Indexed
+  ttlSecondsAfterFinished: 21600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: training-inprocess
+    spec:
+      restartPolicy: Never
+      serviceAccountName: default
+      containers:
+      - name: training
+        image: ${IMAGE_URI}
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Determine node rank from hostname (K8s Indexed Job completion index)
+            NODE_RANK=$(echo $HOSTNAME | grep -o '[0-9]*$')
+            echo "Node rank: $NODE_RANK"
+            
+            if [ "$NODE_RANK" -eq "0" ]; then
+              export MASTER_ADDR=$POD_IP
+              export MASTER_PORT=29500
+              echo "Node 0 - Master address: $MASTER_ADDR:$MASTER_PORT"
+              sleep 10
+            else
+              echo "Node $NODE_RANK - Waiting for node 0..."
+              sleep 20
+              
+              export MASTER_PORT=29500
+              
+              for i in {1..10}; do
+                MASTER_IP=$(getent hosts training-inprocess.${NAMESPACE}.svc.cluster.local | awk '{print $1}' | grep -v "$POD_IP" | head -1)
+                if [ ! -z "$MASTER_IP" ]; then
+                  echo "Node $NODE_RANK - Found node 0 IP: $MASTER_IP (excluded own IP: $POD_IP)"
+                  export MASTER_ADDR=$MASTER_IP
+                  break
+                fi
+                echo "Node $NODE_RANK - Waiting for node 0 service endpoint... ($i/10)"
+                sleep 5
+              done
+              
+              if [ -z "$MASTER_ADDR" ]; then
+                echo "ERROR: Could not find master address"
+                exit 1
+              fi
+              
+              echo "Node $NODE_RANK - Master address: $MASTER_ADDR:$MASTER_PORT"
+            fi
+            
+            # Required for NVRx in-process restart
+            export TORCH_CPP_LOG_LEVEL=error
+            export TORCH_NCCL_RETHROW_CUDA_ERRORS=0
+            
+            # Launch with torchrun for multi-GPU per node.
+            # torchrun sets RANK, WORLD_SIZE, LOCAL_RANK automatically.
+            # The in-process Wrapper manages process group lifecycle on restarts.
+            echo "Starting in-process restart training (${GPU_PER_NODE} GPUs per node)..."
+            torchrun \
+              --nnodes=${NUM_NODES} \
+              --nproc_per_node=${GPU_PER_NODE} \
+              --node_rank=$NODE_RANK \
+              --master_addr=$MASTER_ADDR \
+              --master_port=$MASTER_PORT \
+              /app/src/train_inprocess.py \
+              --model_name=${MODEL_NAME} \
+              --max_seq_length=${MAX_SEQ_LENGTH} \
+              --batch_size=${BATCH_SIZE} \
+              --learning_rate=${LEARNING_RATE} \
+              --inject_faults \
+              --fault_count=5 \
+              --fault_seed=42 \
+              --fault_after_step=10 \
+              --fault_types=exception \
+              --max_steps=2000 \
+              --training_duration_minutes=120 \
+              --checkpoint_interval=500 \
+              --dataset_path=/checkpoints/c4_subset \
+              --max_restarts=30 \
+              --soft_timeout_seconds=300 \
+              --hard_timeout_seconds=600 \
+              --barrier_timeout_seconds=900 \
+              --nccl_timeout_seconds=60
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_DEBUG
+          value: "${NCCL_DEBUG}"
+        - name: NCCL_SOCKET_IFNAME
+          value: "^docker,lo,veth"
+        - name: NCCL_BUFFSIZE
+          value: "8388608"
+        - name: NCCL_P2P_NET_CHUNKSIZE
+          value: "2097152"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: NCCL_NVLS_ENABLE
+          value: "0"
+        - name: NCCL_TUNER_PLUGIN
+          value: "/opt/amazon/ofi-nccl/lib/libnccl-ofi-tuner.so"
+        - name: RDMAV_FORK_SAFE
+          value: "1"
+        - name: NCCL_NET_GDR_LEVEL
+          value: "5"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: FI_LOG_LEVEL
+          value: "warn"
+        - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+          value: "1"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: HF_HOME
+          value: "/checkpoints/.cache"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: huggingface-token
+              key: token
+        resources:
+          limits:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_LIMIT}"
+            cpu: "${CPU_LIMIT}"
+          requests:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_REQUEST}"
+            cpu: "${CPU_REQUEST}"
+        volumeMounts:
+        - name: checkpoints
+          mountPath: /checkpoints
+        - name: shm
+          mountPath: /dev/shm
+        securityContext:
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: checkpoints
+        persistentVolumeClaim:
+          claimName: ${FSX_PVC_NAME}
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      nodeSelector:
+        node-type: ${NODE_TYPE}
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: ${DEDICATED_TAINT_VALUE}
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-inprocess
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: training-inprocess
+  clusterIP: None
+  ports:
+  - port: 29500
+    targetPort: 29500

--- a/3.test_cases/pytorch/nvrx/kubernetes/training-job-local-ckpt-baseline.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/training-job-local-ckpt-baseline.yaml
@@ -1,0 +1,165 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-local-ckpt-baseline
+  namespace: ${NAMESPACE}
+spec:
+  parallelism: ${NUM_NODES}
+  completions: ${NUM_NODES}
+  completionMode: Indexed
+  ttlSecondsAfterFinished: 21600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: training-local-ckpt-baseline
+    spec:
+      restartPolicy: Never
+      serviceAccountName: default
+      containers:
+      - name: training
+        image: ${IMAGE_URI}
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Determine rank from Job completion index
+            RANK=$(echo $HOSTNAME | grep -o '[0-9]*$')
+            echo "Pod index: $RANK"
+
+            if [ "$RANK" -eq "0" ]; then
+              export MASTER_ADDR=$POD_IP
+              export MASTER_PORT=29500
+              echo "Rank 0 - Master address: $MASTER_ADDR:$MASTER_PORT"
+              sleep 5
+            else
+              echo "Rank 1 - Waiting for rank 0..."
+              sleep 15
+
+              # Discover rank 0 IP from headless service DNS (exclude own IP)
+              for i in {1..10}; do
+                MASTER_IP=$(getent hosts training-local-ckpt-baseline.${NAMESPACE}.svc.cluster.local | awk '{print $1}' | grep -v "$POD_IP" | head -1)
+                if [ ! -z "$MASTER_IP" ]; then
+                  echo "Rank 1 - Found rank 0 IP: $MASTER_IP (excluded own IP: $POD_IP)"
+                  export MASTER_ADDR=$MASTER_IP
+                  export MASTER_PORT=29500
+                  break
+                fi
+                echo "Rank 1 - Waiting for rank 0 service endpoint... ($i/10)"
+                sleep 5
+              done
+
+              if [ -z "$MASTER_ADDR" ]; then
+                echo "ERROR: Could not find master address"
+                exit 1
+              fi
+
+              echo "Rank 1 - Master address: $MASTER_ADDR:$MASTER_PORT"
+            fi
+
+            # Standard torch.save (no --use_local_checkpoint flag)
+            echo "Starting standard checkpoint baseline training..."
+            python -m torch.distributed.run \
+              --nproc_per_node=${GPU_PER_NODE} \
+              --nnodes=${NUM_NODES} \
+              --node_rank=$RANK \
+              --master_addr=$MASTER_ADDR \
+              --master_port=$MASTER_PORT \
+              /app/src/train_local_ckpt.py \
+                --model_name=${MODEL_NAME} \
+                --max_seq_length=${MAX_SEQ_LENGTH} \
+                --batch_size=${BATCH_SIZE} \
+                --learning_rate=${LEARNING_RATE} \
+                --training_duration_minutes=30 \
+                --checkpoint_interval=200 \
+                --nccl_timeout_seconds=60
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_DEBUG
+          value: "${NCCL_DEBUG}"
+        - name: NCCL_SOCKET_IFNAME
+          value: "^docker,lo,veth"
+        - name: NCCL_BUFFSIZE
+          value: "8388608"
+        - name: NCCL_P2P_NET_CHUNKSIZE
+          value: "2097152"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: NCCL_NVLS_ENABLE
+          value: "0"
+        - name: NCCL_TUNER_PLUGIN
+          value: "/opt/amazon/ofi-nccl/lib/libnccl-ofi-tuner.so"
+        - name: RDMAV_FORK_SAFE
+          value: "1"
+        - name: NCCL_NET_GDR_LEVEL
+          value: "5"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: FI_LOG_LEVEL
+          value: "warn"
+        - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+          value: "1"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: HF_HOME
+          value: "/checkpoints/.cache"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: huggingface-token
+              key: token
+        resources:
+          limits:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_LIMIT}"
+            cpu: "${CPU_LIMIT}"
+          requests:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_REQUEST}"
+            cpu: "${CPU_REQUEST}"
+        volumeMounts:
+        - name: checkpoints
+          mountPath: /checkpoints
+        - name: shm
+          mountPath: /dev/shm
+        securityContext:
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: checkpoints
+        persistentVolumeClaim:
+          claimName: ${FSX_PVC_NAME}
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      nodeSelector:
+        node-type: ${NODE_TYPE}
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: ${DEDICATED_TAINT_VALUE}
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-local-ckpt-baseline
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: training-local-ckpt-baseline
+  clusterIP: None
+  ports:
+  - port: 29500
+    targetPort: 29500

--- a/3.test_cases/pytorch/nvrx/kubernetes/training-job-local-ckpt.yaml
+++ b/3.test_cases/pytorch/nvrx/kubernetes/training-job-local-ckpt.yaml
@@ -1,0 +1,165 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-local-ckpt
+  namespace: ${NAMESPACE}
+spec:
+  parallelism: ${NUM_NODES}
+  completions: ${NUM_NODES}
+  completionMode: Indexed
+  ttlSecondsAfterFinished: 21600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: training-local-ckpt
+    spec:
+      restartPolicy: Never
+      serviceAccountName: default
+      containers:
+      - name: training
+        image: ${IMAGE_URI}
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Determine rank from Job completion index
+            RANK=$(echo $HOSTNAME | grep -o '[0-9]*$')
+            echo "Pod index: $RANK"
+
+            if [ "$RANK" -eq "0" ]; then
+              export MASTER_ADDR=$POD_IP
+              export MASTER_PORT=29500
+              echo "Rank 0 - Master address: $MASTER_ADDR:$MASTER_PORT"
+              sleep 5
+            else
+              echo "Rank 1 - Waiting for rank 0..."
+              sleep 15
+
+              # Discover rank 0 IP from headless service DNS (exclude own IP)
+              for i in {1..10}; do
+                MASTER_IP=$(getent hosts training-local-ckpt.${NAMESPACE}.svc.cluster.local | awk '{print $1}' | grep -v "$POD_IP" | head -1)
+                if [ ! -z "$MASTER_IP" ]; then
+                  echo "Rank 1 - Found rank 0 IP: $MASTER_IP (excluded own IP: $POD_IP)"
+                  export MASTER_ADDR=$MASTER_IP
+                  export MASTER_PORT=29500
+                  break
+                fi
+                echo "Rank 1 - Waiting for rank 0 service endpoint... ($i/10)"
+                sleep 5
+              done
+
+              if [ -z "$MASTER_ADDR" ]; then
+                echo "ERROR: Could not find master address"
+                exit 1
+              fi
+
+              echo "Rank 1 - Master address: $MASTER_ADDR:$MASTER_PORT"
+            fi
+
+            echo "Starting local checkpoint training..."
+            python -m torch.distributed.run \
+              --nproc_per_node=${GPU_PER_NODE} \
+              --nnodes=${NUM_NODES} \
+              --node_rank=$RANK \
+              --master_addr=$MASTER_ADDR \
+              --master_port=$MASTER_PORT \
+              /app/src/train_local_ckpt.py \
+                --model_name=${MODEL_NAME} \
+                --max_seq_length=${MAX_SEQ_LENGTH} \
+                --batch_size=${BATCH_SIZE} \
+                --learning_rate=${LEARNING_RATE} \
+                --use_local_checkpoint \
+                --training_duration_minutes=30 \
+                --checkpoint_interval=200 \
+                --nccl_timeout_seconds=60
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_DEBUG
+          value: "${NCCL_DEBUG}"
+        - name: NCCL_SOCKET_IFNAME
+          value: "^docker,lo,veth"
+        - name: NCCL_BUFFSIZE
+          value: "8388608"
+        - name: NCCL_P2P_NET_CHUNKSIZE
+          value: "2097152"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: NCCL_NVLS_ENABLE
+          value: "0"
+        - name: NCCL_TUNER_PLUGIN
+          value: "/opt/amazon/ofi-nccl/lib/libnccl-ofi-tuner.so"
+        - name: RDMAV_FORK_SAFE
+          value: "1"
+        - name: NCCL_NET_GDR_LEVEL
+          value: "5"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: FI_LOG_LEVEL
+          value: "warn"
+        - name: TORCH_NCCL_ASYNC_ERROR_HANDLING
+          value: "1"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
+        - name: HF_HOME
+          value: "/checkpoints/.cache"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: huggingface-token
+              key: token
+        resources:
+          limits:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_LIMIT}"
+            cpu: "${CPU_LIMIT}"
+          requests:
+            nvidia.com/gpu: ${GPU_PER_NODE}
+            vpc.amazonaws.com/efa: ${EFA_PER_NODE}
+            memory: "${MEMORY_REQUEST}"
+            cpu: "${CPU_REQUEST}"
+        volumeMounts:
+        - name: checkpoints
+          mountPath: /checkpoints
+        - name: shm
+          mountPath: /dev/shm
+        securityContext:
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: checkpoints
+        persistentVolumeClaim:
+          claimName: ${FSX_PVC_NAME}
+      - name: shm
+        hostPath:
+          path: /dev/shm
+      nodeSelector:
+        node-type: ${NODE_TYPE}
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: ${DEDICATED_TAINT_VALUE}
+        effect: NoSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-local-ckpt
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: training-local-ckpt
+  clusterIP: None
+  ports:
+  - port: 29500
+    targetPort: 29500

--- a/3.test_cases/pytorch/nvrx/prepare_dataset.py
+++ b/3.test_cases/pytorch/nvrx/prepare_dataset.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Pre-download a subset of the training dataset to local storage.
+
+Downloads N samples from the HuggingFace Hub and saves them as an Arrow
+dataset on the local/shared filesystem. This eliminates HuggingFace API
+calls during training, preventing 429 rate-limiting errors when
+ft_launcher or K8s restarts spawn many workers simultaneously.
+
+Usage:
+    python prepare_dataset.py --output_path /checkpoints/c4_subset
+    python prepare_dataset.py --output_path /checkpoints/c4_subset --num_samples 100000
+    python prepare_dataset.py --dataset_name allenai/c4 --subset en --num_samples 50000
+
+The saved dataset can be used in training with:
+    --dataset_path /checkpoints/c4_subset
+
+Without --dataset_path, training scripts fall back to HF streaming
+(the original behavior).
+"""
+
+import argparse
+import time
+from datasets import load_dataset, Dataset
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pre-download dataset subset to local storage"
+    )
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        default="allenai/c4",
+        help="HuggingFace dataset name (default: allenai/c4)",
+    )
+    parser.add_argument(
+        "--subset",
+        type=str,
+        default="en",
+        help="Dataset subset/config (default: en)",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="train",
+        help="Dataset split (default: train)",
+    )
+    parser.add_argument(
+        "--num_samples",
+        type=int,
+        default=100000,
+        help="Number of samples to download (default: 100000)",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        required=True,
+        help="Path to save the dataset (e.g., /checkpoints/c4_subset)",
+    )
+    args = parser.parse_args()
+
+    print(
+        f"Downloading {args.num_samples} samples from {args.dataset_name}/{args.subset}..."
+    )
+    start = time.time()
+
+    # Stream from HF and collect N samples
+    ds_stream = load_dataset(
+        args.dataset_name,
+        args.subset,
+        split=args.split,
+        streaming=True,
+        trust_remote_code=True,
+    )
+
+    samples = []
+    for i, sample in enumerate(ds_stream):
+        if i >= args.num_samples:
+            break
+        samples.append(sample)
+        if (i + 1) % 10000 == 0:
+            print(f"  Downloaded {i + 1}/{args.num_samples} samples...")
+
+    elapsed = time.time() - start
+    print(f"Downloaded {len(samples)} samples in {elapsed:.1f}s")
+
+    # Save as Arrow dataset
+    print(f"Saving to {args.output_path}...")
+    dataset = Dataset.from_list(samples)
+    dataset.save_to_disk(args.output_path)
+
+    # Report size
+    import os
+
+    total_size = sum(
+        os.path.getsize(os.path.join(dirpath, f))
+        for dirpath, _, filenames in os.walk(args.output_path)
+        for f in filenames
+    )
+    print(
+        f"Saved {len(samples)} samples to {args.output_path} ({total_size / 1e6:.1f} MB)"
+    )
+    print("Done! Use --dataset_path in training scripts to load this dataset.")
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/pytorch/nvrx/requirements.txt
+++ b/3.test_cases/pytorch/nvrx/requirements.txt
@@ -1,0 +1,33 @@
+# Core ML frameworks - Compatible with PyTorch 2.9.0
+torch==2.9.0
+torchvision==0.24.0
+torchaudio==2.9.0
+
+# Distributed training
+accelerate==1.2.1
+
+# HuggingFace - Latest stable versions
+transformers==4.48.0
+datasets==3.2.0
+huggingface-hub==0.27.1
+tokenizers==0.21.0
+
+# Data processing
+numpy==1.26.4
+tqdm==4.67.1
+pandas==2.2.3
+pyarrow==18.1.0
+
+# AWS
+boto3==1.35.0
+botocore==1.35.0
+
+# Utilities
+pyyaml==6.0.2
+python-json-logger==2.0.7
+requests==2.32.3
+filelock==3.16.1
+packaging==24.2
+
+# NVRx will be installed separately in Dockerfile
+# nvidia-resiliency-ext==0.4.1

--- a/3.test_cases/pytorch/nvrx/src/distributed_utils.py
+++ b/3.test_cases/pytorch/nvrx/src/distributed_utils.py
@@ -1,0 +1,587 @@
+"""
+Shared distributed training utilities.
+
+Provides strategy-agnostic model creation, wrapping, checkpointing, and
+dataloader helpers that work with both FSDP and DDP.
+
+Usage in training scripts::
+
+    from distributed_utils import (
+        add_distributed_args,
+        create_model,
+        wrap_model,
+        create_dataloader,
+        train_step,
+        save_checkpoint,
+        load_checkpoint,
+    )
+"""
+
+import os
+import sys
+import logging
+import functools
+import gc
+
+import torch
+import torch.distributed as dist
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from datasets import load_dataset, load_from_disk
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Supported parallelism strategies
+# ---------------------------------------------------------------------------
+STRATEGIES = ("fsdp", "ddp")
+
+# Map user-facing dtype strings to torch dtypes
+_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+}
+
+
+def _to_cpu(obj):
+    """Recursively move all tensors in a nested dict/list to CPU.
+
+    Also handles ``ShardedTensor`` objects produced by FSDP
+    ``LOCAL_STATE_DICT``: extracts the local shard and moves it to CPU.
+    """
+    if type(obj).__name__ == "ShardedTensor":
+        local_shards = obj.local_shards()
+        if local_shards:
+            return local_shards[0].tensor.cpu()
+        return obj
+    if isinstance(obj, torch.Tensor):
+        return obj.cpu()
+    elif isinstance(obj, dict):
+        return {k: _to_cpu(v) for k, v in obj.items()}
+    elif isinstance(obj, (list, tuple)):
+        return type(obj)(_to_cpu(v) for v in obj)
+    return obj
+
+
+def _find_latest_dcp_checkpoint(checkpoint_path: str) -> int:
+    """Find the latest DCP checkpoint step number in *checkpoint_path*.
+
+    DCP checkpoints are stored in subdirectories named ``dcp_step_<N>/``.
+    Returns the highest step number found, or -1 if no DCP checkpoints exist.
+    """
+    import glob as glob_module
+
+    pattern = os.path.join(checkpoint_path, "dcp_step_*")
+    dirs = [d for d in glob_module.glob(pattern) if os.path.isdir(d)]
+    if not dirs:
+        return -1
+
+    steps = []
+    for d in dirs:
+        basename = os.path.basename(d)
+        try:
+            step = int(basename.split("_")[-1])
+            steps.append(step)
+        except (ValueError, IndexError):
+            continue
+
+    return max(steps) if steps else -1
+
+
+# ---------------------------------------------------------------------------
+# CLI argument helpers
+# ---------------------------------------------------------------------------
+def add_distributed_args(parser):
+    """Add --parallel_strategy, --torch_dtype, --model_name to *parser*.
+
+    These args are common across every training script.  Call this from each
+    script's ``parse_args()`` so the flags are consistent everywhere.
+    """
+    parser.add_argument(
+        "--parallel_strategy",
+        type=str,
+        default="fsdp",
+        choices=STRATEGIES,
+        help="Distributed parallelism strategy: fsdp or ddp (default: fsdp)",
+    )
+    parser.add_argument(
+        "--torch_dtype",
+        type=str,
+        default="bfloat16",
+        choices=list(_DTYPE_MAP.keys()),
+        help="Model precision: bfloat16, float16, float32 (default: bfloat16)",
+    )
+    # --model_name is already defined in most scripts, so only add if missing
+    if not any(
+        a.option_strings and "--model_name" in a.option_strings for a in parser._actions
+    ):
+        parser.add_argument(
+            "--model_name",
+            type=str,
+            default="gpt2",
+            help="HuggingFace model name or path",
+        )
+    parser.add_argument(
+        "--log_level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level for rank 0 (default: INFO)",
+    )
+    parser.add_argument(
+        "--log_all_ranks",
+        action="store_true",
+        default=False,
+        help="Log at full verbosity on all ranks (default: rank 0 only)",
+    )
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Logging setup
+# ---------------------------------------------------------------------------
+_NOISY_LOGGERS = (
+    "httpx",
+    "httpcore",
+    "huggingface_hub",
+    "datasets",
+    "urllib3",
+    "filelock",
+)
+
+
+def setup_logging(rank: int, log_level: str = "INFO", log_all_ranks: bool = False):
+    """Configure logging so only rank 0 is verbose by default.
+
+    - Rank 0: logs at *log_level* (default INFO).
+    - Rank != 0: logs at WARNING only (errors/warnings still surface).
+    - ``log_all_ranks=True`` restores full output on every rank.
+    - Third-party noisy loggers are silenced to WARNING on all ranks.
+    """
+    level = getattr(logging, log_level.upper(), logging.INFO)
+    effective_level = level if (rank == 0 or log_all_ranks) else logging.WARNING
+
+    logging.basicConfig(
+        level=effective_level,
+        format=f"[Rank {rank}] %(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+        force=True,
+    )
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
+    return logging.getLogger(__name__)
+
+
+def get_torch_dtype(dtype_str: str) -> torch.dtype:
+    """Convert a string dtype name to a ``torch.dtype``."""
+    return _DTYPE_MAP[dtype_str]
+
+
+# ---------------------------------------------------------------------------
+# Model creation
+# ---------------------------------------------------------------------------
+def create_model(model_name: str, dtype_str: str = "bfloat16"):
+    """Load a HuggingFace causal LM and its tokenizer.
+
+    The model is moved to the current CUDA device and cast to *dtype_str*.
+    The tokenizer's pad token is set to eos_token if not already defined.
+
+    Returns:
+        (model, tokenizer) tuple
+    """
+    torch_dtype = get_torch_dtype(dtype_str)
+
+    logger.info(f"Loading model: {model_name} (dtype={dtype_str})")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype=torch_dtype,
+        device_map=None,
+    )
+    model = model.to(torch.cuda.current_device())
+    return model, tokenizer
+
+
+# ---------------------------------------------------------------------------
+# Model wrapping (FSDP / DDP)
+# ---------------------------------------------------------------------------
+def wrap_model(model, strategy: str, local_rank: int, model_name: str = "gpt2"):
+    """Wrap *model* with the requested distributed parallelism strategy.
+
+    Args:
+        model: A PyTorch module already on the correct CUDA device.
+        strategy: ``"fsdp"`` or ``"ddp"``.
+        local_rank: Local rank (used as device id).
+        model_name: Model name, used to select FSDP auto-wrap policy.
+
+    Returns:
+        The wrapped model.
+    """
+    if strategy == "fsdp":
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+        from fsdp_config import get_fsdp_config
+
+        fsdp_config = get_fsdp_config(model_name)
+        model = FSDP(model, device_id=torch.cuda.current_device(), **fsdp_config)
+        logger.info("Model wrapped with FSDP")
+
+    elif strategy == "ddp":
+        from torch.nn.parallel import DistributedDataParallel as DDP
+
+        model = DDP(model, device_ids=[local_rank])
+        logger.info("Model wrapped with DDP")
+
+    else:
+        raise ValueError(
+            f"Unknown parallel strategy: {strategy!r}. Choose from {STRATEGIES}"
+        )
+
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Dataloader
+# ---------------------------------------------------------------------------
+def create_dataloader(args, tokenizer, rank: int, world_size: int):
+    """Create a DataLoader for causal-LM training.
+
+    Supports two modes:
+      1. **Local dataset** (``args.dataset_path`` is set) -- loads a
+         pre-downloaded Arrow dataset from disk with zero HF API calls.
+      2. **Streaming** (default) -- streams from HuggingFace Hub.
+
+    Expects *args* to have ``dataset_name``, ``streaming``, ``max_seq_length``,
+    and ``batch_size`` attributes.  ``dataset_path`` is optional.
+    """
+    dataset_path = getattr(args, "dataset_path", None)
+    if dataset_path:
+        logger.info("Loading pre-downloaded dataset from %s", dataset_path)
+        dataset = load_from_disk(dataset_path)
+    else:
+        dataset = load_dataset(
+            args.dataset_name,
+            "en",
+            split="train",
+            streaming=args.streaming,
+            trust_remote_code=True,
+        )
+
+    def collate_fn(batch):
+        texts = [item["text"] for item in batch]
+        encodings = tokenizer(
+            texts,
+            truncation=True,
+            max_length=args.max_seq_length,
+            padding=True,
+            return_tensors="pt",
+        )
+        return {
+            "input_ids": encodings["input_ids"],
+            "attention_mask": encodings["attention_mask"],
+            "labels": encodings["input_ids"].clone(),
+        }
+
+    if world_size > 1:
+        dataset = dataset.shard(num_shards=world_size, index=rank)
+
+    from torch.utils.data import DataLoader
+
+    return DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        collate_fn=collate_fn,
+        num_workers=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Training step
+# ---------------------------------------------------------------------------
+def train_step(model, batch, optimizer):
+    """Execute one training step.  Returns the scalar loss value."""
+    input_ids = batch["input_ids"].cuda()
+    attention_mask = batch["attention_mask"].cuda()
+    labels = batch["labels"].cuda()
+
+    outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=labels)
+    loss = outputs.loss
+
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+
+    return loss.item()
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint save / load
+# ---------------------------------------------------------------------------
+def save_checkpoint(
+    model,
+    optimizer,
+    step: int,
+    checkpoint_path: str,
+    rank: int,
+    strategy: str,
+    call_wrapper=None,
+    extra_state: dict | None = None,
+):
+    """Save a training checkpoint using DCP for FSDP or torch.save for DDP.
+
+    For FSDP, uses ``torch.distributed.checkpoint`` (DCP) which natively
+    handles sharded state dicts.  DCP writes per-rank shard files into a
+    subdirectory ``dcp_step_<N>/`` and can load them back correctly
+    regardless of the world size or sharding.  Extra state (step number,
+    ft_client state, etc.) is saved as a separate ``extra_step_<N>.pt``
+    file alongside the DCP directory.
+
+    For DDP, all ranks save their full model state via ``torch.save``.
+
+    Args:
+        model: Wrapped model (FSDP or DDP).
+        optimizer: Optimizer.
+        step: Current training step.
+        checkpoint_path: Directory to write into.
+        rank: Global rank.
+        strategy: ``"fsdp"`` or ``"ddp"``.
+        call_wrapper: Optional NVRx ``CallWrapper`` for atomic saves.
+        extra_state: Optional dict of additional state to persist
+            (e.g. ``ft_client.state_dict()``).
+
+    Returns:
+        (path, save_time) tuple.
+    """
+    os.makedirs(checkpoint_path, exist_ok=True)
+
+    import time
+
+    start_time = time.time()
+
+    if strategy == "fsdp":
+        import torch.distributed.checkpoint as dcp
+        from torch.distributed.checkpoint.state_dict import (
+            get_state_dict,
+            StateDictOptions,
+        )
+
+        # Get FSDP-aware state dicts using the new DCP API.
+        # This returns shardable state dicts that DCP can save natively.
+        model_state, optim_state = get_state_dict(
+            model,
+            optimizer,
+            options=StateDictOptions(full_state_dict=False, cpu_offload=True),
+        )
+
+        state_dict = {
+            "model": model_state,
+            "optimizer": optim_state,
+        }
+
+        # DCP save is collective -- all ranks must call.
+        ckpt_dir = os.path.join(checkpoint_path, f"dcp_step_{step}")
+        if call_wrapper is not None:
+            with call_wrapper.atomic():
+                dcp.save(state_dict, checkpoint_id=ckpt_dir)
+        else:
+            dcp.save(state_dict, checkpoint_id=ckpt_dir)
+
+        # Save extra state (step number, ft_client, etc.) as a plain file.
+        # Only rank 0 writes this to avoid conflicts.
+        extra_path = os.path.join(checkpoint_path, f"extra_step_{step}.pt")
+        extra = {"step": step, "parallel_strategy": strategy}
+        if extra_state:
+            extra.update(extra_state)
+        if rank == 0:
+            torch.save(extra, extra_path)
+
+        path = ckpt_dir
+
+    else:
+        # DDP: save full state dict via torch.save (non-collective)
+        model_state = model.state_dict()
+        optim_state = optimizer.state_dict()
+
+        checkpoint = {
+            "step": step,
+            "model_state_dict": model_state,
+            "optimizer_state_dict": optim_state,
+            "parallel_strategy": strategy,
+        }
+        if extra_state:
+            checkpoint.update(extra_state)
+
+        checkpoint = _to_cpu(checkpoint)
+
+        path = os.path.join(checkpoint_path, f"checkpoint_step_{step}_rank_{rank}.pt")
+
+        if call_wrapper is not None:
+            with call_wrapper.atomic():
+                torch.save(checkpoint, path)
+        else:
+            torch.save(checkpoint, path)
+
+        del checkpoint
+
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    save_time = time.time() - start_time
+    return path, save_time
+
+
+def load_checkpoint(
+    checkpoint_path: str,
+    model,
+    optimizer,
+    rank: int,
+    strategy: str,
+    extra_loaders: dict | None = None,
+):
+    """Load a training checkpoint if one exists.
+
+    For FSDP, uses ``torch.distributed.checkpoint`` (DCP) to load sharded
+    state dicts from a ``dcp_step_<N>/`` directory.  DCP handles the
+    ShardedTensor/DTensor deserialization natively.
+
+    For DDP, loads from per-rank ``checkpoint_step_<N>_rank_<R>.pt`` files
+    or the legacy ``latest_checkpoint.pt``.
+
+    Handles DDP ``module.`` prefix mismatches transparently.
+
+    Args:
+        checkpoint_path: Directory containing checkpoint files.
+        model: Wrapped model.
+        optimizer: Optimizer.
+        rank: Global rank.
+        strategy: ``"fsdp"`` or ``"ddp"``.
+        extra_loaders: Optional dict of ``{key: callback(value)}`` for
+            restoring additional state (e.g. ft_client).
+
+    Returns:
+        (start_step, extra_values) -- *extra_values* is a dict of the raw
+        checkpoint values for each key in *extra_loaders* (or empty dict).
+    """
+    extra_values = {}
+
+    if strategy == "fsdp":
+        # Find the latest DCP checkpoint directory
+        latest_step = _find_latest_dcp_checkpoint(checkpoint_path)
+        if latest_step < 0:
+            return 0, extra_values
+
+        ckpt_dir = os.path.join(checkpoint_path, f"dcp_step_{latest_step}")
+
+        try:
+            import torch.distributed.checkpoint as dcp
+            from torch.distributed.checkpoint.state_dict import (
+                get_state_dict,
+                set_state_dict,
+                StateDictOptions,
+            )
+
+            # Get empty state dicts with the correct structure for DCP to fill.
+            model_state, optim_state = get_state_dict(
+                model,
+                optimizer,
+                options=StateDictOptions(full_state_dict=False, cpu_offload=True),
+            )
+
+            state_dict = {
+                "model": model_state,
+                "optimizer": optim_state,
+            }
+
+            # DCP load is collective -- all ranks must call.
+            dcp.load(state_dict, checkpoint_id=ckpt_dir)
+
+            # Apply the loaded state dicts back to model and optimizer.
+            set_state_dict(
+                model,
+                optimizer,
+                model_state_dict=state_dict["model"],
+                optim_state_dict=state_dict["optimizer"],
+                options=StateDictOptions(full_state_dict=False),
+            )
+
+            # Load extra state (step number, ft_client, etc.)
+            extra_path = os.path.join(checkpoint_path, f"extra_step_{latest_step}.pt")
+            start_step = latest_step
+            if os.path.exists(extra_path):
+                local_rank = int(os.environ.get("LOCAL_RANK", 0))
+                extra = torch.load(extra_path, map_location=f"cuda:{local_rank}")
+                start_step = extra.get("step", latest_step)
+
+                if extra_loaders:
+                    for key, loader_fn in extra_loaders.items():
+                        if key in extra:
+                            loader_fn(extra[key])
+                            extra_values[key] = extra[key]
+
+            logger.info(
+                f"Loaded DCP checkpoint from step {start_step} "
+                f"(dir={os.path.basename(ckpt_dir)})"
+            )
+            return start_step, extra_values
+
+        except Exception as e:
+            logger.warning(f"Failed to load DCP checkpoint: {e}")
+            return 0, extra_values
+
+    else:
+        # DDP: load from per-rank torch.save files
+        import glob as glob_module
+
+        pattern = os.path.join(checkpoint_path, f"checkpoint_step_*_rank_{rank}.pt")
+        rank_files = sorted(glob_module.glob(pattern))
+        if rank_files:
+            path = rank_files[-1]
+        else:
+            path = os.path.join(checkpoint_path, "latest_checkpoint.pt")
+
+        if not os.path.exists(path):
+            return 0, extra_values
+
+        try:
+            local_rank = int(os.environ.get("LOCAL_RANK", 0))
+            ckpt = torch.load(path, map_location=f"cuda:{local_rank}")
+
+            saved_state = ckpt["model_state_dict"]
+
+            # Handle DDP module. prefix mismatch
+            model_keys = set(model.state_dict().keys())
+            saved_keys = set(saved_state.keys())
+            if model_keys and saved_keys and model_keys != saved_keys:
+                if all(k.startswith("module.") for k in model_keys) and not any(
+                    k.startswith("module.") for k in saved_keys
+                ):
+                    saved_state = {"module." + k: v for k, v in saved_state.items()}
+                elif not any(k.startswith("module.") for k in model_keys) and all(
+                    k.startswith("module.") for k in saved_keys
+                ):
+                    saved_state = {
+                        k.replace("module.", "", 1): v for k, v in saved_state.items()
+                    }
+
+            model.load_state_dict(saved_state)
+            optimizer.load_state_dict(ckpt["optimizer_state_dict"])
+
+            if extra_loaders:
+                for key, loader_fn in extra_loaders.items():
+                    if key in ckpt:
+                        loader_fn(ckpt[key])
+                        extra_values[key] = ckpt[key]
+
+            start_step = ckpt["step"]
+            logger.info(
+                f"Loaded checkpoint from step {start_step} "
+                f"(strategy={ckpt.get('parallel_strategy', 'unknown')}, "
+                f"file={os.path.basename(path)})"
+            )
+            return start_step, extra_values
+
+        except Exception as e:
+            logger.warning(f"Failed to load checkpoint: {e}")
+            return 0, extra_values

--- a/3.test_cases/pytorch/nvrx/src/failure_simulator.py
+++ b/3.test_cases/pytorch/nvrx/src/failure_simulator.py
@@ -1,0 +1,343 @@
+"""
+Configurable Fault Injector for NVRx Resiliency Testing
+
+Supports three fault types that exercise different recovery paths:
+
+  exception  -- raise RuntimeError. Caught by NVRx in-process Wrapper
+               (sub-second recovery) or causes worker crash for ft_launcher
+               in-job restart.
+
+  sigkill    -- os.kill(os.getpid(), SIGKILL). Instantly kills the worker
+               process. In-process Wrapper cannot catch this; only
+               ft_launcher in-job restart (or K8s container restart in
+               baseline mode) can recover.
+
+  hang       -- time.sleep(999999). Simulates a stuck process (e.g. NCCL
+               deadlock, GPU hang). Detected by in-process Wrapper's soft
+               timeout or ft_launcher's heartbeat timeout.
+
+Fault injection modes:
+
+  Stochastic (--fault_probability):
+    Each rank independently rolls per step. Total faults vary between runs.
+
+  Deterministic (--fault_count + --fault_seed):
+    Pre-generates exactly N faults at random steps, each targeting a random
+    non-zero rank. Both experiments using the same seed get identical fault
+    patterns, making the comparison fair. Ignores --fault_probability.
+
+Usage (stochastic):
+    injector = FaultInjector(
+        fault_types=["exception", "sigkill"],
+        weights=[0.7, 0.3],
+        probability=0.002,
+        after_step=50,
+    )
+
+Usage (deterministic):
+    injector = FaultInjector(
+        fault_types=["exception"],
+        fault_count=5,
+        fault_seed=42,
+        max_steps=1000,
+        world_size=16,
+        after_step=10,
+    )
+
+    # Inside training loop:
+    injector.maybe_inject(step, rank)
+"""
+
+import os
+import time
+import random
+import signal
+import logging
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+VALID_FAULT_TYPES = {"exception", "sigkill", "hang"}
+
+
+class FaultInjector:
+    """
+    Fault injector for distributed training resilience testing.
+
+    Supports two modes:
+
+    **Stochastic mode** (default): Each rank independently rolls
+    ``random() < probability`` at every step. Total fault count varies
+    between runs.
+
+    **Deterministic mode** (``fault_count`` set): Pre-generates exactly N
+    faults at random steps, each targeting a specific non-zero rank. Using
+    the same ``fault_seed`` across experiments guarantees identical fault
+    patterns, making comparisons fair.
+
+    Faults are only injected on non-zero ranks (rank 0 hosts the rendezvous
+    store and killing it would take down the entire job rather than testing
+    per-worker recovery).
+
+    Args:
+        fault_types: List of fault types to inject. Valid values:
+            "exception", "sigkill", "hang".
+        weights: Optional list of weights (same length as fault_types).
+            Controls relative probability of each fault type.  Defaults
+            to uniform distribution.
+        probability: Per-step probability of injecting a fault (stochastic mode).
+        after_step: Only inject faults after this step number (allow
+            initial training to stabilise).
+        on_fault: Optional callback(step, rank, fault_type) called before injection.
+        fault_count: If set, use deterministic mode with exactly this many faults.
+            Overrides ``probability``.
+        fault_seed: Random seed for deterministic fault schedule generation.
+            Only used when ``fault_count`` is set.
+        max_steps: Total training steps (required for deterministic mode to
+            generate fault steps within range).
+        world_size: Total number of ranks (required for deterministic mode to
+            assign target ranks).
+    """
+
+    def __init__(
+        self,
+        fault_types: List[str],
+        weights: Optional[List[float]] = None,
+        probability: float = 0.002,
+        after_step: int = 50,
+        on_fault: Optional[Callable] = None,
+        fault_count: Optional[int] = None,
+        fault_seed: int = 42,
+        max_steps: int = 1000,
+        world_size: int = 2,
+        shared_store=None,
+        pre_injected_steps: Optional[List[int]] = None,
+    ):
+        # Validate fault types
+        for ft in fault_types:
+            if ft not in VALID_FAULT_TYPES:
+                raise ValueError(
+                    f"Invalid fault type '{ft}'. "
+                    f"Valid types: {sorted(VALID_FAULT_TYPES)}"
+                )
+        if len(fault_types) == 0:
+            raise ValueError("At least one fault type must be specified")
+
+        self.fault_types = list(fault_types)
+        self.probability = probability
+        self.after_step = after_step
+        self.on_fault = on_fault  # callback(step, rank, fault_type) before injection
+
+        # Weights default to uniform
+        if weights is not None:
+            if len(weights) != len(fault_types):
+                raise ValueError(
+                    f"weights length ({len(weights)}) must match "
+                    f"fault_types length ({len(fault_types)})"
+                )
+            self.weights = list(weights)
+        else:
+            self.weights = [1.0] * len(fault_types)
+
+        # Dispatch table
+        self._dispatch = {
+            "exception": self._inject_exception,
+            "sigkill": self._inject_sigkill,
+            "hang": self._inject_hang,
+        }
+
+        # Stats
+        self.injected_count = 0
+        self.injected_by_type = {ft: 0 for ft in fault_types}
+        self.injected_steps: Set[int] = set()  # Track already-injected steps
+
+        # Pre-populate injected steps from prior container runs (for baseline
+        # mode where FaultInjector is recreated on each container restart).
+        # Without this, deterministic faults re-trigger on the same step
+        # after container restart, creating an infinite crash loop.
+        if pre_injected_steps:
+            self.injected_steps.update(pre_injected_steps)
+
+        # Fault timing (for shutdown time measurement)
+        self.last_fault_time: Optional[float] = None  # time.time() of last injection
+        self.last_fault_step: Optional[int] = None  # step of last injection
+
+        # Shared store for broadcasting fault time to all ranks (Option D).
+        # The faulting rank writes fault_time to the store; all ranks read it
+        # at function re-entry to compute shutdown time. Works across ranks
+        # because the store (TCPStore/PrefixStore) is shared.
+        self._shared_store = shared_store
+
+        # Deterministic fault schedule (if fault_count is set)
+        self.fault_count = fault_count
+        self.fault_schedule: Dict[
+            int, Tuple[int, str]
+        ] = {}  # step -> (target_rank, fault_type)
+
+        if fault_count is not None:
+            self._generate_schedule(
+                fault_count, fault_seed, max_steps, world_size, after_step
+            )
+
+    def _generate_schedule(
+        self,
+        fault_count: int,
+        seed: int,
+        max_steps: int,
+        world_size: int,
+        after_step: int,
+    ) -> None:
+        """Pre-generate a deterministic fault schedule.
+
+        Creates exactly ``fault_count`` faults at unique random steps in
+        [after_step+1, max_steps], each targeting a random non-zero rank
+        with a pre-determined fault type. The schedule is identical across
+        all ranks (same seed), making experiments fully reproducible.
+        """
+        rng = random.Random(seed)
+        eligible_steps = list(range(after_step + 1, max_steps + 1))
+        if fault_count > len(eligible_steps):
+            fault_count = len(eligible_steps)
+        fault_steps = sorted(rng.sample(eligible_steps, fault_count))
+
+        # Assign each fault a target rank and fault type
+        for step in fault_steps:
+            target_rank = rng.randint(1, world_size - 1)
+            fault_type = rng.choices(self.fault_types, weights=self.weights, k=1)[0]
+            self.fault_schedule[step] = (target_rank, fault_type)
+
+        logger.info(
+            f"Deterministic fault schedule (seed={seed}): "
+            f"{[(s, r, t) for s, (r, t) in sorted(self.fault_schedule.items())]}"
+        )
+
+    def maybe_inject(self, step: int, rank: int) -> None:
+        """
+        Potentially inject a fault at the given training step.
+
+        In deterministic mode, injects only if this step/rank matches the
+        pre-generated schedule. In stochastic mode, rolls against probability.
+
+        Only injects on non-zero ranks and after ``after_step`` warmup.
+        Call this once per training step.
+
+        Args:
+            step: Current training step number.
+            rank: Current distributed rank.
+        """
+        # Never inject on rank 0 (rendezvous host)
+        if rank == 0:
+            return
+
+        # Warmup period
+        if step <= self.after_step:
+            return
+
+        if self.fault_count is not None:
+            # Deterministic mode: check pre-generated schedule
+            if step not in self.fault_schedule:
+                return
+            # Skip faults that were already injected (e.g., after in-process
+            # restart rolls back to a step before this fault)
+            if step in self.injected_steps:
+                return
+            target_rank, scheduled_fault_type = self.fault_schedule[step]
+            # Record fault time on ALL ranks (for shutdown measurement).
+            # Only the target rank actually injects, but all ranks will
+            # experience the restart and need to know when the fault occurred.
+            self.last_fault_time = time.time()
+            self.last_fault_step = step
+            # Broadcast fault time via shared store so rank 0 (which writes
+            # results JSON) can compute accurate shutdown time even if it
+            # didn't reach this step before the Wrapper interrupted it.
+            if self._shared_store is not None:
+                try:
+                    self._shared_store.set("last_fault_time", str(self.last_fault_time))
+                    self._shared_store.set("last_fault_step", str(step))
+                except Exception:
+                    pass  # Store write failure is non-critical
+            if target_rank != rank:
+                return
+        else:
+            # Stochastic mode: probabilistic trigger
+            if random.random() >= self.probability:
+                return
+            scheduled_fault_type = None
+
+        # Choose fault type: use pre-generated type in deterministic mode,
+        # weighted random in stochastic mode
+        if scheduled_fault_type is not None:
+            fault_type = scheduled_fault_type
+        else:
+            fault_type = random.choices(self.fault_types, weights=self.weights, k=1)[0]
+
+        self.injected_count += 1
+        self.injected_by_type[fault_type] += 1
+        self.injected_steps.add(step)
+
+        logger.warning(
+            f"INJECTING FAULT at step {step}! "
+            f"type={fault_type}, "
+            f"fault #{self.injected_count}"
+        )
+
+        # Pre-injection callback (e.g. record fault step in metrics).
+        # Called before dispatch because SIGKILL kills the process instantly.
+        if self.on_fault is not None:
+            self.on_fault(step, rank, fault_type)
+
+        self._dispatch[fault_type](step, rank)
+
+    def _inject_exception(self, step: int, rank: int) -> None:
+        """Raise a RuntimeError. Recoverable by in-process restart."""
+        raise RuntimeError(f"Simulated fault (exception) at step {step} on rank {rank}")
+
+    def _inject_sigkill(self, step: int, rank: int) -> None:
+        """Send SIGKILL to this process. Only recoverable by ft_launcher or K8s restart."""
+        # Flush logs so the warning message above is visible
+        for handler in logging.getLogger().handlers:
+            handler.flush()
+        os.kill(os.getpid(), signal.SIGKILL)
+
+    def _inject_hang(self, step: int, rank: int) -> None:
+        """Simulate a hung process (e.g., NCCL deadlock, GPU stall).
+
+        Uses time.sleep() to keep the process alive but unresponsive.
+        Detection depends on the fault tolerance mechanism:
+        - NVRx inprocess.Wrapper: soft_timeout detects unresponsive rank
+        - ft_launcher: heartbeat timeout detects hung worker
+        - Baseline: NCCL timeout causes all ranks to crash
+
+        NOTE: Hang faults with inprocess.Wrapper may cause cascading
+        restarts on the hung rank's node because the Wrapper cannot kill
+        the sleeping thread. Use exception-only faults for in-process
+        restart experiments. Hang faults work correctly with ft_launcher
+        and baseline (K8s restart) modes.
+        """
+        while True:
+            time.sleep(3600)
+
+    def summary(self) -> str:
+        """Return a human-readable summary of injected faults."""
+        parts = [f"Total faults injected: {self.injected_count}"]
+        for ft in self.fault_types:
+            parts.append(f"  {ft}: {self.injected_by_type[ft]}")
+        return "\n".join(parts)
+
+    def __repr__(self) -> str:
+        if self.fault_count is not None:
+            schedule_str = [
+                (s, r, t) for s, (r, t) in sorted(self.fault_schedule.items())
+            ]
+            return (
+                f"FaultInjector(mode=deterministic, fault_types={self.fault_types}, "
+                f"fault_count={self.fault_count}, "
+                f"schedule={schedule_str}, "
+                f"after_step={self.after_step})"
+            )
+        return (
+            f"FaultInjector(mode=stochastic, fault_types={self.fault_types}, "
+            f"weights={self.weights}, "
+            f"probability={self.probability}, "
+            f"after_step={self.after_step})"
+        )

--- a/3.test_cases/pytorch/nvrx/src/fsdp_config.py
+++ b/3.test_cases/pytorch/nvrx/src/fsdp_config.py
@@ -1,0 +1,78 @@
+"""
+FSDP Configuration.
+
+Returns FSDP-specific kwargs for ``FullyShardedDataParallel``.  Model-aware
+``auto_wrap_policy`` is set for models that benefit from per-layer sharding
+(e.g. LLaMA).  Called by ``distributed_utils.wrap_model`` when
+``strategy="fsdp"``.
+"""
+
+import functools
+import logging
+
+from torch.distributed.fsdp import ShardingStrategy, BackwardPrefetch
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+
+logger = logging.getLogger(__name__)
+
+
+def get_fsdp_config(model_name):
+    """Return a dict of FSDP kwargs suitable for the given *model_name*.
+
+    For small models (GPT-2 124M) no auto-wrap policy is needed.  For larger
+    transformer models (LLaMA, Mistral, etc.) we wrap at the decoder-layer
+    level so that FSDP can shard each layer independently -- critical for
+    fitting 7B+ models in GPU memory.
+    """
+    config = {
+        "sharding_strategy": ShardingStrategy.FULL_SHARD,
+        "backward_prefetch": BackwardPrefetch.BACKWARD_PRE,
+        "cpu_offload": None,
+        "limit_all_gathers": True,
+        "use_orig_params": False,
+    }
+
+    if "gpt2" in model_name.lower():
+        # GPT-2 (124M) is small enough to shard without per-layer wrapping.
+        config["auto_wrap_policy"] = None
+
+    elif "llama" in model_name.lower():
+        try:
+            from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+
+            config["auto_wrap_policy"] = functools.partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={LlamaDecoderLayer},
+            )
+            logger.info("FSDP: using LlamaDecoderLayer auto-wrap policy")
+        except ImportError:
+            logger.warning(
+                "Could not import LlamaDecoderLayer -- falling back to no "
+                "auto-wrap policy.  Install a recent transformers version."
+            )
+            config["auto_wrap_policy"] = None
+
+    elif "mistral" in model_name.lower():
+        try:
+            from transformers.models.mistral.modeling_mistral import (
+                MistralDecoderLayer,
+            )
+
+            config["auto_wrap_policy"] = functools.partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={MistralDecoderLayer},
+            )
+            logger.info("FSDP: using MistralDecoderLayer auto-wrap policy")
+        except ImportError:
+            config["auto_wrap_policy"] = None
+
+    else:
+        # Unknown model -- no auto-wrap.  Works for any model but may not be
+        # memory-optimal for very large models.
+        logger.info(
+            f"FSDP: no model-specific auto-wrap policy for '{model_name}'. "
+            "Using flat sharding."
+        )
+        config["auto_wrap_policy"] = None
+
+    return config

--- a/3.test_cases/pytorch/nvrx/src/metrics_collector.py
+++ b/3.test_cases/pytorch/nvrx/src/metrics_collector.py
@@ -1,0 +1,295 @@
+"""
+Metrics Collector
+Collects and reports MTBF and Goodput metrics
+"""
+
+import os
+import time
+import json
+import logging
+from datetime import datetime
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsCollector:
+    """
+    Collects training metrics for MTBF and Goodput calculation
+    """
+
+    def __init__(self, rank, world_size, output_dir="/checkpoints"):
+        self.rank = rank
+        self.world_size = world_size
+        self.is_main = rank == 0
+        self.output_dir = output_dir
+
+        self.training_start_time = None
+        self.training_end_time = None
+        self.total_training_time = 0
+
+        self.failure_events = []
+        self.recovery_events = []
+        self.total_downtime = 0
+
+        self.steps_completed = 0
+        self.total_samples_processed = 0
+        self.throughput_history = []
+
+        self.checkpoint_save_times = []
+        self.checkpoint_load_times = []
+        self.checkpoint_sizes = []
+        self.checkpoint_performance = None
+
+        # Run completion tracking
+        self.max_steps = None
+        self.termination_reason = None  # "max_steps_reached" or "time_limit"
+
+    def start_training(self):
+        """Mark training start"""
+        self.training_start_time = time.time()
+        if self.is_main:
+            logger.info("Metrics: Training started")
+
+    def end_training(self, success=True, error=None):
+        """Mark training end"""
+        self.training_end_time = time.time()
+        self.total_training_time = self.training_end_time - self.training_start_time
+
+        if self.is_main:
+            status = "SUCCESS" if success else "FAILED"
+            logger.info(f"Metrics: Training ended - {status}")
+            if error:
+                logger.info(f"Metrics: Error - {error}")
+
+    def log_step(self, step, loss, elapsed_time):
+        """Log training step"""
+        self.steps_completed = step
+
+        throughput = step / elapsed_time if elapsed_time > 0 else 0
+        self.throughput_history.append(
+            {
+                "step": step,
+                "timestamp": time.time(),
+                "throughput": throughput,
+                "loss": loss,
+            }
+        )
+
+    def log_failure(self, failure_type, timestamp=None):
+        """Log a failure event"""
+        if timestamp is None:
+            timestamp = time.time()
+
+        self.failure_events.append(
+            {"timestamp": timestamp, "type": failure_type, "step": self.steps_completed}
+        )
+
+        if self.is_main:
+            logger.warning(f"Metrics: Failure logged - {failure_type}")
+
+    def log_recovery(self, recovery_time, timestamp=None):
+        """Log a recovery event"""
+        if timestamp is None:
+            timestamp = time.time()
+
+        self.recovery_events.append(
+            {
+                "timestamp": timestamp,
+                "recovery_time": recovery_time,
+                "step": self.steps_completed,
+            }
+        )
+
+        self.total_downtime += recovery_time
+
+        if self.is_main:
+            logger.info(f"Metrics: Recovery logged - {recovery_time:.2f}s")
+
+    def log_checkpoint_save(self, duration):
+        """Log checkpoint save time"""
+        self.checkpoint_save_times.append(duration)
+
+    def log_checkpoint_load(self, duration):
+        """Log checkpoint load time"""
+        self.checkpoint_load_times.append(duration)
+
+    def log_checkpoint_size(self, size_mb):
+        """Log checkpoint size in MB"""
+        self.checkpoint_sizes.append(size_mb)
+
+    def set_checkpoint_performance(
+        self,
+        mode,
+        checkpoint_count,
+        checkpoint_interval,
+        total_checkpoint_time,
+        checkpoint_times,
+        checkpoint_sizes,
+        total_wall_time,
+        total_steps,
+    ):
+        """Store computed checkpoint performance metrics for JSON output."""
+        avg_ckpt_time = (
+            total_checkpoint_time / checkpoint_count if checkpoint_count else 0
+        )
+        overhead_pct = (
+            (total_checkpoint_time / total_wall_time) * 100 if total_wall_time else 0
+        )
+        efficiency_pct = 100 - overhead_pct
+        avg_size = (
+            sum(checkpoint_sizes) / len(checkpoint_sizes) if checkpoint_sizes else 0
+        )
+        bandwidth = avg_size / avg_ckpt_time if avg_ckpt_time > 0 else 0
+
+        self.checkpoint_performance = {
+            "mode": mode,
+            "checkpoint_count": checkpoint_count,
+            "checkpoint_interval": checkpoint_interval,
+            "total_checkpoint_time_seconds": round(total_checkpoint_time, 3),
+            "avg_checkpoint_time_seconds": round(avg_ckpt_time, 3),
+            "min_checkpoint_time_seconds": round(min(checkpoint_times), 3)
+            if checkpoint_times
+            else 0,
+            "max_checkpoint_time_seconds": round(max(checkpoint_times), 3)
+            if checkpoint_times
+            else 0,
+            "checkpoint_times": [round(t, 3) for t in checkpoint_times],
+            "avg_checkpoint_size_mb": round(avg_size, 1),
+            "checkpoint_sizes_mb": [round(s, 1) for s in checkpoint_sizes],
+            "write_bandwidth_mb_s": round(bandwidth, 1),
+            "checkpoint_overhead_pct": round(overhead_pct, 2),
+            "training_efficiency_pct": round(efficiency_pct, 2),
+            "total_wall_time_seconds": round(total_wall_time, 1),
+            "total_steps": total_steps,
+        }
+
+    def calculate_mtbf(self):
+        """
+        Calculate Mean Time Between Failures
+        MTBF = Total Uptime / Number of Failures
+        """
+        if len(self.failure_events) == 0:
+            return float("inf")
+
+        total_uptime = self.total_training_time - self.total_downtime
+        mtbf = total_uptime / len(self.failure_events)
+
+        return mtbf
+
+    def calculate_goodput(self):
+        """
+        Calculate Goodput
+        Goodput = Useful Work / Total Time
+        """
+        if self.total_training_time == 0:
+            return 0.0
+
+        useful_time = self.total_training_time - self.total_downtime
+        goodput = useful_time / self.total_training_time
+
+        return goodput * 100
+
+    def calculate_average_throughput(self):
+        """Calculate average throughput"""
+        if not self.throughput_history:
+            return 0.0
+
+        throughputs = [t["throughput"] for t in self.throughput_history]
+        return sum(throughputs) / len(throughputs)
+
+    def set_run_completion(self, max_steps, termination_reason):
+        """Record how the run terminated for fair cross-experiment comparison.
+
+        Args:
+            max_steps: The target step count (--max_steps).
+            termination_reason: "max_steps_reached" or "time_limit".
+        """
+        self.max_steps = max_steps
+        self.termination_reason = termination_reason
+
+    def get_summary(self):
+        """Get metrics summary"""
+        summary = {
+            "training_duration_seconds": self.total_training_time,
+            "steps_completed": self.steps_completed,
+            "max_steps": self.max_steps,
+            "termination_reason": self.termination_reason,
+            "num_failures": len(self.failure_events),
+            "num_recoveries": len(self.recovery_events),
+            "total_downtime_seconds": self.total_downtime,
+            "mtbf_seconds": self.calculate_mtbf(),
+            "goodput_percentage": self.calculate_goodput(),
+            "average_throughput": self.calculate_average_throughput(),
+            "failure_events": self.failure_events,
+            "recovery_events": self.recovery_events,
+            "avg_checkpoint_save_time": sum(self.checkpoint_save_times)
+            / len(self.checkpoint_save_times)
+            if self.checkpoint_save_times
+            else 0,
+            "avg_checkpoint_load_time": sum(self.checkpoint_load_times)
+            / len(self.checkpoint_load_times)
+            if self.checkpoint_load_times
+            else 0,
+        }
+
+        # Include detailed checkpoint performance if set by the training script
+        if self.checkpoint_performance:
+            summary["checkpoint_performance"] = self.checkpoint_performance
+
+        return summary
+
+    def print_summary(self):
+        """Print metrics summary"""
+        if not self.is_main:
+            return
+
+        summary = self.get_summary()
+
+        print("\n" + "=" * 80)
+        print("TRAINING METRICS SUMMARY")
+        print("=" * 80)
+        print(
+            f"Total Training Time: {summary['training_duration_seconds']:.2f} seconds ({summary['training_duration_seconds'] / 60:.2f} minutes)"
+        )
+        # Run completion status
+        if summary.get("max_steps") is not None:
+            reason = summary.get("termination_reason", "unknown")
+            reason_label = (
+                "completed" if reason == "max_steps_reached" else "time-limited"
+            )
+            print(
+                f"Steps: {summary['steps_completed']}/{summary['max_steps']} ({reason_label})"
+            )
+            print(f"Termination: {reason}")
+        else:
+            print(f"Steps Completed: {summary['steps_completed']}")
+        print(f"Number of Failures: {summary['num_failures']}")
+        print(f"Number of Recoveries: {summary['num_recoveries']}")
+        print(
+            f"Total Downtime: {summary['total_downtime_seconds']:.2f} seconds ({summary['total_downtime_seconds'] / 60:.2f} minutes)"
+        )
+        print("")
+        print("RESILIENCY METRICS:")
+        print(
+            f"  MTBF (Mean Time Between Failures): {summary['mtbf_seconds']:.2f} seconds ({summary['mtbf_seconds'] / 60:.2f} minutes)"
+        )
+        print(f"  Goodput: {summary['goodput_percentage']:.2f}%")
+        print(f"  Average Throughput: {summary['average_throughput']:.2f} steps/sec")
+        print("")
+        print("CHECKPOINT METRICS:")
+        print(
+            f"  Avg Checkpoint Save Time: {summary['avg_checkpoint_save_time']:.2f} seconds"
+        )
+        print(
+            f"  Avg Checkpoint Load Time: {summary['avg_checkpoint_load_time']:.2f} seconds"
+        )
+        print("=" * 80)
+
+        try:
+            metrics_path = os.path.join(self.output_dir, "metrics_summary.json")
+            with open(metrics_path, "w") as f:
+                json.dump(summary, f, indent=2, default=str)
+            print(f"Metrics saved to {metrics_path}")
+        except Exception as e:
+            logger.error(f"Failed to save metrics: {e}")

--- a/3.test_cases/pytorch/nvrx/src/train_async_ckpt.py
+++ b/3.test_cases/pytorch/nvrx/src/train_async_ckpt.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+NVRx Async Checkpointing Training Script
+
+Compares sync vs async checkpoint performance with FSDP/DDP training.
+Supports both FSDP and DDP via --parallel_strategy flag.
+"""
+
+import gc
+import os
+import sys
+import time
+import argparse
+import logging
+
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import StateDictType
+
+# Import NVRx async checkpointing
+try:
+    from nvidia_resiliency_ext.checkpointing.async_ckpt.torch_ckpt import (
+        TorchAsyncCheckpoint,
+    )
+
+    NVRX_ASYNC_AVAILABLE = True
+except ImportError:
+    NVRX_ASYNC_AVAILABLE = False
+    print("WARNING: NVRx async checkpointing not available")
+
+from distributed_utils import (
+    add_distributed_args,
+    create_model,
+    wrap_model,
+    create_dataloader,
+    train_step,
+    save_checkpoint as save_checkpoint_sync,
+    setup_logging,
+)
+from metrics_collector import MetricsCollector
+
+
+def str2bool(v):
+    """Argparse type for boolean arguments."""
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "1"):
+        return True
+    if v.lower() in ("no", "false", "f", "0"):
+        return False
+    raise argparse.ArgumentTypeError(f"Boolean value expected, got {v!r}")
+
+
+def _to_cpu(obj):
+    """Recursively move all tensors in a nested dict/list to CPU.
+
+    This is critical for async checkpointing: state_dict() tensors live on GPU,
+    and the async writer holds a reference until I/O completes. Without CPU
+    offload, GPU memory accumulates across checkpoint intervals and causes OOM.
+
+    Also handles ``ShardedTensor`` objects produced by FSDP
+    ``LOCAL_STATE_DICT``: extracts the local shard and moves it to CPU.
+    """
+    # Handle ShardedTensor from FSDP LOCAL_STATE_DICT
+    if type(obj).__name__ == "ShardedTensor":
+        # Extract the local shard(s) and move to CPU.
+        # Each rank has exactly one local shard for FSDP FULL_SHARD.
+        local_shards = obj.local_shards()
+        if local_shards:
+            return local_shards[0].tensor.cpu()
+        return obj
+    if isinstance(obj, torch.Tensor):
+        return obj.cpu()
+    elif isinstance(obj, dict):
+        return {k: _to_cpu(v) for k, v in obj.items()}
+    elif isinstance(obj, (list, tuple)):
+        return type(obj)(_to_cpu(v) for v in obj)
+    return obj
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="NVRx FSDP/DDP Training with Async Checkpointing"
+    )
+
+    parser.add_argument("--model_name", type=str, default="gpt2")
+    parser.add_argument("--max_seq_length", type=int, default=512)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--learning_rate", type=float, default=5e-5)
+    parser.add_argument("--max_steps", type=int, default=1000)
+
+    parser.add_argument("--dataset_name", type=str, default="allenai/c4")
+    parser.add_argument("--streaming", type=str2bool, default=True)
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default=None,
+        help="Path to pre-downloaded dataset (created by prepare_dataset.py). "
+        "If set, loads from local disk with zero HF API calls. "
+        "If not set, streams from HuggingFace Hub.",
+    )
+
+    # Checkpointing args
+    parser.add_argument("--checkpoint_enabled", type=str2bool, default=True)
+    parser.add_argument("--checkpoint_path", type=str, default="/checkpoints")
+    parser.add_argument("--checkpoint_interval", type=int, default=100)
+    parser.add_argument("--use_async_checkpoint", type=str2bool, default=False)
+
+    # Training duration
+    parser.add_argument("--training_duration_minutes", type=int, default=15)
+
+    # Distributed strategy & dtype (from shared utils)
+    add_distributed_args(parser)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Read distributed env vars (set by torchrun)
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+
+    if world_size > 1:
+        torch.cuda.set_device(local_rank)
+        dist.init_process_group(backend="nccl")
+
+    logger = setup_logging(rank, args.log_level, args.log_all_ranks)
+
+    logger.info("=" * 80)
+    logger.info("NVRx Async Checkpointing Training Starting")
+    logger.info("=" * 80)
+    logger.info(f"Rank: {rank}, World Size: {world_size}, Local Rank: {local_rank}")
+    logger.info(f"Parallel Strategy: {args.parallel_strategy}")
+    logger.info(f"Async Checkpointing: {args.use_async_checkpoint}")
+    logger.info(f"NVRx Available: {NVRX_ASYNC_AVAILABLE}")
+
+    # Initialize async checkpointing if enabled
+    async_ckpt = None
+    if args.use_async_checkpoint and NVRX_ASYNC_AVAILABLE:
+        logger.info("Initializing NVRx async checkpointing...")
+        async_ckpt = TorchAsyncCheckpoint(persistent_queue=True)
+    elif args.use_async_checkpoint and not NVRX_ASYNC_AVAILABLE:
+        logger.warning("Async checkpointing requested but NVRx not available!")
+        logger.warning("Falling back to synchronous checkpointing")
+        args.use_async_checkpoint = False
+
+    # Initialize metrics
+    metrics = MetricsCollector(rank, world_size, output_dir=args.checkpoint_path)
+    metrics.start_training()
+
+    try:
+        # Create model and tokenizer (shared utility -- uses args.torch_dtype)
+        model, tokenizer = create_model(args.model_name, args.torch_dtype)
+
+        # Wrap model with FSDP or DDP
+        model = wrap_model(model, args.parallel_strategy, local_rank, args.model_name)
+
+        # Create optimizer
+        optimizer = torch.optim.AdamW(model.parameters(), lr=args.learning_rate)
+
+        # Create dataloader
+        dataloader = create_dataloader(args, tokenizer, rank, world_size)
+        dataloader_iter = iter(dataloader)
+
+        # Training loop
+        model.train()
+        step = 0
+        training_start_time = time.time()
+        max_training_time = args.training_duration_minutes * 60
+
+        # Track checkpoint metrics
+        total_checkpoint_time = 0
+        checkpoint_count = 0
+        checkpoint_times = []
+        checkpoint_sizes = []
+        termination_reason = "max_steps_reached"
+
+        logger.info("Starting training loop...")
+
+        while step < args.max_steps:
+            # Check if training time exceeded
+            elapsed = time.time() - training_start_time
+            if elapsed >= max_training_time:
+                logger.info(
+                    f"Training time limit reached ({args.training_duration_minutes} minutes)"
+                )
+                termination_reason = "time_limit"
+                break
+
+            # Get batch
+            try:
+                batch = next(dataloader_iter)
+            except StopIteration:
+                dataloader_iter = iter(dataloader)
+                batch = next(dataloader_iter)
+
+            # Training step
+            loss = train_step(model, batch, optimizer)
+            step += 1
+
+            # Log progress every step and update metrics
+            elapsed = time.time() - training_start_time
+            metrics.log_step(step, loss, elapsed)
+            if step % 10 == 0:
+                logger.info(f"Step {step}, Loss: {loss:.4f}, Time: {elapsed:.1f}s")
+
+            # Checkpoint saving
+            if args.checkpoint_enabled and step % args.checkpoint_interval == 0:
+                logger.info(f"Saving checkpoint at step {step}...")
+
+                if args.use_async_checkpoint and async_ckpt:
+                    # Async checkpointing -- unique to this script
+                    ckpt_start = time.time()
+
+                    # Wait for previous async write before building new state_dict
+                    async_ckpt.finalize_async_save(blocking=True, no_dist=False)
+
+                    # Use LOCAL_STATE_DICT for FSDP to avoid the expensive
+                    # FULL_STATE_DICT all-gather (~80GB/rank for LLaMA-8B).
+                    # Each rank saves only its local shard (~2.8GB).
+                    if args.parallel_strategy == "fsdp" and isinstance(model, FSDP):
+                        FSDP.set_state_dict_type(model, StateDictType.LOCAL_STATE_DICT)
+
+                    state_dict = model.state_dict()
+                    checkpoint = {
+                        "step": step,
+                        "model_state_dict": state_dict,
+                        "optimizer_state_dict": optimizer.state_dict(),
+                        "parallel_strategy": args.parallel_strategy,
+                    }
+
+                    # Move to CPU before enqueuing. Safe with LOCAL_STATE_DICT
+                    # since tensors are local shards (no shared memory from
+                    # all-gather that caused SIGBUS with FULL_STATE_DICT).
+                    checkpoint = _to_cpu(checkpoint)
+
+                    path = os.path.join(
+                        args.checkpoint_path, f"checkpoint_step_{step}_rank_{rank}.pt"
+                    )
+
+                    async_ckpt.async_save(checkpoint, path)
+
+                    del checkpoint, state_dict
+                    gc.collect()
+                    torch.cuda.empty_cache()
+
+                    ckpt_time = time.time() - ckpt_start
+
+                    logger.info(f"Async checkpoint scheduled in {ckpt_time:.3f}s")
+                    total_checkpoint_time += ckpt_time
+                    checkpoint_count += 1
+                    checkpoint_times.append(ckpt_time)
+                    metrics.log_checkpoint_save(ckpt_time)
+                else:
+                    # Synchronous checkpointing -- uses LOCAL_STATE_DICT
+                    # to avoid the expensive FULL_STATE_DICT all-gather,
+                    # same as the async path above.
+                    ckpt_start = time.time()
+
+                    if args.parallel_strategy == "fsdp" and isinstance(model, FSDP):
+                        FSDP.set_state_dict_type(model, StateDictType.LOCAL_STATE_DICT)
+
+                    checkpoint = {
+                        "step": step,
+                        "model_state_dict": model.state_dict(),
+                        "optimizer_state_dict": optimizer.state_dict(),
+                        "parallel_strategy": args.parallel_strategy,
+                    }
+                    checkpoint = _to_cpu(checkpoint)
+
+                    path = os.path.join(
+                        args.checkpoint_path, f"checkpoint_step_{step}_rank_{rank}.pt"
+                    )
+                    torch.save(checkpoint, path)
+                    del checkpoint
+                    gc.collect()
+                    torch.cuda.empty_cache()
+
+                    ckpt_time = time.time() - ckpt_start
+                    logger.info(f"Sync checkpoint saved in {ckpt_time:.3f}s (blocking)")
+                    total_checkpoint_time += ckpt_time
+                    checkpoint_count += 1
+                    checkpoint_times.append(ckpt_time)
+                    metrics.log_checkpoint_save(ckpt_time)
+                    # Measure checkpoint file size
+                    if os.path.exists(path):
+                        ckpt_size_mb = os.path.getsize(path) / (1024 * 1024)
+                        checkpoint_sizes.append(ckpt_size_mb)
+                        logger.info(f"Checkpoint size: {ckpt_size_mb:.1f} MB")
+
+        # Finalize async checkpointing if used
+        if async_ckpt:
+            logger.info("Finalizing async checkpointing...")
+            finalize_start = time.time()
+            async_ckpt.finalize_async_save(blocking=True, no_dist=False)
+            # close() may not exist in all NVRx versions
+            if hasattr(async_ckpt, "close"):
+                async_ckpt.close()
+            finalize_time = time.time() - finalize_start
+            logger.info(f"Async finalization completed in {finalize_time:.3f}s")
+
+            # Measure async checkpoint sizes after finalization
+            for ckpt_file in sorted(os.listdir(args.checkpoint_path)):
+                if ckpt_file.endswith(f"_rank_{rank}.pt"):
+                    ckpt_path = os.path.join(args.checkpoint_path, ckpt_file)
+                    ckpt_size_mb = os.path.getsize(ckpt_path) / (1024 * 1024)
+                    checkpoint_sizes.append(ckpt_size_mb)
+
+        logger.info("Training completed successfully!")
+        metrics.set_run_completion(args.max_steps, termination_reason)
+        metrics.end_training(success=True)
+
+        # Print checkpoint summary
+        if checkpoint_count > 0:
+            total_wall_time = time.time() - training_start_time
+            avg_checkpoint_time = total_checkpoint_time / checkpoint_count
+            checkpoint_overhead_pct = (total_checkpoint_time / total_wall_time) * 100
+            training_efficiency_pct = 100 - checkpoint_overhead_pct
+            effective_throughput = step / (total_wall_time - total_checkpoint_time)
+            raw_throughput = step / total_wall_time
+            avg_step_time = total_wall_time / step
+            steps_lost_per_ckpt = avg_checkpoint_time / avg_step_time
+
+            # Run completion status
+            reason_label = (
+                "completed"
+                if termination_reason == "max_steps_reached"
+                else "time-limited"
+            )
+
+            logger.info("=" * 80)
+            logger.info("CHECKPOINT PERFORMANCE SUMMARY")
+            logger.info("=" * 80)
+            logger.info(
+                f"Mode: {'Async (NVRx)' if args.use_async_checkpoint else 'Sync (torch.save)'}"
+            )
+            logger.info(f"Model: {args.model_name}")
+            logger.info(f"World Size: {world_size}")
+            logger.info(f"Parallel Strategy: {args.parallel_strategy}")
+            logger.info("")
+            logger.info("TRAINING METRICS:")
+            logger.info(f"  Steps: {step}/{args.max_steps} ({reason_label})")
+            logger.info(f"  Termination: {termination_reason}")
+            logger.info(f"  Total wall time: {total_wall_time:.1f}s")
+            logger.info(f"  Raw throughput: {raw_throughput:.2f} steps/sec")
+            logger.info(
+                f"  Effective throughput (excl. ckpt): {effective_throughput:.2f} steps/sec"
+            )
+            logger.info("")
+            logger.info("CHECKPOINT METRICS:")
+            logger.info(f"  Total checkpoints: {checkpoint_count}")
+            logger.info(
+                f"  Checkpoint interval: every {args.checkpoint_interval} steps"
+            )
+            logger.info(f"  Avg checkpoint time: {avg_checkpoint_time:.3f}s")
+            logger.info(f"  Total checkpoint time: {total_checkpoint_time:.3f}s")
+            if checkpoint_times:
+                logger.info(f"  Min checkpoint time: {min(checkpoint_times):.3f}s")
+                logger.info(
+                    f"  Max checkpoint time (P100): {max(checkpoint_times):.3f}s"
+                )
+            if checkpoint_sizes:
+                avg_size = sum(checkpoint_sizes) / len(checkpoint_sizes)
+                logger.info(f"  Avg checkpoint size: {avg_size:.1f} MB")
+                logger.info(
+                    f"  Write bandwidth: {avg_size / avg_checkpoint_time:.1f} MB/s"
+                )
+            logger.info("")
+            logger.info("EFFICIENCY METRICS:")
+            logger.info(f"  Checkpoint overhead: {checkpoint_overhead_pct:.2f}%")
+            logger.info(f"  Training efficiency: {training_efficiency_pct:.2f}%")
+            logger.info(f"  Steps lost per checkpoint: {steps_lost_per_ckpt:.2f}")
+            logger.info("=" * 80)
+
+    except KeyboardInterrupt:
+        logger.warning("Training interrupted (SIGTERM/Ctrl-C)")
+        metrics.end_training(success=False, error="interrupted")
+
+    except Exception as e:
+        logger.error(f"Training failed with error: {e}")
+        metrics.end_training(success=False, error=str(e))
+        raise
+
+    finally:
+        # Finalize any pending async writes before shutdown
+        if async_ckpt:
+            try:
+                async_ckpt.finalize_async_save(blocking=True, no_dist=False)
+            except Exception:
+                pass
+
+        if world_size > 1:
+            dist.destroy_process_group()
+
+        # Print final metrics
+        metrics.print_summary()
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/pytorch/nvrx/src/train_ft_launcher.py
+++ b/3.test_cases/pytorch/nvrx/src/train_ft_launcher.py
@@ -1,0 +1,1137 @@
+#!/usr/bin/env python3
+"""
+NVRx ft_launcher In-Job Restart Test Script
+
+Demonstrates NVRx fault tolerance using ft_launcher for in-job restart
+on EKS with FSDP/DDP training.  Two modes are supported:
+
+  Default (in-job only):
+      ft_launcher monitors worker heartbeats.  If a worker crashes or
+      hangs, ft_launcher kills all workers and respawns them.  Recovery
+      takes ~10-30 s (process respawn + checkpoint reload) but does NOT
+      involve Kubernetes container restarts.
+
+  --inprocess (combined in-job + in-process):
+      Adds NVRx inprocess.Wrapper on top of ft_launcher.  Soft faults
+      (Python exceptions, NCCL errors) are recovered in-process in ~1-2 s.
+      Hard faults (SIGKILL, OOM) fall through to ft_launcher for in-job
+      restart.  Hang detection is provided by both the Wrapper (soft/hard
+      timeout) and ft_launcher (heartbeat timeout).
+
+ft_launcher replaces torchrun as the launcher.  It sets RANK, WORLD_SIZE,
+LOCAL_RANK, MASTER_ADDR, MASTER_PORT automatically.
+
+Supports both FSDP and DDP via --parallel_strategy flag.
+
+Port allocation scheme:
+    MASTER_PORT     -> ft_launcher rendezvous (c10d TCPStore)
+    MASTER_PORT + 1 -> application TCPStore (base store in combined, PG store in injob-only)
+    MASTER_PORT + 2 -> inprocess.Wrapper internal store (only in --inprocess mode)
+"""
+
+import os
+import sys
+import time
+import json
+import argparse
+import logging
+import datetime
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Environment variable setup (must happen before importing torch)
+import random
+
+# ---------------------------------------------------------------------------
+# When --inprocess is used, we need to suppress NCCL error rethrows so the
+# Wrapper can catch them.  In in-job-only mode we let NCCL errors crash the
+# worker so ft_launcher can detect the failure.
+#
+# We check the env var ENABLE_INPROCESS here because argparse hasn't run yet.
+_inprocess_enabled = os.environ.get("ENABLE_INPROCESS", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+if _inprocess_enabled:
+    os.environ.setdefault("TORCH_CPP_LOG_LEVEL", "error")
+    os.environ.setdefault("NCCL_NVLS_ENABLE", "0")
+    os.environ.setdefault("TORCH_NCCL_RETHROW_CUDA_ERRORS", "0")
+else:
+    # In-job-only mode: still need NCCL_NVLS_ENABLE=0 for g5 (no NVSwitch)
+    os.environ.setdefault("NCCL_NVLS_ENABLE", "0")
+
+import torch
+import torch.distributed as dist
+
+from transformers import AutoTokenizer
+from datasets import load_dataset
+
+# NVRx imports
+try:
+    import nvidia_resiliency_ext.inprocess as inprocess
+    from nvidia_resiliency_ext.inprocess import CallWrapper
+
+    NVRX_INPROCESS_AVAILABLE = True
+except ImportError:
+    NVRX_INPROCESS_AVAILABLE = False
+    CallWrapper = None
+
+try:
+    import nvidia_resiliency_ext.fault_tolerance as fault_tolerance
+
+    NVRX_FT_AVAILABLE = True
+except ImportError:
+    NVRX_FT_AVAILABLE = False
+
+from distributed_utils import (
+    add_distributed_args,
+    create_model,
+    wrap_model,
+    train_step,
+    save_checkpoint as _save_checkpoint_shared,
+    load_checkpoint as _load_checkpoint_shared,
+)
+from failure_simulator import FaultInjector
+
+# ============================================================================
+# Global state that survives across in-process restarts
+# ============================================================================
+_tokenizer = None
+_dataset = None
+
+
+def setup_logging(rank):
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"[Rank {rank}] %(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+        force=True,
+    )
+    return logging.getLogger(__name__)
+
+
+def str2bool(v):
+    """Argparse type for boolean arguments."""
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "1"):
+        return True
+    if v.lower() in ("no", "false", "f", "0"):
+        return False
+    raise argparse.ArgumentTypeError(f"Boolean value expected, got {v!r}")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="NVRx ft_launcher In-Job Restart Test")
+
+    # Model / training
+    parser.add_argument("--model_name", type=str, default="gpt2")
+    parser.add_argument("--max_seq_length", type=int, default=512)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--learning_rate", type=float, default=5e-5)
+    parser.add_argument("--max_steps", type=int, default=1000)
+
+    # Dataset
+    parser.add_argument("--dataset_name", type=str, default="allenai/c4")
+    parser.add_argument("--streaming", type=str2bool, default=True)
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default=None,
+        help="Path to pre-downloaded dataset (created by prepare_dataset.py). "
+        "If set, loads from local disk with zero HF API calls. "
+        "If not set, streams from HuggingFace Hub.",
+    )
+
+    # Checkpointing
+    parser.add_argument("--checkpoint_path", type=str, default="/checkpoints")
+    parser.add_argument("--checkpoint_interval", type=int, default=50)
+
+    # Training duration
+    parser.add_argument("--training_duration_minutes", type=int, default=10)
+
+    # Fault injection
+    parser.add_argument(
+        "--inject_faults",
+        action="store_true",
+        default=False,
+        help="Enable random fault injection for testing",
+    )
+    parser.add_argument(
+        "--fault_probability",
+        type=float,
+        default=0.002,
+        help="Probability of fault per step (only on rank 1)",
+    )
+    parser.add_argument(
+        "--fault_after_step",
+        type=int,
+        default=50,
+        help="Only inject faults after this step (allow initial training)",
+    )
+    parser.add_argument(
+        "--fault_types",
+        type=str,
+        default="exception",
+        help="Comma-separated fault types to inject: exception, sigkill, hang. "
+        "Default: exception. For combined mode use 'exception,sigkill' to "
+        "exercise both in-process and in-job restart paths.",
+    )
+    parser.add_argument(
+        "--fault_type_weights",
+        type=str,
+        default=None,
+        help="Comma-separated weights for fault types (same length as --fault_types). "
+        "Default: uniform. Example: '0.7,0.3' for 70%% exception / 30%% sigkill.",
+    )
+    parser.add_argument(
+        "--fault_count",
+        type=int,
+        default=None,
+        help="If set, inject exactly this many faults at pre-determined steps "
+        "(deterministic mode). Overrides --fault_probability. Use with "
+        "--fault_seed for reproducible fault patterns across experiments.",
+    )
+    parser.add_argument(
+        "--fault_seed",
+        type=int,
+        default=42,
+        help="Random seed for deterministic fault schedule. Only used when "
+        "--fault_count is set. Same seed = same fault steps and target ranks.",
+    )
+
+    # NCCL timeout
+    parser.add_argument(
+        "--nccl_timeout_seconds",
+        type=int,
+        default=60,
+        help="NCCL operation timeout (seconds).",
+    )
+
+    # In-process restart (opt-in)
+    parser.add_argument(
+        "--inprocess",
+        action="store_true",
+        default=False,
+        help="Enable NVRx in-process restart on top of ft_launcher in-job restart. "
+        "Without this flag, only ft_launcher in-job restart is used.",
+    )
+    parser.add_argument(
+        "--soft_timeout_seconds",
+        type=int,
+        default=120,
+        help="Soft timeout for in-process hang detection (seconds)",
+    )
+    parser.add_argument(
+        "--hard_timeout_seconds",
+        type=int,
+        default=180,
+        help="Hard timeout for in-process rank termination (seconds)",
+    )
+    parser.add_argument(
+        "--barrier_timeout_seconds",
+        type=int,
+        default=300,
+        help="Barrier/completion timeout for in-process Wrapper (seconds). "
+        "Must be > hard_timeout_seconds.",
+    )
+    parser.add_argument(
+        "--max_inprocess_restarts",
+        type=int,
+        default=10,
+        help="Maximum number of in-process restarts before giving up",
+    )
+
+    # Distributed strategy & dtype (from shared utils)
+    add_distributed_args(parser)
+
+    return parser.parse_args()
+
+
+# ============================================================================
+# Data loading (global state survives in-process restarts)
+# ============================================================================
+def get_tokenizer(model_name):
+    global _tokenizer
+    if _tokenizer is None:
+        _tokenizer = AutoTokenizer.from_pretrained(model_name)
+        if _tokenizer.pad_token is None:
+            _tokenizer.pad_token = _tokenizer.eos_token
+    return _tokenizer
+
+
+def get_dataset(dataset_name, streaming=True, dataset_path=None):
+    """Get or create dataset.
+
+    If dataset_path is set, loads a pre-downloaded dataset from local disk
+    (no HuggingFace API calls -- eliminates 429 rate limiting on restarts).
+    Otherwise, streams from HuggingFace Hub with retry logic.
+
+    Use prepare_dataset.py to create the local dataset:
+        python prepare_dataset.py --output_path /checkpoints/c4_subset
+    """
+    global _dataset
+    if _dataset is None:
+        if dataset_path is not None:
+            from datasets import load_from_disk
+
+            _dataset = load_from_disk(dataset_path)
+            print(
+                f"Loaded dataset from local path: {dataset_path} ({len(_dataset)} samples)"
+            )
+        else:
+            # Retry with exponential backoff for HuggingFace 429 rate limiting.
+            for attempt in range(10):
+                try:
+                    _dataset = load_dataset(
+                        dataset_name,
+                        "en",
+                        split="train",
+                        streaming=streaming,
+                        trust_remote_code=True,
+                    )
+                    break
+                except Exception as e:
+                    if "429" in str(e) and attempt < 9:
+                        wait = 2**attempt + random.random() * 2
+                        logging.getLogger(__name__).warning(
+                            f"HF rate limit (429), retry {attempt + 1}/10 in {wait:.1f}s"
+                        )
+                        time.sleep(wait)
+                    else:
+                        raise
+    return _dataset
+
+
+def create_dataloader(args, tokenizer, rank, world_size):
+    dataset = get_dataset(args.dataset_name, args.streaming, args.dataset_path)
+
+    def collate_fn(batch):
+        texts = [item["text"] for item in batch]
+        encodings = tokenizer(
+            texts,
+            truncation=True,
+            max_length=args.max_seq_length,
+            padding=True,
+            return_tensors="pt",
+        )
+        return {
+            "input_ids": encodings["input_ids"],
+            "attention_mask": encodings["attention_mask"],
+            "labels": encodings["input_ids"].clone(),
+        }
+
+    if world_size > 1:
+        dataset_shard = dataset.shard(num_shards=world_size, index=rank)
+    else:
+        dataset_shard = dataset
+
+    from torch.utils.data import DataLoader
+
+    return DataLoader(
+        dataset_shard,
+        batch_size=args.batch_size,
+        collate_fn=collate_fn,
+        num_workers=2,
+    )
+
+
+# train_step is imported from distributed_utils
+
+
+# ============================================================================
+# Checkpoint save / load (delegates to shared utils, adds ft_client state)
+# ============================================================================
+def save_checkpoint(
+    model,
+    optimizer,
+    step,
+    checkpoint_path,
+    rank,
+    strategy,
+    ft_client=None,
+    call_wrapper=None,
+):
+    """Save checkpoint with optional ft_client state."""
+    extra_state = {}
+    if ft_client is not None and ft_client.is_initialized:
+        extra_state["ft_state"] = ft_client.state_dict()
+
+    return _save_checkpoint_shared(
+        model,
+        optimizer,
+        step,
+        checkpoint_path,
+        rank,
+        strategy,
+        call_wrapper=call_wrapper,
+        extra_state=extra_state if extra_state else None,
+    )
+
+
+def load_checkpoint(checkpoint_path, model, optimizer, rank, strategy, ft_client=None):
+    """Load checkpoint with optional ft_client state restore."""
+    extra_loaders = {}
+    if ft_client is not None:
+        extra_loaders["ft_state"] = lambda state: ft_client.load_state_dict(state)
+
+    start_step, _ = _load_checkpoint_shared(
+        checkpoint_path,
+        model,
+        optimizer,
+        rank,
+        strategy,
+        extra_loaders=extra_loaders if extra_loaders else None,
+    )
+    return start_step
+
+
+# ============================================================================
+# Persistent metrics (survives K8s container restarts and ft_launcher respawns)
+# ============================================================================
+METRICS_FILENAME = "cumulative_metrics.json"
+
+
+def load_persistent_metrics(checkpoint_path):
+    path = os.path.join(checkpoint_path, METRICS_FILENAME)
+    if os.path.exists(path):
+        try:
+            with open(path, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return None
+
+
+def save_persistent_metrics(checkpoint_path, metrics):
+    os.makedirs(checkpoint_path, exist_ok=True)
+    path = os.path.join(checkpoint_path, METRICS_FILENAME)
+    with open(path, "w") as f:
+        json.dump(metrics, f, indent=2)
+
+
+def merge_persistent_metrics(restart_metrics, checkpoint_path):
+    """Merge metrics from prior container / in-job restarts."""
+    prior = load_persistent_metrics(checkpoint_path)
+    if prior is None:
+        restart_metrics["job_start_time"] = time.time()
+        return
+
+    restart_metrics["injob_restarts"] = prior.get("injob_restarts", 0) + 1
+    restart_metrics["cumulative_fault_steps"] = prior.get("cumulative_fault_steps", [])
+    restart_metrics["cumulative_recovery_times"] = prior.get(
+        "cumulative_recovery_times", []
+    )
+    restart_metrics["cumulative_steps_completed"] = prior.get(
+        "cumulative_steps_completed", 0
+    )
+    restart_metrics["cumulative_training_time"] = prior.get(
+        "cumulative_training_time", 0
+    )
+    restart_metrics["cumulative_checkpoint_time"] = prior.get(
+        "cumulative_checkpoint_time", 0
+    )
+    restart_metrics["cumulative_checkpoint_count"] = prior.get(
+        "cumulative_checkpoint_count", 0
+    )
+    restart_metrics["job_start_time"] = prior.get("job_start_time", time.time())
+    restart_metrics["recovery_breakdown"] = prior.get("recovery_breakdown", [])
+    restart_metrics["last_fault_time"] = prior.get("last_fault_time")
+
+
+def persist_current_metrics(restart_metrics, checkpoint_path):
+    cumulative = {
+        "injob_restarts": restart_metrics.get("injob_restarts", 0),
+        "cumulative_fault_steps": restart_metrics.get("cumulative_fault_steps", [])
+        + restart_metrics.get("fault_steps", []),
+        "cumulative_recovery_times": restart_metrics.get(
+            "cumulative_recovery_times", []
+        )
+        + restart_metrics.get("recovery_times", []),
+        "cumulative_steps_completed": restart_metrics.get("total_steps", 0),
+        "cumulative_training_time": restart_metrics.get("cumulative_training_time", 0)
+        + restart_metrics.get("total_wall_time", 0),
+        "cumulative_checkpoint_time": restart_metrics.get(
+            "cumulative_checkpoint_time", 0
+        )
+        + restart_metrics.get("total_checkpoint_time", 0),
+        "cumulative_checkpoint_count": restart_metrics.get(
+            "cumulative_checkpoint_count", 0
+        )
+        + restart_metrics.get("checkpoint_count", 0),
+        "job_start_time": restart_metrics.get("job_start_time", time.time()),
+        "recovery_breakdown": restart_metrics.get("recovery_breakdown", []),
+        "last_fault_time": restart_metrics.get("last_fault_time"),
+    }
+    save_persistent_metrics(checkpoint_path, cumulative)
+
+
+# ============================================================================
+# Core training function
+#
+# In combined mode (--inprocess), this function is wrapped by
+# inprocess.Wrapper and may be re-invoked multiple times.
+#
+# In in-job-only mode, this function runs once per ft_launcher worker
+# spawn.  If the worker crashes, ft_launcher respawns a new process that
+# calls this function again from scratch.
+# ============================================================================
+def train_fn(
+    args,
+    restart_metrics,
+    ft_client,
+    base_store,
+    fault_injector: Optional[FaultInjector] = None,
+    call_wrapper: Optional[CallWrapper] = None,
+):
+    """
+    Training function.
+
+    On each invocation (initial, after in-process restart, or after in-job respawn):
+    1. Reconnect FT client to rank monitor
+    2. Re-initialize the distributed process group
+    3. Re-create the FSDP model
+    4. Load from latest checkpoint
+    5. Resume training
+    """
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+
+    logger = setup_logging(rank)
+
+    # Determine restart type and iteration
+    iteration = call_wrapper.iteration if call_wrapper else 0
+    restart_entry_time = time.time()
+
+    # Load cumulative metrics from prior in-job restarts (iteration 0 only)
+    if iteration == 0:
+        merge_persistent_metrics(restart_metrics, args.checkpoint_path)
+
+    is_injob_restart = iteration == 0 and restart_metrics.get("injob_restarts", 0) > 0
+
+    if iteration > 0:
+        restart_metrics["inprocess_restart_count"] += 1
+        logger.info("=" * 60)
+        logger.info(f"IN-PROCESS RESTART #{iteration}")
+        logger.info(f"World size: {world_size}")
+        logger.info("=" * 60)
+    elif is_injob_restart:
+        n = restart_metrics["injob_restarts"]
+        logger.info("=" * 60)
+        logger.info(f"IN-JOB RESTART #{n} (ft_launcher respawn)")
+        logger.info(f"World size: {world_size}")
+        logger.info("=" * 60)
+    else:
+        mode_str = (
+            "COMBINED (ft_launcher + inprocess)"
+            if call_wrapper
+            else "IN-JOB ONLY (ft_launcher)"
+        )
+        logger.info("=" * 80)
+        logger.info(f"ft_launcher Training Starting - {mode_str}")
+        logger.info("=" * 80)
+        logger.info(f"Rank: {rank}, World Size: {world_size}, Local Rank: {local_rank}")
+        logger.info(f"In-Process Restart: {'Enabled' if call_wrapper else 'Disabled'}")
+        logger.info(f"Fault Injection: {args.inject_faults}")
+
+    # -----------------------------------------------------------------------
+    # Initialize distributed process group
+    # -----------------------------------------------------------------------
+    torch.cuda.set_device(local_rank)
+    t_nccl_start = time.time()
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+    # NOTE: Do NOT add an EFA cooldown here for ft_launcher. Unlike
+    # in-process restart (same process, stale EFA state), ft_launcher
+    # spawns fresh processes. Adding a sleep causes timing mismatches
+    # between nodes (workers sleep different durations, miss each other's
+    # NCCL init window, cascade restarts). ft_launcher's own rendezvous
+    # handles coordination.
+
+    master_addr = os.environ.get("MASTER_ADDR", "localhost")
+    master_port = int(os.environ.get("MASTER_PORT", 29500))
+
+    # ft_launcher sets MASTER_ADDR to localhost (each pod's ft_launcher
+    # manages only local workers).  For the cross-pod NCCL process group
+    # we need the actual rank-0 pod IP.  Use PG_MASTER_ADDR if set by
+    # the K8s manifest; fall back to MASTER_ADDR (works for single-node).
+    pg_master_addr = os.environ.get("PG_MASTER_ADDR", master_addr)
+
+    if base_store is not None:
+        # Combined mode: use PrefixStore on the shared base_store, keyed by
+        # the inprocess restart iteration to avoid stale keys.
+        store = dist.PrefixStore(str(iteration), base_store)
+    else:
+        # In-job-only mode: create a TCPStore on MASTER_PORT+1 to avoid
+        # conflict with ft_launcher's rendezvous store on MASTER_PORT.
+        store = dist.TCPStore(
+            host_name=pg_master_addr,
+            port=master_port + 1,
+            world_size=world_size,
+            is_master=(rank == 0),
+            multi_tenant=True,
+            wait_for_workers=True,
+            use_libuv=True,
+        )
+
+    dist.init_process_group(
+        backend="nccl",
+        store=store,
+        rank=rank,
+        world_size=world_size,
+        timeout=datetime.timedelta(seconds=args.nccl_timeout_seconds),
+    )
+    logger.info(f"Distributed initialized: rank={rank}, world_size={world_size}")
+    t_nccl_end = time.time()
+
+    # -----------------------------------------------------------------------
+    # Initialize FT client AFTER process group (needs distributed context)
+    # -----------------------------------------------------------------------
+    if ft_client is not None:
+        if ft_client.is_initialized:
+            ft_client.shutdown_workload_monitoring()
+        ft_client.init_workload_monitoring()
+        logger.info("FT client: workload monitoring initialized")
+
+    # -----------------------------------------------------------------------
+    # Create model and wrap with FSDP
+    # -----------------------------------------------------------------------
+    t_model_start = time.time()
+    logger.info(f"Loading model: {args.model_name}")
+    tokenizer = get_tokenizer(args.model_name)
+
+    model, _ = create_model(args.model_name, args.torch_dtype)
+    model = wrap_model(model, args.parallel_strategy, local_rank, args.model_name)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.learning_rate)
+    t_model_end = time.time()
+
+    # Load from checkpoint
+    t_ckpt_load_start = time.time()
+    start_step = load_checkpoint(
+        args.checkpoint_path, model, optimizer, rank, args.parallel_strategy, ft_client
+    )
+    t_ckpt_load_end = time.time()
+
+    # Mark scheduled faults as already injected to prevent re-triggering
+    # after ft_launcher restart. Same logic as train_inprocess.py.
+    if fault_injector is not None and hasattr(fault_injector, "fault_schedule"):
+        max_completed = max(
+            start_step,
+            restart_metrics.get("cumulative_steps_completed", 0),
+        )
+        for fstep in fault_injector.fault_schedule:
+            if fstep <= max_completed:
+                fault_injector.injected_steps.add(fstep)
+
+    # Create dataloader
+    t_dl_start = time.time()
+    dataloader = create_dataloader(args, tokenizer, rank, world_size)
+    dataloader_iter = iter(dataloader)
+    t_dl_end = time.time()
+
+    # -----------------------------------------------------------------------
+    # Training loop
+    # -----------------------------------------------------------------------
+    model.train()
+    training_start_time = restart_metrics.get("training_start_time", time.time())
+    if "training_start_time" not in restart_metrics:
+        restart_metrics["training_start_time"] = training_start_time
+
+    job_start_time = restart_metrics.get("job_start_time", training_start_time)
+
+    # Recovery overhead measurement with per-phase breakdown
+    if iteration > 0 or is_injob_restart:
+        startup_time = time.time() - restart_entry_time
+        nccl_time = t_nccl_end - t_nccl_start
+        model_time = t_model_end - t_model_start
+        ckpt_load_time = t_ckpt_load_end - t_ckpt_load_start
+        dl_time = t_dl_end - t_dl_start
+
+        # Compute shutdown time.
+        # Priority: (1) shared store (in-process mode with base_store),
+        # (2) local FaultInjector (same process),
+        # (3) persisted last_fault_time from cumulative_metrics.json
+        #     (ft_launcher in-job mode: new process, old fault time on FSx).
+        # Shutdown includes: ft_launcher heartbeat detection, worker kill,
+        # cross-node rendezvous, and new process spawn.
+        shutdown_time = 0.0
+        if base_store is not None:
+            try:
+                fault_time_str = base_store.get("last_fault_time")
+                shutdown_time = restart_entry_time - float(fault_time_str)
+                if shutdown_time < 0:
+                    shutdown_time = 0.0
+            except Exception:
+                pass
+        if shutdown_time == 0.0 and fault_injector and fault_injector.last_fault_time:
+            shutdown_time = restart_entry_time - fault_injector.last_fault_time
+        if shutdown_time == 0.0 and is_injob_restart:
+            persisted_ft = restart_metrics.get("last_fault_time")
+            if persisted_ft is not None:
+                shutdown_time = restart_entry_time - persisted_ft
+                if shutdown_time < 0:
+                    shutdown_time = 0.0
+
+        total_recovery = shutdown_time + startup_time
+        restart_metrics["recovery_times"].append(total_recovery)
+
+        if "recovery_breakdown" not in restart_metrics:
+            restart_metrics["recovery_breakdown"] = []
+        restart_metrics["recovery_breakdown"].append(
+            {
+                "iteration": iteration,
+                "type": "in-process" if iteration > 0 else "in-job",
+                "shutdown_seconds": round(shutdown_time, 3),
+                "startup_nccl_seconds": round(nccl_time, 3),
+                "startup_model_seconds": round(model_time, 3),
+                "startup_ckpt_load_seconds": round(ckpt_load_time, 3),
+                "startup_dataloader_seconds": round(dl_time, 3),
+                "startup_total_seconds": round(startup_time, 3),
+                "total_seconds": round(total_recovery, 3),
+                "resumed_from_step": start_step,
+            }
+        )
+
+        restart_type = "in-process" if iteration > 0 else "in-job (ft_launcher)"
+        logger.info(
+            f"Recovery overhead [{restart_type}]: "
+            f"shutdown={shutdown_time:.3f}s, "
+            f"startup={startup_time:.3f}s "
+            f"(NCCL: {nccl_time:.3f}s, "
+            f"Model: {model_time:.3f}s, "
+            f"Ckpt: {ckpt_load_time:.3f}s, "
+            f"DL: {dl_time:.3f}s), "
+            f"total={total_recovery:.3f}s, "
+            f"resumed from step {start_step}"
+        )
+    else:
+        # First iteration: record setup time
+        restart_metrics["setup_time"] = time.time() - restart_entry_time
+
+    max_training_time = args.training_duration_minutes * 60
+    step = start_step
+    checkpoint_count = restart_metrics.get("checkpoint_count", 0)
+    total_checkpoint_time = restart_metrics.get("total_checkpoint_time", 0)
+    termination_reason = "max_steps_reached"
+
+    logger.info(f"Starting training from step {start_step}...")
+
+    while step < args.max_steps:
+        wall_elapsed = time.time() - training_start_time
+        if wall_elapsed >= max_training_time:
+            logger.info(
+                f"Training time limit reached ({args.training_duration_minutes} min)"
+            )
+            termination_reason = "time_limit"
+            break
+
+        # Get batch
+        try:
+            batch = next(dataloader_iter)
+        except StopIteration:
+            dataloader_iter = iter(dataloader)
+            batch = next(dataloader_iter)
+
+        # Training step
+        loss = train_step(model, batch, optimizer)
+        step += 1
+
+        # Signal liveness to both monitors
+        if call_wrapper is not None:
+            call_wrapper.ping()  # in-process Wrapper liveness
+        if ft_client is not None and ft_client.is_initialized:
+            ft_client.send_heartbeat()  # ft_launcher rank monitor liveness
+
+        # Log progress
+        if step % 10 == 0:
+            logger.info(
+                f"Step {step}, Loss: {loss:.4f}, "
+                f"Wall: {wall_elapsed:.0f}s, "
+                f"InProcess: {restart_metrics['inprocess_restart_count']}, "
+                f"InJob: {restart_metrics.get('injob_restarts', 0)}"
+            )
+
+        # Fault injection (configurable types: exception, sigkill, hang)
+        if fault_injector is not None:
+            fault_injector.maybe_inject(step, rank)
+
+        # Checkpoint saving
+        if step % args.checkpoint_interval == 0:
+            logger.info(f"Saving checkpoint at step {step}...")
+            _, ckpt_time = save_checkpoint(
+                model,
+                optimizer,
+                step,
+                args.checkpoint_path,
+                rank,
+                args.parallel_strategy,
+                ft_client=ft_client,
+                call_wrapper=call_wrapper,
+            )
+            logger.info(f"Checkpoint saved in {ckpt_time:.3f}s")
+            total_checkpoint_time += ckpt_time
+            checkpoint_count += 1
+
+            # Persist metrics alongside checkpoint
+            restart_metrics["total_steps"] = step
+            restart_metrics["total_wall_time"] = time.time() - training_start_time
+            restart_metrics["total_checkpoint_time"] = total_checkpoint_time
+            restart_metrics["checkpoint_count"] = checkpoint_count
+            persist_current_metrics(restart_metrics, args.checkpoint_path)
+
+    # -----------------------------------------------------------------------
+    # Training complete
+    # -----------------------------------------------------------------------
+    total_wall_time = time.time() - training_start_time
+    total_job_time = time.time() - job_start_time
+    restart_metrics["total_steps"] = step
+    restart_metrics["total_wall_time"] = total_wall_time
+    restart_metrics["total_checkpoint_time"] = total_checkpoint_time
+    restart_metrics["checkpoint_count"] = checkpoint_count
+
+    persist_current_metrics(restart_metrics, args.checkpoint_path)
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+    # -----------------------------------------------------------------------
+    # Summary (rank 0 only)
+    # -----------------------------------------------------------------------
+    all_fault_steps = restart_metrics.get(
+        "cumulative_fault_steps", []
+    ) + restart_metrics.get("fault_steps", [])
+    all_recovery_times = restart_metrics.get(
+        "cumulative_recovery_times", []
+    ) + restart_metrics.get("recovery_times", [])
+    total_injob_restarts = restart_metrics.get("injob_restarts", 0)
+    inprocess_restarts = restart_metrics.get("inprocess_restart_count", 0)
+    cum_ckpt_count = (
+        restart_metrics.get("cumulative_checkpoint_count", 0) + checkpoint_count
+    )
+    cum_ckpt_time = (
+        restart_metrics.get("cumulative_checkpoint_time", 0) + total_checkpoint_time
+    )
+
+    if rank == 0:
+        if call_wrapper is not None:
+            mode_str = "COMBINED (ft_launcher + inprocess)"
+        else:
+            mode_str = "IN-JOB ONLY (ft_launcher)"
+
+        # Run completion status
+        reason_label = (
+            "completed" if termination_reason == "max_steps_reached" else "time-limited"
+        )
+
+        logger.info("=" * 80)
+        logger.info(f"TRAINING SUMMARY - {mode_str}")
+        logger.info("=" * 80)
+        logger.info(f"Model: {args.model_name}")
+        logger.info(f"World Size: {world_size}")
+        logger.info(f"Parallel Strategy: {args.parallel_strategy}")
+        logger.info(f"Mode: {mode_str}")
+        logger.info(f"NCCL Timeout: {args.nccl_timeout_seconds}s")
+        logger.info(f"Fault Injection: {args.inject_faults}")
+        logger.info("")
+        logger.info("TRAINING METRICS:")
+        logger.info(f"  Steps: {step}/{args.max_steps} ({reason_label})")
+        logger.info(f"  Termination: {termination_reason}")
+        logger.info(f"  Job wall time (incl. all restarts): {total_job_time:.1f}s")
+        cum_training_time = (
+            restart_metrics.get("cumulative_training_time", 0) + total_wall_time
+        )
+        logger.info(f"  Cumulative active training time: {cum_training_time:.1f}s")
+        logger.info(f"  Effective throughput: {step / total_job_time:.2f} steps/sec")
+        logger.info("")
+        logger.info("RESILIENCY METRICS:")
+        logger.info(f"  In-job restarts (ft_launcher): {total_injob_restarts}")
+        logger.info(f"  In-process restarts (NVRx Wrapper): {inprocess_restarts}")
+        logger.info(f"  Container restarts (K8s): 0 (ft_launcher handles recovery)")
+        logger.info(f"  Fault injection steps: {all_fault_steps}")
+        if all_recovery_times:
+            avg_recovery = sum(all_recovery_times) / len(all_recovery_times)
+            max_recovery = max(all_recovery_times)
+            min_recovery = min(all_recovery_times)
+            total_downtime = total_job_time - cum_training_time
+            logger.info(f"  Avg recovery overhead: {avg_recovery:.3f}s")
+            logger.info(f"  Min recovery overhead: {min_recovery:.3f}s")
+            logger.info(f"  Max recovery overhead: {max_recovery:.3f}s")
+            logger.info(
+                f"  Total downtime (job time - cumulative training): {total_downtime:.1f}s"
+            )
+            efficiency = (
+                (cum_training_time / total_job_time) * 100
+                if total_job_time > 0
+                else 100
+            )
+            logger.info(f"  Training efficiency: {efficiency:.1f}%")
+        else:
+            logger.info("  No restarts occurred")
+        logger.info("")
+        logger.info("CHECKPOINT METRICS:")
+        logger.info(f"  Total checkpoints: {cum_ckpt_count}")
+        logger.info(f"  Checkpoint interval: every {args.checkpoint_interval} steps")
+        if cum_ckpt_count > 0:
+            logger.info(f"  Avg checkpoint time: {cum_ckpt_time / cum_ckpt_count:.3f}s")
+        logger.info("=" * 80)
+
+        # Write results JSON for automated comparison
+        results = {
+            "experiment_type": "fault_recovery",
+            "mode": mode_str,
+            "model": args.model_name,
+            "world_size": world_size,
+            "parallel_strategy": args.parallel_strategy,
+            "max_steps": args.max_steps,
+            "steps_completed": step,
+            "termination_reason": termination_reason,
+            "job_wall_time_seconds": round(total_job_time, 1),
+            "cumulative_training_time_seconds": round(cum_training_time, 1),
+            "effective_throughput_steps_per_sec": round(step / total_job_time, 4)
+            if total_job_time > 0
+            else 0,
+            "training_efficiency_pct": round(
+                (cum_training_time / total_job_time) * 100, 2
+            )
+            if total_job_time > 0
+            else 100,
+            "injob_restarts": total_injob_restarts,
+            "inprocess_restarts": inprocess_restarts,
+            "total_faults": len(all_fault_steps),
+            "fault_steps": all_fault_steps,
+            "recovery_times": [round(t, 3) for t in all_recovery_times],
+            "avg_recovery_time_seconds": round(
+                sum(all_recovery_times) / len(all_recovery_times), 3
+            )
+            if all_recovery_times
+            else None,
+            "total_checkpoints": cum_ckpt_count,
+            "checkpoint_interval": args.checkpoint_interval,
+            "avg_checkpoint_time_seconds": round(cum_ckpt_time / cum_ckpt_count, 3)
+            if cum_ckpt_count > 0
+            else None,
+            "recovery_breakdown": restart_metrics.get("recovery_breakdown", []),
+        }
+
+        # Compute goodput metrics
+        recovery_bd = results["recovery_breakdown"]
+        total_shutdown = sum(r.get("shutdown_seconds", 0) for r in recovery_bd)
+        total_startup = sum(r.get("startup_total_seconds", 0) for r in recovery_bd)
+        total_fault_downtime = total_shutdown + total_startup
+
+        wasted_steps = 0
+        fault_steps_for_wasted = all_fault_steps
+        if fault_injector and fault_injector.fault_count is not None:
+            fault_steps_for_wasted = [s for s in fault_injector.fault_schedule.keys()]
+        for fs in fault_steps_for_wasted:
+            last_ckpt = (fs // args.checkpoint_interval) * args.checkpoint_interval
+            wasted_steps += fs - last_ckpt
+
+        # Step time from pure training (excluding checkpoint blocking)
+        pure_training_time = cum_training_time - cum_ckpt_time
+        avg_step_time = (
+            pure_training_time / step if step > 0 and pure_training_time > 0 else 0.37
+        )
+        wasted_time = wasted_steps * avg_step_time
+        setup_time = restart_metrics.get("setup_time", 0)
+
+        # Training goodput: useful training compute / wall time
+        # Useful training = completed_steps × avg_step_time (pure compute)
+        useful_training_time = step * avg_step_time
+        training_goodput = (
+            (useful_training_time / total_job_time) * 100 if total_job_time > 0 else 100
+        )
+        useful_training_time = max(0, useful_training_time)
+        training_goodput = (
+            (useful_training_time / total_job_time) * 100 if total_job_time > 0 else 100
+        )
+        infra_goodput = (
+            ((total_job_time - total_fault_downtime) / total_job_time) * 100
+            if total_job_time > 0
+            else 100
+        )
+
+        results["training_goodput_pct"] = round(training_goodput, 2)
+        results["infra_goodput_pct"] = round(infra_goodput, 2)
+        results["wasted_steps"] = wasted_steps
+        results["wasted_time_seconds"] = round(wasted_time, 1)
+        results["total_shutdown_time_seconds"] = round(total_shutdown, 1)
+        results["total_startup_time_seconds"] = round(total_startup, 1)
+        results["total_checkpoint_time_seconds"] = round(cum_ckpt_time, 1)
+        results["useful_training_time_seconds"] = round(useful_training_time, 1)
+        results["setup_time_seconds"] = round(setup_time, 1)
+        results["avg_step_time_seconds"] = round(avg_step_time, 4)
+
+        logger.info(f"Training Goodput: {training_goodput:.1f}%")
+        logger.info(f"Infra Goodput: {infra_goodput:.1f}%")
+        logger.info(
+            f"Wasted steps: {wasted_steps} ({wasted_time:.1f}s), "
+            f"Shutdown: {total_shutdown:.1f}s, Startup: {total_startup:.1f}s"
+        )
+        try:
+            results_path = os.path.join(args.checkpoint_path, "results.json")
+            with open(results_path, "w") as f:
+                json.dump(results, f, indent=2)
+            logger.info(f"Results saved to {results_path}")
+        except Exception as e:
+            logger.error(f"Failed to save results: {e}")
+
+
+# ============================================================================
+# Main
+# ============================================================================
+def main():
+    args = parse_args()
+
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    master_port = int(os.environ.get("MASTER_PORT", 29500))
+
+    # Also honour the env var so the K8s manifest can set it
+    use_inprocess = args.inprocess or os.environ.get(
+        "ENABLE_INPROCESS", ""
+    ).lower() in ("1", "true", "yes")
+
+    # ------------------------------------------------------------------
+    # Prepare FT client (works in both modes)
+    # ------------------------------------------------------------------
+    ft_client = None
+    if NVRX_FT_AVAILABLE:
+        ft_client = fault_tolerance.RankMonitorClient()
+        print(f"[Rank {rank}] FT RankMonitorClient created")
+    else:
+        print(f"[Rank {rank}] WARNING: fault_tolerance not available, no heartbeats")
+
+    # Shared metrics dict
+    restart_metrics = {
+        "inprocess_restart_count": 0,
+        "recovery_times": [],
+        "fault_steps": [],
+        "total_steps": 0,
+        "total_wall_time": 0,
+        "total_checkpoint_time": 0,
+        "checkpoint_count": 0,
+    }
+
+    # Pre-load tokenizer and dataset
+    print(f"[Rank {rank}] Pre-loading tokenizer and dataset...")
+    get_tokenizer(args.model_name)
+    get_dataset(args.dataset_name, args.streaming, args.dataset_path)
+    print(f"[Rank {rank}] Pre-loading complete.")
+
+    # ------------------------------------------------------------------
+    # Create fault injector (if enabled)
+    # ------------------------------------------------------------------
+    fault_injector = None
+    if args.inject_faults:
+        fault_types = [ft.strip() for ft in args.fault_types.split(",")]
+        weights = None
+        if args.fault_type_weights:
+            weights = [float(w.strip()) for w in args.fault_type_weights.split(",")]
+
+        def _on_fault(step, _rank, fault_type):
+            restart_metrics["fault_steps"].append(step)
+            # Record fault time for shutdown measurement
+            restart_metrics["last_fault_time"] = time.time()
+            # Persist metrics before injection -- SIGKILL kills process instantly
+            restart_metrics["total_steps"] = step
+            persist_current_metrics(restart_metrics, args.checkpoint_path)
+
+        fault_injector = FaultInjector(
+            fault_types=fault_types,
+            weights=weights,
+            probability=args.fault_probability,
+            after_step=args.fault_after_step,
+            on_fault=_on_fault,
+            fault_count=args.fault_count,
+            fault_seed=args.fault_seed,
+            max_steps=args.max_steps,
+            world_size=int(os.environ.get("WORLD_SIZE", 2)),
+        )
+        print(f"[Rank {rank}] Fault injector: {fault_injector}")
+    else:
+        print(f"[Rank {rank}] Fault injection disabled")
+
+    if use_inprocess:
+        # ==============================================================
+        # Combined mode: ft_launcher + inprocess.Wrapper
+        # ==============================================================
+        if not NVRX_INPROCESS_AVAILABLE:
+            print("ERROR: --inprocess requested but inprocess module not available")
+            sys.exit(1)
+
+        print(f"[Rank {rank}] Mode: COMBINED (ft_launcher + inprocess)")
+
+        # Base TCPStore shared across all inprocess restart iterations.
+        # Port MASTER_PORT+1 avoids conflict with ft_launcher's rendezvous
+        # on MASTER_PORT.  Use PG_MASTER_ADDR for cross-pod connectivity.
+        pg_master_addr = os.environ.get("PG_MASTER_ADDR", os.environ["MASTER_ADDR"])
+        base_store = dist.TCPStore(
+            host_name=pg_master_addr,
+            port=master_port + 1,
+            world_size=world_size,
+            is_master=(rank == 0),
+            multi_tenant=True,
+            wait_for_workers=True,
+            use_libuv=True,
+        )
+
+        # Connect fault injector to shared store for fault time broadcast
+        if fault_injector is not None:
+            fault_injector._shared_store = base_store
+
+        # Wrap training function with inprocess.Wrapper
+        # store_kwargs must include host for cross-pod connectivity since
+        # ft_launcher sets MASTER_ADDR=localhost (per-pod).
+        wrapped_train = inprocess.Wrapper(
+            store_kwargs={"host_name": pg_master_addr, "port": master_port + 2},
+            soft_timeout=datetime.timedelta(seconds=args.soft_timeout_seconds),
+            hard_timeout=datetime.timedelta(seconds=args.hard_timeout_seconds),
+            barrier_timeout=datetime.timedelta(seconds=args.barrier_timeout_seconds),
+            completion_timeout=datetime.timedelta(seconds=args.barrier_timeout_seconds),
+            health_check=inprocess.Compose(
+                inprocess.health_check.CudaHealthCheck(),
+                inprocess.health_check.FaultCounter(max_rank_faults=5),
+            ),
+            initialize=inprocess.initialize.RetryController(
+                max_iterations=args.max_inprocess_restarts,
+                min_active_world_size=1,
+            ),
+            rank_assignment=inprocess.Compose(
+                inprocess.rank_assignment.ActivateAllRanks(),
+                inprocess.rank_assignment.ShiftRanks(),
+            ),
+        )(train_fn)
+
+        try:
+            wrapped_train(args, restart_metrics, ft_client, base_store, fault_injector)
+        finally:
+            if ft_client is not None and ft_client.is_initialized:
+                ft_client.shutdown_workload_monitoring()
+
+    else:
+        # ==============================================================
+        # In-job only mode: ft_launcher without inprocess.Wrapper
+        # ==============================================================
+        print(f"[Rank {rank}] Mode: IN-JOB ONLY (ft_launcher)")
+
+        try:
+            train_fn(
+                args,
+                restart_metrics,
+                ft_client,
+                base_store=None,
+                fault_injector=fault_injector,
+                call_wrapper=None,
+            )
+        finally:
+            if ft_client is not None and ft_client.is_initialized:
+                ft_client.shutdown_workload_monitoring()
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/pytorch/nvrx/src/train_inprocess.py
+++ b/3.test_cases/pytorch/nvrx/src/train_inprocess.py
@@ -1,0 +1,1088 @@
+#!/usr/bin/env python3
+"""
+NVRx In-Process Restart Test Script
+
+Demonstrates NVRx in-process restart with FSDP/DDP training.
+Compares recovery time and training continuity between:
+  - Baseline: No fault tolerance (crash = full restart)
+  - NVRx: In-process restart (crash = seconds-level recovery)
+
+The script wraps the training function with nvidia_resiliency_ext.inprocess.Wrapper,
+which automatically detects failures and restarts the training on healthy ranks
+without restarting the container or re-creating the CUDA context.
+
+Supports both FSDP and DDP via --parallel_strategy flag.
+
+Launch with torchrun for multi-GPU per node:
+  torchrun --nnodes=2 --nproc_per_node=8 \\
+    --rdzv_backend=c10d --rdzv_endpoint=$MASTER_ADDR:29500 \\
+    train_inprocess.py [args]
+
+Port allocation:
+  MASTER_PORT (29500)     -- torchrun rendezvous (only used by torchrun, not by this script)
+  MASTER_PORT + 1         -- inprocess.Wrapper internal store
+  MASTER_PORT + 2         -- base TCPStore for NCCL process group (PrefixStore per restart)
+"""
+
+import os
+import sys
+import time
+import json
+import random
+import argparse
+import logging
+import datetime
+from typing import Optional
+
+# Required environment variables for NVRx in-process restart.
+# These suppress error rethrows so the Wrapper can handle them.
+# In baseline mode (DISABLE_NVRX_WRAPPER=1), we do NOT set these
+# so that NCCL errors properly crash the process for K8s to restart.
+if os.environ.get("DISABLE_NVRX_WRAPPER", "").lower() not in ("1", "true", "yes"):
+    os.environ.setdefault("TORCH_CPP_LOG_LEVEL", "error")
+    os.environ.setdefault("NCCL_NVLS_ENABLE", "0")
+    os.environ.setdefault("TORCH_NCCL_RETHROW_CUDA_ERRORS", "0")
+
+import torch
+import torch.distributed as dist
+
+from transformers import AutoTokenizer
+from datasets import load_dataset
+
+# Import NVRx in-process restart
+try:
+    import nvidia_resiliency_ext.inprocess as inprocess
+    from nvidia_resiliency_ext.inprocess import CallWrapper
+
+    NVRX_INPROCESS_AVAILABLE = True
+except ImportError:
+    NVRX_INPROCESS_AVAILABLE = False
+    CallWrapper = None
+
+from distributed_utils import (
+    add_distributed_args,
+    create_model,
+    wrap_model,
+    create_dataloader as _create_dataloader_shared,
+    train_step,
+    save_checkpoint as _save_checkpoint_shared,
+    load_checkpoint as _load_checkpoint_shared,
+)
+from metrics_collector import MetricsCollector
+from failure_simulator import FaultInjector
+
+
+# ============================================================================
+# Global state that survives across restarts (process-group independent)
+# This is a key advantage of in-process restart: we don't re-download
+# the dataset or re-tokenize on each recovery.
+# ============================================================================
+_tokenizer = None
+_dataset = None
+
+
+def str2bool(v):
+    """Argparse type for boolean arguments."""
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "1"):
+        return True
+    if v.lower() in ("no", "false", "f", "0"):
+        return False
+    raise argparse.ArgumentTypeError(f"Boolean value expected, got {v!r}")
+
+
+def setup_logging(rank):
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"[Rank {rank}] %(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+        force=True,
+    )
+    return logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="NVRx In-Process Restart Test")
+
+    parser.add_argument("--model_name", type=str, default="gpt2")
+    parser.add_argument("--max_seq_length", type=int, default=512)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--learning_rate", type=float, default=5e-5)
+    parser.add_argument("--max_steps", type=int, default=1000)
+
+    parser.add_argument("--dataset_name", type=str, default="allenai/c4")
+    parser.add_argument("--streaming", type=str2bool, default=True)
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default=None,
+        help="Path to pre-downloaded dataset (created by prepare_dataset.py). "
+        "If set, loads from local disk with zero HF API calls. "
+        "If not set, streams from HuggingFace Hub.",
+    )
+
+    # Checkpointing
+    parser.add_argument("--checkpoint_path", type=str, default="/checkpoints")
+    parser.add_argument("--checkpoint_interval", type=int, default=50)
+
+    # Training duration
+    parser.add_argument("--training_duration_minutes", type=int, default=10)
+
+    # Fault injection
+    parser.add_argument(
+        "--inject_faults",
+        action="store_true",
+        default=False,
+        help="Enable random fault injection for testing",
+    )
+    parser.add_argument(
+        "--fault_probability",
+        type=float,
+        default=0.002,
+        help="Probability of fault per step (only on rank 1)",
+    )
+    parser.add_argument(
+        "--fault_after_step",
+        type=int,
+        default=50,
+        help="Only inject faults after this step (allow initial training)",
+    )
+    parser.add_argument(
+        "--fault_types",
+        type=str,
+        default="exception",
+        help="Comma-separated fault types to inject: exception, sigkill, hang. "
+        "Default: exception. Note: sigkill is unrecoverable in pure in-process "
+        "mode (will crash the container).",
+    )
+    parser.add_argument(
+        "--fault_type_weights",
+        type=str,
+        default=None,
+        help="Comma-separated weights for fault types (same length as --fault_types). "
+        "Default: uniform. Example: '0.7,0.3' for 70%% exception / 30%% sigkill.",
+    )
+    parser.add_argument(
+        "--fault_count",
+        type=int,
+        default=None,
+        help="If set, inject exactly this many faults at pre-determined steps "
+        "(deterministic mode). Overrides --fault_probability. Use with "
+        "--fault_seed for reproducible fault patterns across experiments.",
+    )
+    parser.add_argument(
+        "--fault_seed",
+        type=int,
+        default=42,
+        help="Random seed for deterministic fault schedule. Only used when "
+        "--fault_count is set. Same seed = same fault steps and target ranks.",
+    )
+
+    # In-process restart config
+    parser.add_argument(
+        "--soft_timeout_seconds",
+        type=int,
+        default=120,
+        help="Soft timeout for hang detection (seconds)",
+    )
+    parser.add_argument(
+        "--hard_timeout_seconds",
+        type=int,
+        default=180,
+        help="Hard timeout for rank termination (seconds)",
+    )
+    parser.add_argument(
+        "--barrier_timeout_seconds",
+        type=int,
+        default=300,
+        help="Barrier timeout (must be > hard_timeout_seconds)",
+    )
+    parser.add_argument(
+        "--max_restarts",
+        type=int,
+        default=10,
+        help="Maximum number of in-process restarts before giving up",
+    )
+    parser.add_argument(
+        "--nccl_timeout_seconds",
+        type=int,
+        default=300,
+        help="NCCL operation timeout (seconds). Lower values detect peer "
+        "failures faster in baseline mode.",
+    )
+    parser.add_argument(
+        "--disable_nvrx_wrapper",
+        action="store_true",
+        default=False,
+        help="Run without NVRx in-process restart wrapper (baseline mode). "
+        "Faults will crash the container and rely on Kubernetes restart.",
+    )
+
+    # Distributed strategy & dtype (from shared utils)
+    add_distributed_args(parser)
+
+    return parser.parse_args()
+
+
+def get_tokenizer(model_name):
+    """Get or create tokenizer (survives across restarts)."""
+    global _tokenizer
+    if _tokenizer is None:
+        _tokenizer = AutoTokenizer.from_pretrained(model_name)
+        if _tokenizer.pad_token is None:
+            _tokenizer.pad_token = _tokenizer.eos_token
+    return _tokenizer
+
+
+def get_dataset(dataset_name, streaming=True, dataset_path=None):
+    """Get or create dataset (survives across restarts).
+
+    If dataset_path is set, loads a pre-downloaded dataset from local disk
+    (no HuggingFace API calls -- eliminates 429 rate limiting on restarts).
+    Otherwise, streams from HuggingFace Hub with retry logic.
+
+    Use prepare_dataset.py to create the local dataset:
+        python prepare_dataset.py --output_path /checkpoints/c4_subset
+    """
+    global _dataset
+    if _dataset is None:
+        if dataset_path is not None:
+            from datasets import load_from_disk
+
+            _dataset = load_from_disk(dataset_path)
+            print(
+                f"Loaded dataset from local path: {dataset_path} ({len(_dataset)} samples)"
+            )
+        else:
+            for attempt in range(10):
+                try:
+                    _dataset = load_dataset(
+                        dataset_name,
+                        "en",
+                        split="train",
+                        streaming=streaming,
+                        trust_remote_code=True,
+                    )
+                    break
+                except Exception as e:
+                    if "429" in str(e) and attempt < 9:
+                        wait = 2**attempt + random.random() * 2
+                        logging.getLogger(__name__).warning(
+                            f"HF rate limit (429), retry {attempt + 1}/10 in {wait:.1f}s"
+                        )
+                        time.sleep(wait)
+                    else:
+                        raise
+    return _dataset
+
+
+def create_dataloader(args, tokenizer, rank, world_size):
+    """Create dataloader using cached dataset (survives across restarts)."""
+    dataset = get_dataset(args.dataset_name, args.streaming, args.dataset_path)
+
+    def collate_fn(batch):
+        texts = [item["text"] for item in batch]
+        encodings = tokenizer(
+            texts,
+            truncation=True,
+            max_length=args.max_seq_length,
+            padding=True,
+            return_tensors="pt",
+        )
+        return {
+            "input_ids": encodings["input_ids"],
+            "attention_mask": encodings["attention_mask"],
+            "labels": encodings["input_ids"].clone(),
+        }
+
+    if world_size > 1:
+        dataset_shard = dataset.shard(num_shards=world_size, index=rank)
+    else:
+        dataset_shard = dataset
+
+    from torch.utils.data import DataLoader
+
+    return DataLoader(
+        dataset_shard,
+        batch_size=args.batch_size,
+        collate_fn=collate_fn,
+        num_workers=2,
+    )
+
+
+# train_step is imported from distributed_utils
+
+
+def save_checkpoint(
+    model, optimizer, step, checkpoint_path, rank, strategy, call_wrapper=None
+):
+    """Save checkpoint, optionally protected by in-process restart atomic context.
+
+    All ranks save (both FSDP and DDP with local emptyDir storage).
+    """
+    return _save_checkpoint_shared(
+        model,
+        optimizer,
+        step,
+        checkpoint_path,
+        rank,
+        strategy,
+        call_wrapper=call_wrapper,
+    )
+
+
+def load_checkpoint(checkpoint_path, model, optimizer, rank, strategy):
+    """Load checkpoint if it exists. Returns start_step."""
+    start_step, _ = _load_checkpoint_shared(
+        checkpoint_path, model, optimizer, rank, strategy
+    )
+    return start_step
+
+
+# ============================================================================
+# Persistent metrics (survives across K8s container restarts)
+# ============================================================================
+METRICS_FILENAME = "cumulative_metrics.json"
+
+
+def load_persistent_metrics(checkpoint_path):
+    """Load cumulative metrics from disk, if they exist from a prior container restart."""
+    path = os.path.join(checkpoint_path, METRICS_FILENAME)
+    if os.path.exists(path):
+        try:
+            with open(path, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return None
+
+
+def save_persistent_metrics(checkpoint_path, metrics):
+    """Save cumulative metrics to disk so they survive container restarts."""
+    os.makedirs(checkpoint_path, exist_ok=True)
+    path = os.path.join(checkpoint_path, METRICS_FILENAME)
+    with open(path, "w") as f:
+        json.dump(metrics, f, indent=2)
+
+
+def merge_persistent_metrics(restart_metrics, checkpoint_path):
+    """
+    Load previously persisted metrics and merge into restart_metrics.
+
+    In baseline mode, each container restart gets a fresh restart_metrics dict.
+    This function restores cumulative state (total faults, total steps across
+    all container lifetimes, first-ever start time) from the metrics file.
+    """
+    prior = load_persistent_metrics(checkpoint_path)
+    if prior is None:
+        # First container start - record the absolute start time
+        restart_metrics["job_start_time"] = time.time()
+        return
+
+    # Merge cumulative fields from prior container runs
+    restart_metrics["container_restarts"] = prior.get("container_restarts", 0) + 1
+    restart_metrics["cumulative_fault_steps"] = prior.get("cumulative_fault_steps", [])
+    restart_metrics["cumulative_recovery_times"] = prior.get(
+        "cumulative_recovery_times", []
+    )
+    restart_metrics["cumulative_steps_completed"] = prior.get(
+        "cumulative_steps_completed", 0
+    )
+    restart_metrics["cumulative_training_time"] = prior.get(
+        "cumulative_training_time", 0
+    )
+    restart_metrics["cumulative_checkpoint_time"] = prior.get(
+        "cumulative_checkpoint_time", 0
+    )
+    restart_metrics["cumulative_checkpoint_count"] = prior.get(
+        "cumulative_checkpoint_count", 0
+    )
+    restart_metrics["job_start_time"] = prior.get("job_start_time", time.time())
+    restart_metrics["recovery_breakdown"] = prior.get("recovery_breakdown", [])
+    restart_metrics["last_fault_time"] = prior.get("last_fault_time")
+    restart_metrics["injected_fault_steps"] = prior.get("injected_fault_steps", [])
+
+
+def persist_current_metrics(restart_metrics, checkpoint_path):
+    """Persist the current cumulative metrics snapshot to disk."""
+    cumulative = {
+        "container_restarts": restart_metrics.get("container_restarts", 0),
+        "cumulative_fault_steps": restart_metrics.get("cumulative_fault_steps", [])
+        + restart_metrics.get("fault_steps", []),
+        "cumulative_recovery_times": restart_metrics.get(
+            "cumulative_recovery_times", []
+        )
+        + restart_metrics.get("recovery_times", []),
+        "cumulative_steps_completed": restart_metrics.get("total_steps", 0),
+        "cumulative_training_time": restart_metrics.get("cumulative_training_time", 0)
+        + restart_metrics.get("total_wall_time", 0),
+        "cumulative_checkpoint_time": restart_metrics.get(
+            "cumulative_checkpoint_time", 0
+        )
+        + restart_metrics.get("total_checkpoint_time", 0),
+        "cumulative_checkpoint_count": restart_metrics.get(
+            "cumulative_checkpoint_count", 0
+        )
+        + restart_metrics.get("checkpoint_count", 0),
+        "job_start_time": restart_metrics.get("job_start_time", time.time()),
+        "recovery_breakdown": restart_metrics.get("recovery_breakdown", []),
+        "last_fault_time": restart_metrics.get("last_fault_time"),
+        "injected_fault_steps": restart_metrics.get("injected_fault_steps", []),
+    }
+    save_persistent_metrics(checkpoint_path, cumulative)
+
+
+# ============================================================================
+# Training function wrapped by NVRx in-process restart
+# ============================================================================
+def train_with_inprocess_restart(
+    args,
+    restart_metrics,
+    base_store=None,
+    fault_injector: Optional[FaultInjector] = None,
+    call_wrapper: Optional[CallWrapper] = None,
+):
+    """
+    Training function that can be wrapped by NVRx in-process restart.
+
+    On each invocation (initial or after restart):
+    1. Re-initialize the distributed process group
+    2. Re-create the FSDP model
+    3. Load from latest checkpoint
+    4. Resume training from the checkpoint step
+
+    Args:
+        base_store: Shared TCPStore for NCCL process group. In NVRx mode, a
+            PrefixStore keyed by the restart iteration is created on top of
+            this to avoid stale keys. In baseline mode, this is None and a
+            fresh TCPStore is created each time (only one iteration).
+    """
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+
+    logger = setup_logging(rank)
+
+    # Track restart iteration
+    iteration = call_wrapper.iteration if call_wrapper else 0
+    restart_entry_time = time.time()
+
+    # Load cumulative metrics from prior container restarts (baseline mode)
+    # or prior Wrapper iterations (NVRx mode, iteration 0 only).
+    # This must happen before we log anything about restarts.
+    if iteration == 0:
+        merge_persistent_metrics(restart_metrics, args.checkpoint_path)
+
+    is_container_restart = (
+        iteration == 0 and restart_metrics.get("container_restarts", 0) > 0
+    )
+
+    if iteration > 0:
+        restart_metrics["restart_count"] += 1
+        logger.info(f"=" * 60)
+        logger.info(f"IN-PROCESS RESTART #{iteration}")
+        logger.info(f"World size: {world_size}")
+        logger.info(f"=" * 60)
+    elif is_container_restart:
+        n = restart_metrics["container_restarts"]
+        logger.info(f"=" * 60)
+        logger.info(f"CONTAINER RESTART #{n} (Kubernetes)")
+        logger.info(f"World size: {world_size}")
+        logger.info(f"=" * 60)
+    else:
+        logger.info("=" * 80)
+        logger.info("NVRx In-Process Restart Training Starting")
+        logger.info("=" * 80)
+        logger.info(f"Rank: {rank}, World Size: {world_size}, Local Rank: {local_rank}")
+        logger.info(f"In-Process Restart: {'Enabled' if call_wrapper else 'Disabled'}")
+        logger.info(f"Fault Injection: {args.inject_faults}")
+
+    # Initialize distributed (must be done each restart)
+    torch.cuda.set_device(local_rank)
+    t_nccl_start = time.time()
+    if world_size > 1:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+            # Allow EFA/libfabric to fully release RDMA connections before
+            # re-creating the process group. Without this delay, stale EFA
+            # connection state causes transient NCCL errors on re-init,
+            # especially at scale (32 EFA devices on p5.48xlarge).
+            if iteration > 0:
+                time.sleep(5)
+                logger.info("EFA cooldown (5s) after process group destroy")
+
+        master_addr = os.environ.get("MASTER_ADDR", "localhost")
+        master_port = int(os.environ.get("MASTER_PORT", 29500))
+
+        if base_store is not None:
+            # NVRx mode: use PrefixStore on the shared base_store, keyed by
+            # the restart iteration to avoid stale keys from prior process
+            # groups. This matches the pattern in train_ft_launcher.py.
+            store = dist.PrefixStore(str(iteration), base_store)
+        else:
+            # Baseline mode (or single iteration): create a fresh TCPStore.
+            # Use MASTER_PORT + 2 to avoid conflict with the Wrapper's
+            # internal store on MASTER_PORT + 1.
+            store = dist.TCPStore(
+                host_name=master_addr,
+                port=master_port + 2,
+                world_size=world_size,
+                is_master=(rank == 0),
+                multi_tenant=True,
+                wait_for_workers=True,
+                use_libuv=True,
+            )
+
+        dist.init_process_group(
+            backend="nccl",
+            store=store,
+            rank=rank,
+            world_size=world_size,
+            timeout=datetime.timedelta(seconds=args.nccl_timeout_seconds),
+        )
+        logger.info(f"Distributed initialized: rank={rank}, world_size={world_size}")
+    t_nccl_end = time.time()
+
+    # Create model and wrap with FSDP/DDP
+    t_model_start = time.time()
+    logger.info(f"Loading model: {args.model_name}")
+    tokenizer = get_tokenizer(args.model_name)
+
+    model, _ = create_model(args.model_name, args.torch_dtype)
+    model = wrap_model(model, args.parallel_strategy, local_rank, args.model_name)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.learning_rate)
+    t_model_end = time.time()
+
+    # Load from checkpoint (resume after fault)
+    t_ckpt_load_start = time.time()
+    start_step = load_checkpoint(
+        args.checkpoint_path, model, optimizer, rank, args.parallel_strategy
+    )
+    t_ckpt_load_end = time.time()
+
+    # Mark scheduled faults as already injected to prevent re-triggering.
+    # Any fault step <= max(start_step, cumulative_steps_completed) was
+    # already reached in a prior iteration/container. We use the persisted
+    # cumulative_steps_completed because start_step may be 0 if no checkpoint
+    # exists yet but faults already fired (e.g., fault at step 62, no ckpt).
+    if fault_injector is not None and hasattr(fault_injector, "fault_schedule"):
+        max_completed = max(
+            start_step,
+            restart_metrics.get("cumulative_steps_completed", 0),
+        )
+        for fstep in fault_injector.fault_schedule:
+            if fstep <= max_completed:
+                fault_injector.injected_steps.add(fstep)
+        # Also load from persisted metrics (for faults before any checkpoint)
+        for fstep in restart_metrics.get("injected_fault_steps", []):
+            fault_injector.injected_steps.add(fstep)
+
+    # Create dataloader
+    t_dl_start = time.time()
+    dataloader = create_dataloader(args, tokenizer, rank, world_size)
+    dataloader_iter = iter(dataloader)
+    t_dl_end = time.time()
+
+    # Training loop
+    model.train()
+    training_start_time = restart_metrics.get("training_start_time", time.time())
+    if "training_start_time" not in restart_metrics:
+        restart_metrics["training_start_time"] = training_start_time
+
+    # Use job_start_time for total wall clock (persists across container restarts)
+    job_start_time = restart_metrics.get("job_start_time", training_start_time)
+
+    # Measure recovery overhead with per-phase breakdown
+    if iteration > 0 or is_container_restart:
+        startup_time = time.time() - restart_entry_time
+        nccl_time = t_nccl_end - t_nccl_start
+        model_time = t_model_end - t_model_start
+        ckpt_load_time = t_ckpt_load_end - t_ckpt_load_start
+        dl_time = t_dl_end - t_dl_start
+    else:
+        # First iteration: record setup time (NCCL + model + ckpt + dataloader)
+        restart_metrics["setup_time"] = time.time() - restart_entry_time
+
+    if iteration > 0 or is_container_restart:
+        startup_time = time.time() - restart_entry_time
+        nccl_time = t_nccl_end - t_nccl_start
+        model_time = t_model_end - t_model_start
+        ckpt_load_time = t_ckpt_load_end - t_ckpt_load_start
+        dl_time = t_dl_end - t_dl_start
+
+        # Compute shutdown time: from fault injection to function re-entry.
+        # Option D: read from shared store (broadcast by faulting rank).
+        # Fallback: read from local FaultInjector or cumulative_metrics.json.
+        shutdown_time = 0.0
+        if base_store is not None:
+            try:
+                fault_time_str = base_store.get("last_fault_time")
+                shutdown_time = restart_entry_time - float(fault_time_str)
+                if shutdown_time < 0:
+                    shutdown_time = 0.0  # Clock skew guard
+            except Exception:
+                pass
+        if (
+            shutdown_time == 0.0
+            and iteration > 0
+            and fault_injector
+            and fault_injector.last_fault_time
+        ):
+            shutdown_time = restart_entry_time - fault_injector.last_fault_time
+        elif (
+            shutdown_time == 0.0
+            and is_container_restart
+            and "last_fault_time" in restart_metrics
+        ):
+            persisted_ft = restart_metrics.get("last_fault_time")
+            if persisted_ft is not None:
+                shutdown_time = restart_entry_time - persisted_ft
+
+        total_recovery = shutdown_time + startup_time
+        restart_metrics["recovery_times"].append(total_recovery)
+
+        # Store per-phase breakdown for detailed analysis
+        if "recovery_breakdown" not in restart_metrics:
+            restart_metrics["recovery_breakdown"] = []
+        restart_metrics["recovery_breakdown"].append(
+            {
+                "iteration": iteration,
+                "type": "in-process" if iteration > 0 else "container_restart",
+                "shutdown_seconds": round(shutdown_time, 3),
+                "startup_nccl_seconds": round(nccl_time, 3),
+                "startup_model_seconds": round(model_time, 3),
+                "startup_ckpt_load_seconds": round(ckpt_load_time, 3),
+                "startup_dataloader_seconds": round(dl_time, 3),
+                "startup_total_seconds": round(startup_time, 3),
+                "total_seconds": round(total_recovery, 3),
+                "resumed_from_step": start_step,
+            }
+        )
+
+        restart_type = "in-process" if iteration > 0 else "container restart"
+        logger.info(
+            f"Recovery overhead [{restart_type}]: "
+            f"shutdown={shutdown_time:.3f}s, "
+            f"startup={startup_time:.3f}s "
+            f"(NCCL: {nccl_time:.3f}s, "
+            f"Model: {model_time:.3f}s, "
+            f"Ckpt: {ckpt_load_time:.3f}s, "
+            f"DL: {dl_time:.3f}s), "
+            f"total={total_recovery:.3f}s, "
+            f"resumed from step {start_step}"
+        )
+
+    max_training_time = args.training_duration_minutes * 60
+    step = start_step
+    checkpoint_count = restart_metrics.get("checkpoint_count", 0)
+    total_checkpoint_time = restart_metrics.get("total_checkpoint_time", 0)
+    termination_reason = "max_steps_reached"
+
+    logger.info(f"Starting training from step {start_step}...")
+
+    while step < args.max_steps:
+        # Check training time limit (wall clock from first start)
+        wall_elapsed = time.time() - training_start_time
+        if wall_elapsed >= max_training_time:
+            logger.info(
+                f"Training time limit reached ({args.training_duration_minutes} min)"
+            )
+            termination_reason = "time_limit"
+            break
+
+        # Get batch
+        try:
+            batch = next(dataloader_iter)
+        except StopIteration:
+            dataloader_iter = iter(dataloader)
+            batch = next(dataloader_iter)
+
+        # Training step
+        loss = train_step(model, batch, optimizer)
+        step += 1
+
+        # Report progress to in-process restart monitor
+        if call_wrapper is not None:
+            call_wrapper.ping()
+
+        # Log progress
+        if step % 10 == 0:
+            logger.info(
+                f"Step {step}, Loss: {loss:.4f}, "
+                f"Wall: {wall_elapsed:.0f}s, "
+                f"Restarts: {restart_metrics['restart_count']}"
+            )
+
+        # Fault injection (configurable types: exception, sigkill, hang)
+        if fault_injector is not None:
+            fault_injector.maybe_inject(step, rank)
+
+        # Checkpoint saving (all ranks must participate - FSDP state_dict is collective)
+        if step % args.checkpoint_interval == 0:
+            logger.info(f"Saving checkpoint at step {step}...")
+            _, ckpt_time = save_checkpoint(
+                model,
+                optimizer,
+                step,
+                args.checkpoint_path,
+                rank,
+                args.parallel_strategy,
+                call_wrapper,
+            )
+            logger.info(f"Checkpoint saved in {ckpt_time:.3f}s")
+            total_checkpoint_time += ckpt_time
+            checkpoint_count += 1
+
+            # Persist cumulative metrics alongside checkpoint so they survive
+            # container crashes in baseline mode.
+            restart_metrics["total_steps"] = step
+            restart_metrics["total_wall_time"] = time.time() - training_start_time
+            restart_metrics["total_checkpoint_time"] = total_checkpoint_time
+            restart_metrics["checkpoint_count"] = checkpoint_count
+            persist_current_metrics(restart_metrics, args.checkpoint_path)
+
+    # Training complete
+    total_wall_time = time.time() - training_start_time
+    total_job_time = time.time() - job_start_time
+    restart_metrics["total_steps"] = step
+    restart_metrics["total_wall_time"] = total_wall_time
+    restart_metrics["total_checkpoint_time"] = total_checkpoint_time
+    restart_metrics["checkpoint_count"] = checkpoint_count
+
+    # Persist cumulative metrics to disk (survives container restarts)
+    persist_current_metrics(restart_metrics, args.checkpoint_path)
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+    # Build cumulative totals for summary
+    all_fault_steps = restart_metrics.get(
+        "cumulative_fault_steps", []
+    ) + restart_metrics.get("fault_steps", [])
+    all_recovery_times = restart_metrics.get(
+        "cumulative_recovery_times", []
+    ) + restart_metrics.get("recovery_times", [])
+    total_container_restarts = restart_metrics.get("container_restarts", 0)
+    in_process_restarts = restart_metrics.get("restart_count", 0)
+    cum_ckpt_count = (
+        restart_metrics.get("cumulative_checkpoint_count", 0) + checkpoint_count
+    )
+    cum_ckpt_time = (
+        restart_metrics.get("cumulative_checkpoint_time", 0) + total_checkpoint_time
+    )
+
+    # Print summary (only on rank 0 or if single process)
+    if rank == 0:
+        mode_str = (
+            "BASELINE (no fault tolerance)"
+            if call_wrapper is None
+            else "NVRx IN-PROCESS RESTART"
+        )
+        # Run completion status
+        reason_label = (
+            "completed" if termination_reason == "max_steps_reached" else "time-limited"
+        )
+
+        logger.info("=" * 80)
+        logger.info(f"TRAINING SUMMARY - {mode_str}")
+        logger.info("=" * 80)
+        logger.info(f"Model: {args.model_name}")
+        logger.info(f"World Size: {world_size}")
+        logger.info(f"Parallel Strategy: {args.parallel_strategy}")
+        logger.info(f"Mode: {mode_str}")
+        logger.info(f"NCCL Timeout: {args.nccl_timeout_seconds}s")
+        logger.info(f"Fault Injection: {args.inject_faults}")
+        logger.info("")
+        logger.info("TRAINING METRICS:")
+        logger.info(f"  Steps: {step}/{args.max_steps} ({reason_label})")
+        logger.info(f"  Termination: {termination_reason}")
+        logger.info(f"  Job wall time (incl. all restarts): {total_job_time:.1f}s")
+        # Cumulative active training across all container lifetimes
+        cum_training_time = (
+            restart_metrics.get("cumulative_training_time", 0) + total_wall_time
+        )
+        logger.info(f"  Cumulative active training time: {cum_training_time:.1f}s")
+        logger.info(f"  Effective throughput: {step / total_job_time:.2f} steps/sec")
+        logger.info("")
+        logger.info("RESILIENCY METRICS:")
+        logger.info(f"  Container restarts (K8s): {total_container_restarts}")
+        logger.info(f"  In-process restarts (NVRx): {in_process_restarts}")
+        logger.info(f"  Fault injection steps: {all_fault_steps}")
+        if all_recovery_times:
+            avg_recovery = sum(all_recovery_times) / len(all_recovery_times)
+            max_recovery = max(all_recovery_times)
+            min_recovery = min(all_recovery_times)
+            total_downtime = total_job_time - cum_training_time
+            logger.info(f"  Avg recovery overhead: {avg_recovery:.3f}s")
+            logger.info(f"  Min recovery overhead: {min_recovery:.3f}s")
+            logger.info(f"  Max recovery overhead: {max_recovery:.3f}s")
+            logger.info(
+                f"  Total downtime (job time - cumulative training): {total_downtime:.1f}s"
+            )
+            efficiency = (
+                (cum_training_time / total_job_time) * 100
+                if total_job_time > 0
+                else 100
+            )
+            logger.info(f"  Training efficiency: {efficiency:.1f}%")
+        else:
+            logger.info("  No restarts occurred")
+        logger.info("")
+        logger.info("CHECKPOINT METRICS:")
+        logger.info(f"  Total checkpoints: {cum_ckpt_count}")
+        logger.info(f"  Checkpoint interval: every {args.checkpoint_interval} steps")
+        if cum_ckpt_count > 0:
+            logger.info(f"  Avg checkpoint time: {cum_ckpt_time / cum_ckpt_count:.3f}s")
+            # Steps lost per fault = steps since last checkpoint
+            if all_fault_steps:
+                steps_lost = [fs % args.checkpoint_interval for fs in all_fault_steps]
+                avg_lost = sum(steps_lost) / len(steps_lost)
+                logger.info(f"  Avg steps lost per fault: {avg_lost:.0f}")
+        logger.info("=" * 80)
+
+        # Write results JSON for automated comparison
+        results = {
+            "experiment_type": "fault_recovery",
+            "mode": mode_str,
+            "model": args.model_name,
+            "world_size": world_size,
+            "parallel_strategy": args.parallel_strategy,
+            "max_steps": args.max_steps,
+            "steps_completed": step,
+            "termination_reason": termination_reason,
+            "job_wall_time_seconds": round(total_job_time, 1),
+            "cumulative_training_time_seconds": round(cum_training_time, 1),
+            "effective_throughput_steps_per_sec": round(step / total_job_time, 4)
+            if total_job_time > 0
+            else 0,
+            "training_efficiency_pct": round(
+                (cum_training_time / total_job_time) * 100, 2
+            )
+            if total_job_time > 0
+            else 100,
+            "container_restarts": total_container_restarts,
+            "inprocess_restarts": in_process_restarts,
+            "total_faults": len(all_fault_steps),
+            "fault_steps": all_fault_steps,
+            "recovery_times": [round(t, 3) for t in all_recovery_times],
+            "avg_recovery_time_seconds": round(
+                sum(all_recovery_times) / len(all_recovery_times), 3
+            )
+            if all_recovery_times
+            else None,
+            "total_checkpoints": cum_ckpt_count,
+            "checkpoint_interval": args.checkpoint_interval,
+            "avg_checkpoint_time_seconds": round(cum_ckpt_time / cum_ckpt_count, 3)
+            if cum_ckpt_count > 0
+            else None,
+            "recovery_breakdown": restart_metrics.get("recovery_breakdown", []),
+        }
+
+        # Compute goodput metrics
+        recovery_bd = results["recovery_breakdown"]
+        total_shutdown = sum(r.get("shutdown_seconds", 0) for r in recovery_bd)
+        total_startup = sum(r.get("startup_total_seconds", 0) for r in recovery_bd)
+        total_fault_downtime = total_shutdown + total_startup
+
+        # Wasted steps: steps computed between last checkpoint and fault,
+        # then discarded when rolling back to checkpoint.
+        # Use the deterministic fault schedule (all ranks' faults) rather than
+        # just rank 0's observed faults, since rank 0 may not inject any faults.
+        wasted_steps = 0
+        fault_steps_for_wasted = all_fault_steps
+        if fault_injector and fault_injector.fault_count is not None:
+            fault_steps_for_wasted = [s for s in fault_injector.fault_schedule.keys()]
+        for fs in fault_steps_for_wasted:
+            last_ckpt = (fs // args.checkpoint_interval) * args.checkpoint_interval
+            wasted_steps += fs - last_ckpt
+
+        # Step time from pure training (excluding checkpoint blocking)
+        pure_training_time = cum_training_time - cum_ckpt_time
+        avg_step_time = (
+            pure_training_time / step if step > 0 and pure_training_time > 0 else 0.37
+        )
+        wasted_time = wasted_steps * avg_step_time
+
+        # FSDP/NCCL initial setup time (first container only)
+        setup_time = restart_metrics.get("setup_time", 0)
+
+        # Training goodput: useful training compute / wall time
+        # Useful training = completed_steps × avg_step_time (pure compute)
+        useful_training_time = step * avg_step_time
+        training_goodput = (
+            (useful_training_time / total_job_time) * 100 if total_job_time > 0 else 100
+        )
+        useful_training_time = max(0, useful_training_time)
+        training_goodput = (
+            (useful_training_time / total_job_time) * 100 if total_job_time > 0 else 100
+        )
+
+        # Infra goodput: (wall_time - fault_downtime) / wall_time
+        infra_goodput = (
+            ((total_job_time - total_fault_downtime) / total_job_time) * 100
+            if total_job_time > 0
+            else 100
+        )
+
+        results["training_goodput_pct"] = round(training_goodput, 2)
+        results["infra_goodput_pct"] = round(infra_goodput, 2)
+        results["wasted_steps"] = wasted_steps
+        results["wasted_time_seconds"] = round(wasted_time, 1)
+        results["total_shutdown_time_seconds"] = round(total_shutdown, 1)
+        results["total_startup_time_seconds"] = round(total_startup, 1)
+        results["total_checkpoint_time_seconds"] = round(cum_ckpt_time, 1)
+        results["useful_training_time_seconds"] = round(useful_training_time, 1)
+        results["setup_time_seconds"] = round(setup_time, 1)
+        results["avg_step_time_seconds"] = round(avg_step_time, 4)
+
+        logger.info(f"Training Goodput: {training_goodput:.1f}%")
+        logger.info(f"Infra Goodput: {infra_goodput:.1f}%")
+        logger.info(
+            f"Wasted steps: {wasted_steps} ({wasted_time:.1f}s), "
+            f"Shutdown: {total_shutdown:.1f}s, Startup: {total_startup:.1f}s"
+        )
+        try:
+            results_path = os.path.join(args.checkpoint_path, "results.json")
+            with open(results_path, "w") as f:
+                json.dump(results, f, indent=2)
+            logger.info(f"Results saved to {results_path}")
+        except Exception as e:
+            logger.error(f"Failed to save results: {e}")
+
+
+def main():
+    args = parse_args()
+
+    # Check for disable flag (CLI arg or env var)
+    disable_wrapper = args.disable_nvrx_wrapper or os.environ.get(
+        "DISABLE_NVRX_WRAPPER", ""
+    ).lower() in ("1", "true", "yes")
+
+    # Shared metrics dict (mutable, survives across restarts since it's an arg)
+    restart_metrics = {
+        "restart_count": 0,
+        "recovery_times": [],
+        "fault_steps": [],
+        "total_steps": 0,
+        "total_wall_time": 0,
+        "total_checkpoint_time": 0,
+        "checkpoint_count": 0,
+    }
+
+    # ------------------------------------------------------------------
+    # Create fault injector (if enabled)
+    # ------------------------------------------------------------------
+    fault_injector = None
+    if args.inject_faults:
+        fault_types = [ft.strip() for ft in args.fault_types.split(",")]
+        weights = None
+        if args.fault_type_weights:
+            weights = [float(w.strip()) for w in args.fault_type_weights.split(",")]
+
+        def _on_fault(step, _rank, fault_type):
+            restart_metrics["fault_steps"].append(step)
+            # Track injected steps for persistence across container restarts
+            if "injected_fault_steps" not in restart_metrics:
+                restart_metrics["injected_fault_steps"] = []
+            restart_metrics["injected_fault_steps"].append(step)
+            # Record fault time for shutdown measurement across container restarts
+            restart_metrics["last_fault_time"] = time.time()
+            # Persist metrics before injection -- SIGKILL kills process instantly
+            restart_metrics["total_steps"] = step
+            persist_current_metrics(restart_metrics, args.checkpoint_path)
+
+        fault_injector = FaultInjector(
+            fault_types=fault_types,
+            weights=weights,
+            probability=args.fault_probability,
+            after_step=args.fault_after_step,
+            on_fault=_on_fault,
+            fault_count=args.fault_count,
+            fault_seed=args.fault_seed,
+            max_steps=args.max_steps,
+            world_size=int(os.environ.get("WORLD_SIZE", 2)),
+            pre_injected_steps=restart_metrics.get("injected_fault_steps", []),
+        )
+        print(f"Fault injector: {fault_injector}")
+    else:
+        print("Fault injection disabled")
+
+    if not NVRX_INPROCESS_AVAILABLE or disable_wrapper:
+        mode = "BASELINE (no fault tolerance)"
+        if disable_wrapper:
+            print(f"Mode: {mode} -- NVRx Wrapper disabled by flag")
+        else:
+            print(f"Mode: {mode} -- NVRx not available")
+        print(
+            "Faults will crash this process. "
+            "Recovery depends on Kubernetes restarting the container."
+        )
+        # Baseline: no base_store needed (single iteration, fresh TCPStore)
+        train_with_inprocess_restart(
+            args, restart_metrics, base_store=None, fault_injector=fault_injector
+        )
+        return
+
+    # NVRx in-process restart mode
+    print("Mode: NVRx IN-PROCESS RESTART")
+
+    # Pre-load tokenizer and dataset before wrapping (they survive across restarts)
+    print("Pre-loading tokenizer and dataset (will be reused across restarts)...")
+    get_tokenizer(args.model_name)
+    get_dataset(args.dataset_name, args.streaming, args.dataset_path)
+    print("Pre-loading complete.")
+
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    master_addr = os.environ.get("MASTER_ADDR", "localhost")
+    master_port = int(os.environ.get("MASTER_PORT", 29500))
+
+    # Base TCPStore shared across all inprocess restart iterations.
+    # Port MASTER_PORT+2 avoids conflict with the Wrapper's internal store
+    # on MASTER_PORT+1 and torchrun's rendezvous on MASTER_PORT.
+    # A PrefixStore keyed by iteration is created on top of this inside
+    # the training function to avoid stale keys.
+    base_store = dist.TCPStore(
+        host_name=master_addr,
+        port=master_port + 2,
+        world_size=world_size,
+        is_master=(rank == 0),
+        multi_tenant=True,
+        wait_for_workers=True,
+        use_libuv=True,
+    )
+
+    # Connect fault injector to shared store for fault time broadcast
+    if fault_injector is not None:
+        fault_injector._shared_store = base_store
+
+    # Wrap training with NVRx in-process restart
+    # store_kwargs must include host_name for cross-node connectivity.
+    wrapped_train = inprocess.Wrapper(
+        store_kwargs={"host_name": master_addr, "port": master_port + 1},
+        soft_timeout=datetime.timedelta(seconds=args.soft_timeout_seconds),
+        hard_timeout=datetime.timedelta(seconds=args.hard_timeout_seconds),
+        barrier_timeout=datetime.timedelta(seconds=args.barrier_timeout_seconds),
+        completion_timeout=datetime.timedelta(seconds=args.barrier_timeout_seconds),
+        health_check=inprocess.Compose(
+            inprocess.health_check.CudaHealthCheck(),
+            inprocess.health_check.FaultCounter(max_rank_faults=20),
+        ),
+        initialize=inprocess.initialize.RetryController(
+            max_iterations=args.max_restarts,
+            min_active_world_size=1,
+        ),
+        rank_assignment=inprocess.Compose(
+            inprocess.rank_assignment.ActivateAllRanks(),
+            inprocess.rank_assignment.ShiftRanks(),
+        ),
+    )(train_with_inprocess_restart)
+
+    # Run the wrapped training, passing the shared base_store
+    wrapped_train(args, restart_metrics, base_store, fault_injector)
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/pytorch/nvrx/src/train_local_ckpt.py
+++ b/3.test_cases/pytorch/nvrx/src/train_local_ckpt.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""
+NVRx Local Checkpointing Test Script
+
+Compares NVRx local checkpointing vs standard torch.save for FSDP/DDP
+training on EKS.  NVRx LocalCheckpointManager writes checkpoints to
+node-local storage (emptyDir backed by SSD/tmpfs) with tensor-aware
+serialization, avoiding shared-filesystem bottlenecks.
+
+Two checkpoint modes:
+  --use_local_checkpoint    NVRx LocalCheckpointManager (node-local, tensor-aware)
+  (default)                 Standard torch.save to the same local path
+
+Supports both FSDP and DDP via --parallel_strategy flag.
+
+Launched via torchrun:
+    python -m torch.distributed.run --nproc_per_node=1 --nnodes=2 ...
+"""
+
+import os
+import sys
+import time
+import json
+import argparse
+import logging
+import datetime
+
+os.environ.setdefault("NCCL_NVLS_ENABLE", "0")
+
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import StateDictType
+
+try:
+    from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import (
+        LocalCheckpointManager,
+    )
+    from nvidia_resiliency_ext.checkpointing.local.basic_state_dict import (
+        BasicTensorAwareStateDict,
+    )
+
+    NVRX_LOCAL_AVAILABLE = True
+except ImportError:
+    NVRX_LOCAL_AVAILABLE = False
+    LocalCheckpointManager = None
+    BasicTensorAwareStateDict = None
+
+from distributed_utils import (
+    add_distributed_args,
+    create_model,
+    wrap_model,
+    create_dataloader,
+    train_step,
+    save_checkpoint,
+    load_checkpoint,
+)
+
+
+def _move_tensors_to_cuda(obj):
+    """Recursively move all tensors in a nested dict/list to CUDA.
+
+    BasicTensorAwareStateDict requires every tensor to be on CUDA.
+    Optimizer state dicts may contain CPU tensors (e.g. step counts),
+    so we move them before wrapping.
+
+    ShardedTensor objects (from FSDP local/sharded state dict) are
+    left as-is since their local shards are already on CUDA.
+    """
+    # Skip ShardedTensor -- its local shards are already on CUDA
+    if type(obj).__name__ == "ShardedTensor":
+        return obj
+    if isinstance(obj, torch.Tensor):
+        return obj.cuda() if not obj.is_cuda else obj
+    elif isinstance(obj, dict):
+        return {k: _move_tensors_to_cuda(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_move_tensors_to_cuda(v) for v in obj]
+    elif isinstance(obj, tuple):
+        return tuple(_move_tensors_to_cuda(v) for v in obj)
+    return obj
+
+
+def setup_logging(rank):
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"[Rank {rank}] %(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+        force=True,
+    )
+    return logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="NVRx Local Checkpointing Test")
+
+    # Model / training
+    parser.add_argument("--model_name", type=str, default="gpt2")
+    parser.add_argument("--max_seq_length", type=int, default=512)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--learning_rate", type=float, default=5e-5)
+    parser.add_argument("--max_steps", type=int, default=1000)
+
+    # Dataset
+    parser.add_argument("--dataset_name", type=str, default="allenai/c4")
+    parser.add_argument("--streaming", type=bool, default=True)
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default=None,
+        help="Path to pre-downloaded dataset (created by prepare_dataset.py). "
+        "If set, loads from local disk with zero HF API calls. "
+        "If not set, streams from HuggingFace Hub.",
+    )
+
+    # Checkpointing
+    parser.add_argument("--checkpoint_path", type=str, default="/checkpoints")
+    parser.add_argument("--checkpoint_interval", type=int, default=50)
+
+    # Local checkpointing toggle
+    parser.add_argument(
+        "--use_local_checkpoint",
+        action="store_true",
+        default=False,
+        help="Use NVRx LocalCheckpointManager instead of standard torch.save",
+    )
+
+    # Training duration
+    parser.add_argument("--training_duration_minutes", type=int, default=10)
+
+    # NCCL timeout
+    parser.add_argument(
+        "--nccl_timeout_seconds",
+        type=int,
+        default=60,
+        help="NCCL operation timeout (seconds).",
+    )
+
+    # Distributed strategy & dtype (from shared utils)
+    add_distributed_args(parser)
+
+    return parser.parse_args()
+
+
+# ============================================================================
+# Checkpoint: NVRx LocalCheckpointManager
+# ============================================================================
+def save_checkpoint_local(model, optimizer, step, ckpt_manager, rank, strategy):
+    """Save using NVRx local checkpointing with tensor-aware serialization."""
+    start_time = time.time()
+    # state_dict() is collective under FSDP -- all ranks must call.
+    # Under DDP it is non-collective but safe to call on all ranks.
+    model_state = model.state_dict()
+    optim_state = optimizer.state_dict()
+
+    checkpoint = {
+        "step": step,
+        "model_state_dict": model_state,
+        "optimizer_state_dict": optim_state,
+    }
+
+    # BasicTensorAwareStateDict requires ALL tensors on CUDA.
+    # Optimizer state may contain CPU tensors (e.g. step counts).
+    checkpoint = _move_tensors_to_cuda(checkpoint)
+
+    ta_state_dict = BasicTensorAwareStateDict(checkpoint)
+    ckpt_manager.save(ta_state_dict, iteration=step)
+    save_time = time.time() - start_time
+
+    return save_time
+
+
+def load_checkpoint_local(ckpt_manager, model, optimizer, rank, strategy):
+    """Load from NVRx local checkpoint if one exists."""
+    logger = logging.getLogger(__name__)
+
+    iteration = ckpt_manager.find_latest()
+    if iteration < 0:
+        logger.info("No local checkpoint found")
+        return 0
+
+    try:
+        ta_state_dict, ckpt_part_id = ckpt_manager.load()
+        ckpt = ta_state_dict.state_dict
+        model.load_state_dict(ckpt["model_state_dict"])
+        optimizer.load_state_dict(ckpt["optimizer_state_dict"])
+
+        start_step = ckpt["step"]
+        logger.info(
+            f"Loaded local checkpoint from step {start_step} (part_id={ckpt_part_id})"
+        )
+        return start_step
+    except Exception as e:
+        logger.warning(f"Failed to load local checkpoint: {e}")
+    return 0
+
+
+# ============================================================================
+# Main training
+# ============================================================================
+def main():
+    args = parse_args()
+
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+
+    logger = setup_logging(rank)
+
+    # -----------------------------------------------------------------------
+    # Initialize distributed
+    # -----------------------------------------------------------------------
+    torch.cuda.set_device(local_rank)
+    if world_size > 1:
+        dist.init_process_group(
+            backend="nccl",
+            timeout=datetime.timedelta(seconds=args.nccl_timeout_seconds),
+        )
+
+    use_local = args.use_local_checkpoint and NVRX_LOCAL_AVAILABLE
+    mode_str = "LOCAL (NVRx)" if use_local else "STANDARD (torch.save)"
+
+    logger.info("=" * 80)
+    logger.info(f"Local Checkpointing Test - {mode_str}")
+    logger.info("=" * 80)
+    logger.info(f"Rank: {rank}, World Size: {world_size}, Local Rank: {local_rank}")
+    logger.info(f"Parallel strategy: {args.parallel_strategy}")
+    logger.info(f"Checkpoint mode: {mode_str}")
+    logger.info(f"Checkpoint interval: every {args.checkpoint_interval} steps")
+    logger.info(f"Checkpoint path: {args.checkpoint_path}")
+    if args.use_local_checkpoint and not NVRX_LOCAL_AVAILABLE:
+        logger.warning(
+            "NVRx local checkpointing requested but not available! "
+            "Falling back to standard torch.save."
+        )
+
+    # -----------------------------------------------------------------------
+    # Initialize NVRx LocalCheckpointManager (if using local mode)
+    # -----------------------------------------------------------------------
+    ckpt_manager = None
+    if use_local:
+        local_ckpt_dir = os.path.join(args.checkpoint_path, "local_ckpt")
+        logger.info(f"Initializing LocalCheckpointManager at {local_ckpt_dir}")
+        ckpt_manager = LocalCheckpointManager(local_ckpt_dir)
+        logger.info("LocalCheckpointManager initialized")
+
+    # -----------------------------------------------------------------------
+    # Create model and wrap with FSDP/DDP
+    # -----------------------------------------------------------------------
+    model, tokenizer = create_model(args.model_name, args.torch_dtype)
+    model = wrap_model(model, args.parallel_strategy, local_rank, args.model_name)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.learning_rate)
+
+    # -----------------------------------------------------------------------
+    # Load checkpoint (if resuming)
+    # -----------------------------------------------------------------------
+    if use_local:
+        start_step = load_checkpoint_local(
+            ckpt_manager, model, optimizer, rank, args.parallel_strategy
+        )
+    else:
+        start_step, _ = load_checkpoint(
+            args.checkpoint_path, model, optimizer, rank, args.parallel_strategy
+        )
+
+    # -----------------------------------------------------------------------
+    # Create dataloader
+    # -----------------------------------------------------------------------
+    dataloader = create_dataloader(args, tokenizer, rank, world_size)
+    dataloader_iter = iter(dataloader)
+
+    # -----------------------------------------------------------------------
+    # Training loop
+    # -----------------------------------------------------------------------
+    model.train()
+    training_start_time = time.time()
+    max_training_time = args.training_duration_minutes * 60
+
+    step = start_step
+    checkpoint_count = 0
+    total_checkpoint_time = 0.0
+    checkpoint_times = []
+    termination_reason = "max_steps_reached"
+
+    logger.info(f"Starting training from step {start_step}...")
+
+    while step < args.max_steps:
+        wall_elapsed = time.time() - training_start_time
+        if wall_elapsed >= max_training_time:
+            logger.info(
+                f"Training time limit reached ({args.training_duration_minutes} min)"
+            )
+            termination_reason = "time_limit"
+            break
+
+        # Get batch
+        try:
+            batch = next(dataloader_iter)
+        except StopIteration:
+            dataloader_iter = iter(dataloader)
+            batch = next(dataloader_iter)
+
+        # Training step
+        loss = train_step(model, batch, optimizer)
+        step += 1
+
+        # Log progress
+        if step % 10 == 0:
+            throughput = step / wall_elapsed if wall_elapsed > 0 else 0
+            logger.info(
+                f"Step {step}, Loss: {loss:.4f}, "
+                f"Wall: {wall_elapsed:.0f}s, "
+                f"Throughput: {throughput:.2f} steps/sec"
+            )
+
+        # Checkpoint saving
+        if step % args.checkpoint_interval == 0:
+            logger.info(f"Saving checkpoint at step {step}...")
+
+            if use_local:
+                ckpt_time = save_checkpoint_local(
+                    model, optimizer, step, ckpt_manager, rank, args.parallel_strategy
+                )
+                logger.info(f"Local checkpoint saved in {ckpt_time:.3f}s")
+            else:
+                _, ckpt_time = save_checkpoint(
+                    model,
+                    optimizer,
+                    step,
+                    args.checkpoint_path,
+                    rank,
+                    args.parallel_strategy,
+                )
+                logger.info(f"Standard checkpoint saved in {ckpt_time:.3f}s")
+
+            total_checkpoint_time += ckpt_time
+            checkpoint_count += 1
+            checkpoint_times.append(ckpt_time)
+
+    # -----------------------------------------------------------------------
+    # Training complete -- summary
+    # -----------------------------------------------------------------------
+    total_wall_time = time.time() - training_start_time
+    active_training_time = total_wall_time - total_checkpoint_time
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+    if rank == 0:
+        throughput = step / total_wall_time if total_wall_time > 0 else 0
+        ckpt_overhead = (
+            (total_checkpoint_time / total_wall_time) * 100
+            if total_wall_time > 0
+            else 0
+        )
+        training_efficiency = (
+            (active_training_time / total_wall_time) * 100
+            if total_wall_time > 0
+            else 100
+        )
+
+        # Run completion status
+        reason_label = (
+            "completed" if termination_reason == "max_steps_reached" else "time-limited"
+        )
+
+        logger.info("=" * 80)
+        logger.info(f"TRAINING SUMMARY - {mode_str}")
+        logger.info("=" * 80)
+        logger.info(f"Model: {args.model_name}")
+        logger.info(f"World Size: {world_size}")
+        logger.info(f"Parallel Strategy: {args.parallel_strategy}")
+        logger.info(f"Checkpoint Mode: {mode_str}")
+        logger.info("")
+        logger.info("TRAINING METRICS:")
+        logger.info(f"  Steps: {step}/{args.max_steps} ({reason_label})")
+        logger.info(f"  Termination: {termination_reason}")
+        logger.info(f"  Total wall time: {total_wall_time:.1f}s")
+        logger.info(f"  Active training time: {active_training_time:.1f}s")
+        logger.info(f"  Effective throughput: {throughput:.2f} steps/sec")
+        logger.info("")
+        logger.info("CHECKPOINT METRICS:")
+        logger.info(f"  Total checkpoints: {checkpoint_count}")
+        logger.info(f"  Checkpoint interval: every {args.checkpoint_interval} steps")
+        if checkpoint_count > 0:
+            avg_ckpt = total_checkpoint_time / checkpoint_count
+            min_ckpt = min(checkpoint_times)
+            max_ckpt = max(checkpoint_times)
+            logger.info(f"  Total checkpoint time: {total_checkpoint_time:.3f}s")
+            logger.info(f"  Avg checkpoint time: {avg_ckpt:.3f}s")
+            logger.info(f"  Min checkpoint time: {min_ckpt:.3f}s")
+            logger.info(f"  Max checkpoint time: {max_ckpt:.3f}s")
+            logger.info(f"  Checkpoint overhead: {ckpt_overhead:.2f}%")
+            logger.info(f"  Training efficiency: {training_efficiency:.2f}%")
+        logger.info("=" * 80)
+
+        # Write results JSON for automated comparison
+        results = {
+            "experiment_type": "local_checkpointing",
+            "mode": mode_str,
+            "model": args.model_name,
+            "world_size": world_size,
+            "parallel_strategy": args.parallel_strategy,
+            "max_steps": args.max_steps,
+            "steps_completed": step,
+            "termination_reason": termination_reason,
+            "total_wall_time_seconds": round(total_wall_time, 1),
+            "active_training_time_seconds": round(active_training_time, 1),
+            "effective_throughput_steps_per_sec": round(throughput, 4),
+            "checkpoint_count": checkpoint_count,
+            "checkpoint_interval": args.checkpoint_interval,
+            "total_checkpoint_time_seconds": round(total_checkpoint_time, 3),
+            "avg_checkpoint_time_seconds": round(
+                total_checkpoint_time / checkpoint_count, 3
+            )
+            if checkpoint_count > 0
+            else None,
+            "min_checkpoint_time_seconds": round(min(checkpoint_times), 3)
+            if checkpoint_times
+            else None,
+            "max_checkpoint_time_seconds": round(max(checkpoint_times), 3)
+            if checkpoint_times
+            else None,
+            "checkpoint_overhead_pct": round(ckpt_overhead, 2),
+            "training_efficiency_pct": round(training_efficiency, 2),
+        }
+        try:
+            results_path = os.path.join(args.checkpoint_path, "results.json")
+            with open(results_path, "w") as f:
+                json.dump(results, f, indent=2)
+            logger.info(f"Results saved to {results_path}")
+        except Exception as e:
+            logger.error(f"Failed to save results: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose
Adds a new test case for NVIDIA Resiliency Extension (NVRx) (https://github.com/NVIDIA/nvidia-resiliency-ext) benchmarking on Amazon EKS. NVRx provides fault tolerance and resiliency primitives for large-scale distributed training, integrating as a pip install layer on top of standard PyTorch.

Resolves #956 

## Changes
- Add `3.test_cases/pytorch/nvrx/` with 28 files covering 5 NVRx features:
  - Async checkpointing -- non-blocking checkpoint saves overlapping with training
  - In-process restart -- recover from faults without container restart
  - ft_launcher in-job restart -- automatic fault detection and worker respawn
  - ft_launcher + in-process combined -- in-process for exceptions, ft_launcher for hard faults
  - Local checkpointing -- node-local checkpoint storage for faster writes
- Add deterministic fault injection framework for reproducible experiment comparison
- Add Kubernetes manifests with headless Services for multi-node DNS discovery
- Add `prepare_dataset.py` for pre-downloading training data to avoid HuggingFace rate limiting during restarts
- Support both FSDP and DDP parallelism via `--parallel_strategy`
- Support both GPT-2 (124M) and LLaMA-3.1-8B models

## Test Plan
#### Environment:
- AWS Service: Amazon EKS
- Instance type: g5.8xlarge (A10G), p4de.24xlarge (A100), p5.48xlarge (H100)
- Number of nodes: 2
#### Test commands:
```
cd 3.test_cases/pytorch/nvrx

# Build and push container
source env_vars
./build_and_push.sh

# Deploy from kubernetes directory
cd kubernetes
source env_vars
kubectl apply -f namespace.yaml
kubectl apply -f fsx-storage.yaml

# Run in-process restart experiment
./deploy.sh training-job-inprocess.yaml

# Run async checkpoint experiment
./deploy.sh training-job-async-ckpt.yaml
```

## Test Results
Async Checkpointing (LLaMA-3.1-8B, 16x H100, 5000 steps):
- Async (NVRx): 99.1% steady-state training efficiency, 3.5s avg checkpoint schedule time
- Sync (torch.save): 54.8% training efficiency, 277s avg checkpoint blocking time
- Wall time: 34 min (async) vs 53 min (sync) -- 1.54x faster
Fault Recovery (LLaMA-3.1-8B, 16x H100, 2000 steps, 5 faults):
- In-process restart (NVRx): 31.0% training goodput, 86.3% infra goodput, 40 min wall time
- ft_launcher (NVRx): 25.5% training goodput, 84.2% infra goodput, 48 min wall time
- Baseline (K8s restart): 11.5% training goodput, 35.8% infra goodput, 107 min wall time
- In-process restart is 2.7x faster than baseline with zero container restarts

## Directory Structure
```
3.test_cases/
└── pytorch/
    └── nvrx/
        ├── Dockerfile              # PyTorch 2.9 + NVRx 0.4.1 + EFA
        ├── README.md               # Overview, features, model guidance, references
        ├── requirements.txt
        ├── build_and_push.sh       # Build + push to ECR (local or remote via SSH)
        ├── env_vars.template       # Environment configuration template
        ├── prepare_dataset.py      # One-time dataset download utility
        ├── src/
        │   ├── train_inprocess.py      # In-process restart + baseline
        │   ├── train_ft_launcher.py    # ft_launcher in-job + combined
        │   ├── train_async_ckpt.py     # Async vs sync checkpointing
        │   ├── train_local_ckpt.py     # Local checkpointing
        │   ├── distributed_utils.py    # FSDP/DDP wrapping, DCP checkpoint
        │   ├── failure_simulator.py    # Deterministic fault injection
        │   ├── fsdp_config.py          # FSDP config for GPT-2 and LLaMA
        │   └── metrics_collector.py    # Training metrics + JSON persistence
        └── kubernetes/
            ├── README.md               # EKS-specific setup and deployment
            ├── deploy.sh               # Safe envsubst + kubectl apply
            ├── namespace.yaml
            ├── secret-hf-token.yaml
            ├── fsx-storage.yaml        # FSx PV/PVC template with placeholders
            └── training-job-*.yaml     # 8 training manifests
```

Co-authored-by: @ShreyaGupta08  <shregupta@nvidia.com>