### PR TITLE
feat: Add observability IAM permissions for RIG cluster execution role

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/main.tf
@@ -62,7 +62,7 @@ locals {
   create_fsx_module                         = !local.rig_mode ? var.create_fsx_module : false
   create_task_governance_module             = !local.rig_mode && var.create_task_governance_module
   create_hyperpod_training_operator_module  = !local.rig_mode && var.create_hyperpod_training_operator_module
-  create_observability_module               = !local.rig_mode && var.create_observability_module
+  create_observability_module               = var.create_observability_module
   create_hyperpod_inference_operator_module = !local.rig_mode && var.create_hyperpod_inference_operator_module
 }
 
@@ -335,6 +335,8 @@ module "observability" {
   network_metric_level                 = var.network_metric_level
   accelerated_compute_metric_level     = var.accelerated_compute_metric_level
   logging_enabled                      = var.logging_enabled
+  rig_mode                             = local.rig_mode
+  execution_role_name                  = local.sagemaker_iam_role_name
 
   depends_on = [
     module.hyperpod_cluster,

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/observability/iam_roles.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/observability/iam_roles.tf
@@ -214,3 +214,43 @@ resource "aws_iam_role_policy" "grafana_workspace" {
     ]
   })
 }
+
+# Attach observability policy to the cluster execution role for RIG clusters
+resource "aws_iam_role_policy" "execution_role_observability" {
+  count = var.rig_mode ? 1 : 0
+  name  = "${var.resource_name_prefix}-observability-policy"
+  role  = var.execution_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "PrometheusAccess"
+        Effect   = "Allow"
+        Action   = ["aps:RemoteWrite"]
+        Resource = "arn:aws:aps:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:workspace/${local.prometheus_workspace_id}"
+      },
+      {
+        Sid    = "CloudwatchLogsAccess"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:PutLogEvents",
+          "logs:GetLogEvents",
+          "logs:FilterLogEvents",
+          "logs:GetLogRecord",
+          "logs:StartQuery",
+          "logs:StopQuery",
+          "logs:GetQueryResults"
+        ]
+        Resource = [
+          "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/sagemaker/Clusters/*",
+          "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/sagemaker/Clusters/*:log-stream:*"
+        ]
+      }
+    ]
+  })
+}

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/observability/variables.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/observability/variables.tf
@@ -121,3 +121,15 @@ variable "logging_enabled" {
   default     = false
 }
 
+
+variable "rig_mode" {
+  description = "Specify whether this is a RIG cluster."
+  type        = bool
+  default     = false
+}
+
+variable "execution_role_name" {
+  description = "The name of the cluster execution role."
+  type        = string
+  default     = ""
+}

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/rig_custom.tfvars
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/rig_custom.tfvars
@@ -19,3 +19,4 @@ restricted_instance_groups = [
         fsxl_size_in_gi_b = 4800
    }
 ]
+create_observability_module = true


### PR DESCRIPTION
## Summary
When observability is enabled on RIG (Restricted Instance Group) clusters, attach APS RemoteWrite and CloudWatch Logs permissions to the cluster execution role.

## Changes
- **main.tf**: Allow observability module for RIG clusters; pass `rig_mode` and `execution_role_name` to the observability module
- **modules/observability/variables.tf**: Add `rig_mode` (bool) and `execution_role_name` (string) variables
- **modules/observability/iam_roles.tf**: Add `execution_role_observability` inline policy with `aps:RemoteWrite` and CloudWatch Logs permissions, conditional on `rig_mode`
- **rig_custom.tfvars**: Enable observability module (`create_observability_module = true`)

## Testing
- Deployed full RIG HyperPod EKS cluster via `terraform apply` with `rig_custom.tfvars`
- Verified the inline policy was created on the execution role with correct APS and CloudWatch Logs permissions
- `terraform validate` passes