### PR TITLE
feat: Support multiple SSH key types in easy-ssh.sh with auto-detection

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
@@ -7,6 +7,7 @@ declare -a HELP=(
     "[-h|--help]"
     "[-c|--controller-group]"
     "[-u|--user]"
+    "[-k|--key SSH_KEY_PATH]"
     "[-r|--region]"
     "[-p|--profile]"
     "[-d|--dry-run]"
@@ -16,6 +17,7 @@ declare -a HELP=(
 cluster_name=""
 node_group="controller-machine"
 ssh_user="ubuntu"
+ssh_key=""
 declare -a aws_cli_args=()
 DRY_RUN=0
 
@@ -32,6 +34,7 @@ parse_args() {
             echo "  -h, --help              Show this help message"
             echo "  -c, --controller-group  Specify the controller group name (default: controller-machine)"
             echo "  -u, --user              Specify the SSH user (default: ubuntu)"
+            echo "  -k, --key               Specify path to SSH public key (default: auto-detect)"
             echo "  -r, --region            Specify AWS region"
             echo "  -p, --profile           Specify AWS profile"
             echo "  -d, --dry-run           Show the SSM command without executing"
@@ -41,6 +44,7 @@ parse_args() {
             echo "  $(basename ${BASH_SOURCE[0]}) -c login-group ml-cluster"
             echo "  $(basename ${BASH_SOURCE[0]}) -u user1 ml-cluster"
             echo "  $(basename ${BASH_SOURCE[0]}) -u user2 -r us-west-2 ml-cluster"
+            echo "  $(basename ${BASH_SOURCE[0]}) -k ~/.ssh/id_ed25519.pub ml-cluster"
             echo ""
             echo "Note: For non-ubuntu users, ensure your IAM user has the SSMSessionRunAs tag"
             echo "      set to the desired OS username for passwordless login."
@@ -52,6 +56,13 @@ parse_args() {
             ;;
         -u|--user)
             ssh_user="$2"
+            shift 2
+            ;;
+        -k|--key)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Error: -k/--key requires an argument" ; exit 1
+            fi
+            ssh_key="$2"
             shift 2
             ;;
         -r|--region)
@@ -98,10 +109,13 @@ check_ssh_config() {
                 mkdir -p ~/.ssh
                 touch ~/.ssh/config
             fi
+            # Derive private key path from the public key (strip .pub if present)
+            local identity_file="${ssh_key%.pub}"
             echo -e "${GREEN}✅ adding ${ssh_host} to ~/.ssh/config:${NC}"
             cat <<EOL >> ~/.ssh/config 
 Host ${ssh_host}
     User ${ssh_user}
+    IdentityFile ${identity_file}
     ProxyCommand sh -c "aws ssm start-session ${aws_cli_args[@]} --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
 EOL
         else
@@ -118,16 +132,82 @@ escape_spaces() {
     echo "${input// /\\ }"
 }
 
+# Function to check if a file contains a valid SSH public key
+is_public_key() {
+    local file="$1"
+    [[ ! -f "$file" ]] && return 1
+    local first_line
+    first_line=$(head -1 "$file")
+    if [[ "$first_line" == ssh-rsa\ * ]] || \
+       [[ "$first_line" == ssh-ed25519\ * ]] || \
+       [[ "$first_line" == ecdsa-sha2-* ]] || \
+       [[ "$first_line" == ssh-dss\ * ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Function to detect or validate the SSH public key
+detect_ssh_key() {
+    # If user specified a key via -k, validate it
+    if [[ -n "$ssh_key" ]]; then
+        # Expand leading tilde that may not have been shell-expanded (e.g. quoted argument)
+        if [[ "$ssh_key" == "~/"* ]]; then
+            ssh_key="${HOME}/${ssh_key#\~/}"
+        fi
+        if [[ ! -f "$ssh_key" ]]; then
+            echo "Error: Specified SSH key file not found: ${ssh_key}"
+            exit 1
+        fi
+        if ! is_public_key "$ssh_key"; then
+            echo "Error: ${ssh_key} does not appear to be a valid SSH public key."
+            exit 1
+        fi
+        return
+    fi
+
+    # Auto-detect: check .pub files first, then files without .pub (content-validated)
+    local key_names=("id_ed25519" "id_ecdsa" "id_rsa" "id_dsa")
+
+    # First pass: check for .pub files (content-validated)
+    for key_name in "${key_names[@]}"; do
+        local candidate="${HOME}/.ssh/${key_name}.pub"
+        if is_public_key "$candidate"; then
+            ssh_key="$candidate"
+            return
+        fi
+    done
+
+    # Second pass: check files without .pub extension (content-validated)
+    for key_name in "${key_names[@]}"; do
+        local candidate="${HOME}/.ssh/${key_name}"
+        if is_public_key "$candidate"; then
+            ssh_key="$candidate"
+            return
+        fi
+    done
+
+    # No key found
+    echo "Error: No SSH public key found in ~/.ssh/"
+    echo ""
+    echo "Generate one with:  ssh-keygen -t <type>"
+    echo "  Types: ed25519, ecdsa, rsa, dsa"
+    echo "Or specify one with: $(basename ${BASH_SOURCE[0]}) -k /path/to/key.pub CLUSTER_NAME"
+    exit 1
+}
+
 # Function to add the user's SSH public key to the cluster
 add_keypair_to_cluster() {
-    PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)
+    PUBLIC_KEY=$(cat "${ssh_key}")
     
     # Determine the authorized_keys path based on user and filesystem
     # Check if OpenZFS is mounted (home directory would be /home/username)
     local auth_keys_path="/fsx/${ssh_user}/.ssh/authorized_keys"
     
     # Try to detect if user home is on OpenZFS
-    local home_check=$(aws ssm start-session --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="getent passwd ${ssh_user} | cut -d: -f6" 2>/dev/null || echo "")
+    # Note: </dev/null detaches stdin so the SSM session plugin does not attach to the terminal TTY,
+    # which ensures output is captured reliably in a subshell.
+    local home_check=$(aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="getent passwd ${ssh_user} | cut -d: -f6" </dev/null 2>/dev/null || echo "")
     
     if echo "$home_check" | grep -q "^/home/${ssh_user}"; then
         # User home is on OpenZFS, but .ssh is symlinked to /fsx
@@ -135,19 +215,38 @@ add_keypair_to_cluster() {
     fi
 
     # Check if the fingerprint already exists in the cluster's authorized_keys
-    EXISTING_KEYS=$(aws ssm start-session --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="cat ${auth_keys_path}" 2>/dev/null || echo "")
+    EXISTING_KEYS=$(aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="cat ${auth_keys_path}" </dev/null 2>&1)
+    local read_rc=$?
+
+    # The SSM session plugin may return non-zero even on success (due to "Cannot perform start session: EOF").
+    # Check both exit code and output: if we got an actual error (like TargetNotConnected), the output will
+    # contain the error message and no key content.
+    if [[ $read_rc -ne 0 ]] && ! echo "$EXISTING_KEYS" | grep -Eq "^(ssh-rsa|ssh-ed25519|ecdsa-sha2-|ssh-dss) "; then
+        echo -e "${YELLOW}Warning: Could not read authorized_keys from the cluster (SSM command failed).${NC}"
+        echo -e "${YELLOW}The cluster node may not be connected to SSM. Skipping key upload.${NC}"
+        echo -e "${YELLOW}You may need to manually add your public key to ${auth_keys_path} on the cluster.${NC}"
+        return 1
+    fi
     
-    if echo "$EXISTING_KEYS" | grep -q "$PUBLIC_KEY"; then
-        echo -e "${BLUE}2. Detected SSH public key ${GREEN}~/.ssh/id_rsa.pub${BLUE} for user ${GREEN}${ssh_user}${BLUE} on the cluster. Skipping adding...${NC}" 
+    if echo "$EXISTING_KEYS" | grep -Fq "$PUBLIC_KEY"; then
+        echo -e "${BLUE}2. Detected SSH public key ${GREEN}${ssh_key}${BLUE} for user ${GREEN}${ssh_user}${BLUE} on the cluster. Skipping adding...${NC}" 
         return
     else
-        echo -e "${BLUE}2. Do you want to add your SSH public key ${GREEN}~/.ssh/id_rsa.pub${BLUE} to user ${GREEN}${ssh_user}${BLUE} on the cluster (yes/no)?${NC}" 
+        echo -e "${BLUE}2. Do you want to add your SSH public key ${GREEN}${ssh_key}${BLUE} to user ${GREEN}${ssh_user}${BLUE} on the cluster (yes/no)?${NC}" 
         read -p "> " ADD_KEYPAIR
         if [[ $ADD_KEYPAIR == "yes" ]]; then
             echo "Adding ... ${PUBLIC_KEY}"
             command="sed -i \$a$(escape_spaces "$PUBLIC_KEY") ${auth_keys_path}"
-            aws ssm start-session --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}  --document-name AmazonEKS-ExecuteNonInteractiveCommand  --parameters command="$command"
-            echo "✅ Your SSH public key ~/.ssh/id_rsa.pub has been added to user ${ssh_user} on the cluster."
+            aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}  --document-name AmazonEKS-ExecuteNonInteractiveCommand  --parameters command="$command" </dev/null 2>&1
+            
+            # Verify the key was actually written by re-reading authorized_keys
+            local verify_keys=$(aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="cat ${auth_keys_path}" </dev/null 2>&1)
+            if echo "$verify_keys" | grep -Fq "$PUBLIC_KEY"; then
+                echo "✅ Your SSH public key ${ssh_key} has been added to user ${ssh_user} on the cluster."
+            else
+                echo -e "${RED}Error: Failed to add SSH public key to the cluster. The key was not found after writing.${NC}"
+                echo -e "${YELLOW}You may need to manually add your public key to ${auth_keys_path} on the cluster.${NC}"
+            fi
         else
             echo "❌ Skipping adding SSH public key to the cluster."
         fi
@@ -158,6 +257,7 @@ parse_args $@
 
 #===Style Definitions===
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
@@ -173,6 +273,8 @@ print_header() {
 
 print_header "🚀 HyperPod Cluster Easy SSH Script! 🚀"
 
+detect_ssh_key
+
 cluster_id=$(aws sagemaker describe-cluster "${aws_cli_args[@]}" --cluster-name $cluster_name | jq '.ClusterArn' | awk -F/ '{gsub(/"/, "", $NF); print $NF}')
 instance_id=$(aws sagemaker list-cluster-nodes "${aws_cli_args[@]}" --cluster-name $cluster_name --instance-group-name-contains ${node_group} | jq '.ClusterNodeSummaries[0].InstanceId' | tr -d '"')
 
@@ -187,6 +289,7 @@ echo -e "Cluster id: ${GREEN}${cluster_id}${NC}"
 echo -e "Instance id: ${GREEN}${instance_id}${NC}"
 echo -e "Node Group: ${GREEN}${node_group}${NC}"
 echo -e "SSH User: ${GREEN}${ssh_user}${NC}"
+echo -e "SSH Key: ${GREEN}${ssh_key}${NC}"
 
 check_ssh_config
 add_keypair_to_cluster


### PR DESCRIPTION
## Purpose

The easy-ssh.sh script previously hardcoded ~/.ssh/id_rsa.pub as the only supported SSH key, preventing users with ed25519, ecdsa, or other key types from using the script without manual edits.
This PR adds:
- -k / --key flag to explicitly specify any SSH public key file path
- Auto-detection when no key is specified, checking in priority order: ed25519 > ecdsa > rsa > dsa (.pub files first, then files without .pub extension)
- Content validation via is_public_key() to safely distinguish public keys from private keys when files lack the .pub extension, and to reject corrupt/empty .pub files
- Actionable error message when no key is found, showing the ssh-keygen command with all supported key types

## Changes

- Added `ssh_key` variable and `-k/--key` argument to `parse_args()` with missing-argument validation
- Added `is_public_key()` helper that validates file content against known public key prefixes (ssh-rsa, ssh-ed25519, ecdsa-sha2-*, ssh-dss)
- Added `detect_ssh_key()` with two-pass auto-detection (.pub first, then content-validated non-.pub files) and tilde expansion for quoted -k arguments
- Replaced all 4 hardcoded ~/.ssh/id_rsa.pub references in `add_keypair_to_cluster()` with the resolved `${ssh_key}` variable
- Fixed pre-existing bug: `grep -q` → `grep -Fq` for fixed-string matching of public keys (avoids regex metacharacter issues with +, / in keys)
- Key detection runs before any AWS API calls for fast failure

## Testing

Validated locally with 28 unit tests covering:
- `is_public_key()`: all 4 key types accepted; private keys, empty files,
  garbage content, and nonexistent files correctly rejected
- `detect_ssh_key()` auto-detect: priority order (ed25519 > ecdsa > rsa > dsa),
  .pub preferred over non-.pub, fallback to content-validated non-.pub files,
  private keys skipped, empty .pub files skipped, error on no keys
- `detect_ssh_key()` with `-k` flag: valid key, nonexistent file, private key,
  tilde expansion, garbage content — all behave correctly

End-to-end testing (SSH into a live HyperPod cluster with a non-RSA key)
requires a cluster environment and should be validated separately.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
