### PR TITLE
fix: update ParallelCluster version from 3.13.1 to 3.14.2

### DIFF
--- a/1.architectures/2.aws-parallelcluster/README.md
+++ b/1.architectures/2.aws-parallelcluster/README.md
@@ -65,7 +65,7 @@ Then create a directory under home directory to store cluster config files:
 # For example
 export AWS_REGION=ap-northeast-1
 export CLUSTER_NAME=ml-cluster
-export PCLUSTER_VERSION=3.13.1
+export PCLUSTER_VERSION=3.14.2
 export CONFIG_DIR="${HOME}/${CLUSTER_NAME}_${AWS_REGION}_${PCLUSTER_VERSION}"
 
 mkdir -p ${CONFIG_DIR}
@@ -333,7 +333,7 @@ cat  ${CONFIG_DIR}/config.yaml
 # Example values - these will vary by environment
 CLUSTER_NAME: ml-cluster
 AWS_REGION: eu-west-2
-PCLUSTER_VERSION: 3.13.1
+PCLUSTER_VERSION: 3.14.2
 CAPACITY_RESERVATION_ID: cr-XXXXXXXXXXXXXXXXX
 AZ: eu-west-2c
 NUM_INSTANCES: "16"
@@ -410,7 +410,7 @@ You should see output similar to:
     "cloudformationStackStatus": "CREATE_IN_PROGRESS",
     "cloudformationStackArn": "arn:aws:cloudformation:ap-northeast-1:123456789012:stack/ml-cluster/abcd1234-...",
     "region": "ap-northeast-1",
-    "version": "3.13.0",
+    "version": "3.14.2",
     "clusterStatus": "CREATE_IN_PROGRESS",
     "scheduler": {
       "type": "slurm"


### PR DESCRIPTION
## Purpose

Addresses #983. 

## Changes

Updates all three version references in the ParallelCluster README to v3.14.2, which includes a security fix for CVE-2026-25506 (munge 0.5.16 → 0.5.18).

- Line 68: export PCLUSTER_VERSION=3.13.1 → 3.14.2
- Line 336: PCLUSTER_VERSION: 3.13.1 → 3.14.2
- Line 413: "version": "3.13.0" → "3.14.2" (also fixes pre-existing inconsistency)

## Test Plan

**Environment:**
- AWS Service: AWS ParallelCluster 3.14.2 (CLI + cluster)
- Instance type: t3.medium (head node + compute nodes, CPU-only)
- Number of nodes: 2 compute nodes + 1 head node

**Test commands:**
```bash
# 1. Install ParallelCluster CLI v3.14.2
python3 -m venv /tmp/pcluster_test_env
source /tmp/pcluster_test_env/bin/activate
pip install aws-parallelcluster==3.14.2

# 2. Verify CLI version
pcluster version
# Output: { "version": "3.14.2" }

# 3. Create cluster
pcluster create-cluster \
    --cluster-name pcluster-test-v3142 \
    --cluster-configuration cluster.yaml \
    --region us-west-2 \
    --rollback-on-failure false

# 4. Verify cluster status
pcluster describe-cluster --cluster-name pcluster-test-v3142 --region us-west-2
# Output: clusterStatus: CREATE_COMPLETE, version: 3.14.2

# 5. Verify bootstrapped version on head node (via SSM)
cat /opt/parallelcluster/.bootstrapped
# Output: aws-parallelcluster-cookbook-3.14.2

# 6. Verify Slurm is running
sinfo
# Output:
# PARTITION   AVAIL  TIMELIMIT  NODES  STATE NODELIST
# test-queue*    up   infinite      2  idle~ test-queue-dy-test-compute-[1-2]

# 7. Run 2-node PyTorch DDP job (3.test_cases/pytorch/ddp/ddp.py)
sbatch ddp-test.sbatch   # 2 nodes, 1 proc/node, 3 epochs, GLOO backend (CPU)
```

## Test Results

Cluster provisioned successfully with ParallelCluster v3.14.2. A 2-node distributed PyTorch DDP training job (3.test_cases/pytorch/ddp/ddp.py) completed all 3 epochs with loss 
convergence:

[RANK 0] Epoch 0 | Batchsize: 32 | Steps: 938 | Loss: 0.1994
[RANK 1] Epoch 0 | Batchsize: 32 | Steps: 938 | Loss: 0.1986
Epoch 0 | Training snapshot saved at /home/ubuntu/snapshot.pt
[RANK 0] Epoch 1 | Batchsize: 32 | Steps: 938 | Loss: 0.0880
[RANK 1] Epoch 1 | Batchsize: 32 | Steps: 938 | Loss: 0.0870
Epoch 1 | Training snapshot saved at /home/ubuntu/snapshot.pt
[RANK 0] Epoch 2 | Batchsize: 32 | Steps: 938 | Loss: 0.0646
[RANK 1] Epoch 2 | Batchsize: 32 | Steps: 938 | Loss: 0.0640
Epoch 2 | Training snapshot saved at /home/ubuntu/snapshot.pt
Local worker group finished (WorkerState.SUCCEEDED)


Note: Validation was performed on t3.medium (CPU) rather than GPU instances due to the documentation-only nature of this change. The version bump affects only which 
ParallelCluster CLI version users install — no cluster templates or infrastructure code were modified.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
