### PR TITLE
Add CPU support for PyTorch DDP training

### DIFF
--- a/3.test_cases/pytorch/ddp/Dockerfile.cpu
+++ b/3.test_cases/pytorch/ddp/Dockerfile.cpu
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+# --- ADD THIS ---
+# Essential for torchvision image processing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1 \
+    libglx-mesa0 \
+    libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir mlflow==2.13.2 sagemaker-mlflow==0.1.0
+RUN pip install torch==2.10.0+cpu torchvision==0.25.0+cpu --index-url https://download.pytorch.org/whl/cpu
+
+WORKDIR /workspace
+
+# --- CHANGE THESE ---
+COPY ddp.py /workspace/
+COPY slurm/data/ /workspace/data/
+
+# Deleting these prevents the "unzip race condition" entirely
+RUN rm -f /workspace/data/MNIST/raw/*.gz

--- a/3.test_cases/pytorch/ddp/slurm/0.create-venv-cpu.sh
+++ b/3.test_cases/pytorch/ddp/slurm/0.create-venv-cpu.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -ex
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+PYTHON_VERSION=$(python3 --version | awk '{print $2}' | awk -F'.' '{print $1"."$2}')
+
+sudo apt install -y python${PYTHON_VERSION}-venv
+
+# Create and activate Python virtual environment
+python3 -m venv pt
+source ./pt/bin/activate
+
+# Install required packages
+pip install torch==2.10.0+cpu torchvision==0.25.0+cpu --index-url https://download.pytorch.org/whl/cpu
+pip install numpy mlflow==2.13.2 sagemaker-mlflow==0.1.0

--- a/3.test_cases/pytorch/ddp/slurm/2.create-enroot-image-cpu.sh
+++ b/3.test_cases/pytorch/ddp/slurm/2.create-enroot-image-cpu.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+# 1. Pre-download MNIST to a local folder named 'data'
+# This ensures we have the files ready to COPY into the Docker image
+python3 -c "from torchvision import datasets; datasets.MNIST(root='./data', train=True, download=True)"
+
+# 2. Build the Docker image
+docker build -t pytorch-ddp -f ../Dockerfile.cpu ..
+
+# 3. Convert to Enroot squashfs file
+if [ -f pytorch.sqsh ] ; then rm pytorch.sqsh; fi
+enroot import -o pytorch.sqsh dockerd://pytorch-ddp:latest


### PR DESCRIPTION
## Purpose
Enables the distributed training examples to run on CPU instances by adding CPU-specific installation and containerization support for PyTorch DDP training on Amazon Parallel Computing Service (PCS).

## Changes

- Created 0.create-venv-cpu.sh - CPU-specific virtual environment setup script that installs PyTorch and Torchvision with CPU-only support
- Created 2.create-enroot-image-cpu.sh - CPU-specific Enroot container image creation script
- Created Dockerfile.cpu - CPU-specific Dockerfile based on Python 3.12-slim that includes:
  - System dependencies for torchvision image processing (libgl1, libglx-mesa0, libglib2.0-0)
  - PyTorch 2.10.0+cpu and Torchvision 0.25.0+cpu from the official PyTorch CPU repository
  - MLflow 2.13.2 and sagemaker-mlflow 0.1.0 for experiment tracking
  - Pre-copied MNIST dataset to prevent download race conditions during parallel training
  - Optimized image size with --no-cache-dir and apt cleanup
- Added slurm/data/ directory - Contains pre-downloaded MNIST dataset to avoid concurrent download issues across nodes
- Modified installation process to support CPU-only deployments without GPU dependencies

**Key differences between GPU and CPU versions:**
- Dockerfile.cpu uses python:3.12-slim base image vs. pytorch/pytorch:latest in the GPU version
- Dockerfile.cpu explicitly installs CPU-specific PyTorch/Torchvision packages from the CPU wheel repository
- Dockerfile.cpu includes additional system libraries required for torchvision image operations
- Dockerfile.cpu pre-copies training data and removes compressed files to prevent race conditions

## Test Plan
**Environment:**
- AWS Service: Amazon Parallel Computing Service (PCS)
- Instance type: c6i.xlarge
- Number of nodes: 2

**Test commands:**
```bash
# Create CPU-specific virtual environment
./0.create-venv-cpu.sh

# Submit training job to Slurm (venv-based)
sbatch 1.venv-train.sbatch

# Create CPU-specific Enroot container image
./2.create-enroot-image-cpu.sh

# Submit training job to Slurm (container-based)
sbatch 3.container-train.sbatch
```

## Test Results
Successfully tested on Amazon PCS with 2 nodes using c6i.xlarge instances. Both virtual environment and containerized approaches were validated:
- CPU-specific virtual environment created without GPU dependencies
- CPU-specific container image built successfully with all required system libraries
- Training jobs executed successfully in both venv and container modes
- Pre-copied MNIST dataset prevented download race conditions across nodes

## Directory Structure
```text
3.test_cases/
└── pytorch/
    └── ddp/
        ├── kubernetes/
        ├── slurm/
        │   ├── 0.create-venv-cpu.sh          # New: CPU venv setup
        │   ├── 0.create-venv.sh               # Original GPU venv setup
        │   ├── 1.venv-train.sbatch
        │   ├── 2.create-enroot-image-cpu.sh  # New: CPU container image
        │   ├── 2.create-enroot-image.sh       # Original GPU container image
        │   ├── 3.container-train.sbatch
        │   ├── data/                          # New: Pre-downloaded MNIST dataset
        │   └── README.md
        ├── .gitignore
        ├── ddp.py
        ├── Dockerfile                         # Original GPU Dockerfile
        ├── Dockerfile.cpu                     # New: CPU Dockerfile
        └── README.md
```

**Modified/Added files:**

- Added: 3.test_cases/pytorch/ddp/slurm/0.create-venv-cpu.sh
- Added: 3.test_cases/pytorch/ddp/slurm/2.create-enroot-image-cpu.sh
- Added: 3.test_cases/pytorch/ddp/slurm/data/ (MNIST dataset directory)
- Added: 3.test_cases/pytorch/ddp/Dockerfile.cpu
- Updated: 3.test_cases/pytorch/ddp/README.md (to document CPU usage instructions)
- Updated: 3.test_cases/pytorch/ddp/slurm/README.md (to document CPU-specific scripts)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [X] I am working against the latest `main` branch.
- [X] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [X] The contribution is self-contained with documentation and scripts.
- [X] External dependencies are pinned to a specific version or tag (no `latest`).
- [X] A README is included or updated with prerequisites, instructions, and known issues.
- [X] New test cases follow the [expected directory structure](#directory-structure).