### PR TITLE
fix: use object-level ARN for s3:GetObject in HyperPod execution role policy

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/1.AmazonSageMakerClustersExecutionRolePolicy.json
+++ b/1.architectures/5.sagemaker-hyperpod/1.AmazonSageMakerClustersExecutionRolePolicy.json
@@ -38,11 +38,19 @@
         {
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucket",
-                "s3:GetObject"
+                "s3:ListBucket"
             ],
             "Resource": [
                 "arn:aws:s3:::sagemaker-*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::sagemaker-*/*"
             ]
         },
         {


### PR DESCRIPTION
## Summary

- Fixes the S3 IAM policy in `1.AmazonSageMakerClustersExecutionRolePolicy.json` where `s3:GetObject` used a bucket-level ARN (`arn:aws:s3:::sagemaker-*`) instead of the required object-level ARN (`arn:aws:s3:::sagemaker-*/*`)
- Splits the combined statement into two separate statements with correct resource scope for each action
- `s3:ListBucket` (bucket-level) → `arn:aws:s3:::sagemaker-*`
- `s3:GetObject` (object-level) → `arn:aws:s3:::sagemaker-*/*`

Fixes #1044

## Context

This issue was identified through customer feedback from a production HyperPod deployment (42-node H200 cluster, 63-day operation). The bug does not affect the recommended CloudFormation or Terraform deployment paths because those attach the AWS managed policy `AmazonSageMakerClusterInstanceRolePolicy`, which provides correct S3 permissions. However, users who follow the manual CLI setup in the README or adopt this JSON file as the sole S3 policy under the principle of least privilege would encounter implicit denials on `s3:GetObject`.

## Test plan

- [ ] Verify JSON syntax is valid (`python -m json.tool < 1.AmazonSageMakerClustersExecutionRolePolicy.json`)
- [ ] Confirm `s3:ListBucket` retains bucket-level ARN
- [ ] Confirm `s3:GetObject` uses object-level ARN with `/*` suffix
- [ ] Validate that a HyperPod cluster created using the manual CLI path can fetch lifecycle scripts from S3