### PR TITLE
Fix FSDP2 train.py: add missing torch.cuda.set_device() call

### DIFF
--- a/3.test_cases/pytorch/FSDP/src/train.py
+++ b/3.test_cases/pytorch/FSDP/src/train.py
@@ -137,6 +137,7 @@ def main(args):
     dist.init_process_group()
     global_rank = dist.get_rank()
     device = global_rank % torch.cuda.device_count()
+    torch.cuda.set_device(device)
     world_size = dist.get_world_size()
     
     if args.bf16:


### PR DESCRIPTION
## Purpose

Fixes #1041 
Adds back the `torch.cuda.set_device(device)` call that was dropped during the FSDP2 rewrite in PR #951 (a93ad63). Without this call, all torchrun worker processes on each node default to CUDA device 0, causing OOM on any model that doesn't fit in a single GPU.

## Changes

- One-line addition in `3.test_cases/pytorch/FSDP/src/train.py`: `torch.cuda.set_device(device)` after the device computation in `main()`
## Context
The FSDP1 version of this file had `torch.cuda.set_device(device)` at line 192 (commit c98c5fc). PR #951 rewrote the file for FSDP2 but omitted this call. Every other training script in the repo includes it (picotron, deepspeed, nvrx).

**Without fix**: All 8 workers per node map to GPU 0 → OOM during FSDP2 unshard, NCCL "Duplicate GPU detected" warnings.
**With fix**: Proper 1:1 GPU mapping, training runs at ~2.7 samples/sec on 4x p5.48xlarge (Llama 3.1 70B).

**Tested** on SageMaker HyperPod (4x p5.48xlarge, 32x H100, NCCL 2.28.3, PyTorch 2.7.1, CUDA 12.9).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
