### PR TITLE
Easy ssh update

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
+++ b/1.architectures/5.sagemaker-hyperpod/easy-ssh.sh
@@ -215,7 +215,7 @@ add_keypair_to_cluster() {
     fi
 
     # Check if the fingerprint already exists in the cluster's authorized_keys
-    EXISTING_KEYS=$(aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="cat ${auth_keys_path}" </dev/null 2>&1)
+    EXISTING_KEYS=$(aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="cat ${auth_keys_path}" </dev/null 2>/dev/null)
     local read_rc=$?
 
     # The SSM session plugin may return non-zero even on success (due to "Cannot perform start session: EOF").
@@ -237,10 +237,10 @@ add_keypair_to_cluster() {
         if [[ $ADD_KEYPAIR == "yes" ]]; then
             echo "Adding ... ${PUBLIC_KEY}"
             command="sed -i \$a$(escape_spaces "$PUBLIC_KEY") ${auth_keys_path}"
-            aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}  --document-name AmazonEKS-ExecuteNonInteractiveCommand  --parameters command="$command" </dev/null 2>&1
+            aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id}  --document-name AmazonEKS-ExecuteNonInteractiveCommand  --parameters command="$command" </dev/null >/dev/null 2>/dev/null
             
             # Verify the key was actually written by re-reading authorized_keys
-            local verify_keys=$(aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="cat ${auth_keys_path}" </dev/null 2>&1)
+            local verify_keys=$(aws ssm start-session "${aws_cli_args[@]}" --target sagemaker-cluster:${cluster_id}_${node_group}-${instance_id} --document-name AmazonEKS-ExecuteNonInteractiveCommand --parameters command="cat ${auth_keys_path}" </dev/null 2>/dev/null)
             if echo "$verify_keys" | grep -Fq "$PUBLIC_KEY"; then
                 echo "✅ Your SSH public key ${ssh_key} has been added to user ${ssh_user} on the cluster."
             else


### PR DESCRIPTION
## Purpose
Fixes spurious "Starting session with SessionId..." and "Cannot perform start session: EOF" messages displayed to users during SSH key management in easy-ssh.sh.

## Changes
- Suppress stderr (2>/dev/null) on non-interactive SSM commands that capture output into variables (reading and verifying authorized_keys)
- Suppress both stdout and stderr (>/dev/null 2>/dev/null) on the key-writing SSM command, whose output is not needed since success is independently verified in the next step
- The script's error-handling logic is unaffected — it relies on exit codes and content-based grep checks, not stderr content

## Test Plan

### Environment:
- AWS Service: SageMaker HyperPod (Slurm)
- Instance type: controller/login node
- Number of nodes: 1

### Test commands:
bash easy-ssh.sh -c controller-machine my-cluster
bash easy-ssh.sh -c login-group my-cluster

### Test Results
Before fix:
```
> yes
Adding ... ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... user@host
Starting session with SessionId: user-dz7bvvr4rt47rid8r48etdlz3y
Cannot perform start session: EOF
✅ Your SSH public key /Users/user/.ssh/id_ed25519.pub has been added to user ubuntu on the cluster.
```

After fix:
```
> yes
Adding ... ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... user@host
✅ Your SSH public key /Users/user/.ssh/id_ed25519.pub has been added to user ubuntu on the cluster.
```

## Checklist
- [x] I have read the contributing guidelines (https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest main branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no latest).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the expected directory structure (#directory-structure). (N/A — no new test cases)