### PR TITLE
docs: fix typos in markdown files

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/slurm-studio/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/slurm-studio/README.md
@@ -246,7 +246,7 @@ nvidia-smi
 
 2. SLURM failed to set up
 
-This is a rare occurence, but it may happen because the MUNGE authentication key was incorrectly copied over from the controller machine. To remediate, you can follow the steps in the logs:
+This is a rare occurrence, but it may happen because the MUNGE authentication key was incorrectly copied over from the controller machine. To remediate, you can follow the steps in the logs:
 ```
 Here are the manual steps you can try:
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/README-manual-steps.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/README-manual-steps.md
@@ -54,7 +54,7 @@ export NODE_RECOVEY=AUTOMATIC
 
 ```
 
- If you have used the full deployment option while deploying cloud formation you can use the helper script([create_config.sh](./create_config.sh)) to retreive all the required. 
+ If you have used the full deployment option while deploying cloud formation you can use the helper script([create_config.sh](./create_config.sh)) to retrieve all the required. 
 
  If you used Integrative Deployment Mode set the below parameters
 

--- a/3.test_cases/23.SMHP-esm2/README.md
+++ b/3.test_cases/23.SMHP-esm2/README.md
@@ -5,7 +5,7 @@
 
 
 ## What is ESM-2?
-[ESM-2](https://www.biorxiv.org/content/10.1101/2022.07.20.500902v1) is a pLM trained using unsupervied masked language modelling on 250 Million protein sequences by researchers at [Facebook AI Research (FAIR)](https://www.biorxiv.org/content/10.1101/2022.07.20.500902v1). It is available in several sizes, ranging from 8 Million to 15 Billion parameters. The smaller models are suitable for various sequence and token classification tasks. The FAIR team also adapted the 3 Billion parameter version into the ESMFold protein structure prediction algorithm. They have since used ESMFold to predict the struture of [more than 700 Million metagenomic proteins](https://esmatlas.com/about).
+[ESM-2](https://www.biorxiv.org/content/10.1101/2022.07.20.500902v1) is a pLM trained using unsupervised masked language modelling on 250 Million protein sequences by researchers at [Facebook AI Research (FAIR)](https://www.biorxiv.org/content/10.1101/2022.07.20.500902v1). It is available in several sizes, ranging from 8 Million to 15 Billion parameters. The smaller models are suitable for various sequence and token classification tasks. The FAIR team also adapted the 3 Billion parameter version into the ESMFold protein structure prediction algorithm. They have since used ESMFold to predict the structure of [more than 700 Million metagenomic proteins](https://esmatlas.com/about).
 
 ESM-2 is a powerful pLM. We will demonstrate how to use QLoRA to fine-tune ESM-2 on g5.24xlarge instances. We will use ESM-2 to predict [subcellular localization](https://academic.oup.com/nar/article/50/W1/W228/6576357?login=false). Understanding where proteins appear in cells can help us understand their role in disease and find new drug targets.
 

--- a/3.test_cases/pytorch/deepspeed/examples_megatron_deepspeed/finetune_hf_llama/README.md
+++ b/3.test_cases/pytorch/deepspeed/examples_megatron_deepspeed/finetune_hf_llama/README.md
@@ -22,7 +22,7 @@ wget https://raw.githubusercontent.com/tatsu-lab/stanford_alpaca/main/alpaca_dat
 ```
 
 Llama2 model, which governed by the Meta license and must be downloaded and converted to the standard [Hugging Face](https://huggingface.co/) format prior to running this sample.
-You can submit access request from [here](https://ai.meta.com/resources/models-and-libraries/llama-downloads/), we need "Llama 2 & Llama Chat" to be checked. Use the [download.sh](https://github.com/facebookresearch/llama/blob/main/download.sh) in the official repository. You will be asked to input an URL from the email you recieve from meta.  
+You can submit access request from [here](https://ai.meta.com/resources/models-and-libraries/llama-downloads/), we need "Llama 2 & Llama Chat" to be checked. Use the [download.sh](https://github.com/facebookresearch/llama/blob/main/download.sh) in the official repository. You will be asked to input an URL from the email you receive from meta.  
 
 We will assume that you had placed the model and tokenizer as follows on cluster:
 

--- a/3.test_cases/pytorch/distillation/README.md
+++ b/3.test_cases/pytorch/distillation/README.md
@@ -91,7 +91,7 @@ To store your distilled model artifacts, you'll need to configure a Hugging Face
    export HUB_LOCATION="your-username/your-model-name"
    ```
 
-### Setup Persistant Volume Claim(PVC) for fsx 
+### Setup Persistent Volume Claim(PVC) for fsx 
 
 Depending on the save location, We need to setup an PVC for FSx to save the model artifacts. Please follow the link [here](https://catalog.workshops.aws/sagemaker-hyperpod-eks/en-US/01-cluster/06-fsx-for-lustre) to setup FSx CSI Driver and PVC. You can skip this step if you have a model repository setup on Huggingface.
 

--- a/3.test_cases/pytorch/neuronx-distributed/llama3/kubernetes/README.md
+++ b/3.test_cases/pytorch/neuronx-distributed/llama3/kubernetes/README.md
@@ -20,7 +20,7 @@ Before running this training, you'll need to create an Amazon EKS or a SageMaker
 
 Since [llama 3](https://huggingface.co/meta-llama/Meta-Llama-3-8B) is a gated model users have to register in Huggingface and obtain an HF_Access_Token before running this example.
 
-### 0.3 Setup Persistant Volume Claim(PVC) for fsx 
+### 0.3 Setup Persistent Volume Claim(PVC) for fsx 
 
 We need to setup an PVC for FSx to store the tokenized data and training checkpoints. Please follow the link [here](#) to setup FSx CSI Driver and PVC. 
 


### PR DESCRIPTION
## Purpose

Fix common spelling mistakes across documentation files to improve readability and professionalism.

## Changes

- Fix 7 typos across 6 README files:
  - `retreive` → `retrieve`
  - `occurence` → `occurrence`
  - `unsupervied` → `unsupervised`
  - `struture` → `structure`
  - `Persistant` → `Persistent` (2 files)
  - `recieve` → `receive`

## Test Plan

N/A — documentation-only changes. Verified with grep that no instances of the misspelled words remain.

**Environment:**
- N/A (no code changes)

**Test commands:**

- N/A

## Test Results

All misspelled words confirmed removed. No functional changes.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).