### PR TITLE
Add Extensions framework for SageMaker HyperPod OnInitComplete

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/.gitattributes
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/.gitattributes
@@ -1,0 +1,10 @@
+# Enforce LF line endings for all scripts to prevent CRLF issues on HyperPod nodes
+* text=auto eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+*.json text eol=lf
+*.txt text eol=lf
+*.md text eol=lf
+*.csv text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/README.md
@@ -33,7 +33,7 @@ takes precedence (even if empty) for backward compatibility.
 
 ### Legacy Format (shared_users.txt)
 
-Plain CSV — one user per line: `username,uid,home_directory`
+Plain CSV |-- one user per line: `username,uid,home_directory`
 
 ```
 alice,2001,/fsx/alice
@@ -47,7 +47,7 @@ for compatibility but the script auto-detects the shared filesystem mount.
 
 ### YAML Simple Format (shared_users.yaml)
 
-A flat list of users — all get global defaults:
+A flat list of users |-- all get global defaults:
 
 ```yaml
 users:
@@ -64,7 +64,7 @@ users:
 ### YAML Groups Format (shared_users.yaml)
 
 Users organized into groups with per-group Slurm accounts and filesystem mounts.
-Groups are purely organizational — they do not create Linux groups. Per-group
+Groups are purely organizational |-- they do not create Linux groups. Per-group
 settings override the global defaults.
 
 ```yaml
@@ -94,10 +94,10 @@ groups:
 
 | Field | Required | Scope | Default | Description |
 |-------|----------|-------|---------|-------------|
-| `users` | Yes* | Global | — | Simple format: flat list of users. |
-| `groups` | Yes* | Global | — | Groups format: list of user groups. |
-| `groups[].name` | Yes | Group | — | Group name (organizational only, no Linux group created). |
-| `groups[].users` | Yes | Group | — | Users in this group. |
+| `users` | Yes* | Global |  | Simple format: flat list of users. |
+| `groups` | Yes* | Global |  | Groups format: list of user groups. |
+| `groups[].name` | Yes | Group |  | Group name (organizational only, no Linux group created). |
+| `groups[].users` | Yes | Group |  | Users in this group. |
 | `groups[].slurm_account` | No | Group | `root` | Slurm account for this group. Overrides global default. |
 | `groups[].shared_filesystem_mount` | No | Group | auto-detect | Home directory path for this group. Overrides global default. |
 | `shared_filesystem_mount` | No | Global | auto-detect | Default home directory path for all users/groups. |
@@ -110,8 +110,8 @@ groups:
 The script automatically detects which shared filesystem to use for home directories,
 matching the base lifecycle scripts' behavior:
 
-1. **OpenZFS at `/home`** (NFS mount) — preferred when present
-2. **FSx for Lustre at `/fsx`** — fallback
+1. **OpenZFS at `/home`** (NFS mount) |-- preferred when present
+2. **FSx for Lustre at `/fsx`** |-- fallback
 
 When both OpenZFS and Lustre are mounted, home directories go on OpenZFS (`/home/<user>`)
 and a data directory is also created on Lustre (`/fsx/<user>`) for training data and
@@ -172,7 +172,7 @@ Per-group `shared_filesystem_mount` overrides the auto-detection for that group.
    sudo srun --partition=<partition-name> bash /fsx/cluster-scripts/add-users/add_users.sh
    ```
 
-Existing users are skipped — only new users are created. The scripts are fully idempotent.
+Existing users are skipped |-- only new users are created. The scripts are fully idempotent.
 
 ## Execution Order
 
@@ -180,11 +180,11 @@ The scripts run in dependency order on every node, once per group:
 
 ```
 add_users.sh (entrypoint)
-  └── For each group:
-      ├── create_posix_users.sh   All nodes: create POSIX users
-      ├── setup_home_dirs.sh      All nodes: home dirs on shared FS
-      ├── setup_ssh_keys.sh       All nodes: SSH keys on shared FS
-      └── setup_slurm_accounts.sh Controller only: Slurm accounting
+  |-- For each group:
+      |-- create_posix_users.sh   All nodes: create POSIX users
+      |-- setup_home_dirs.sh      All nodes: home dirs on shared FS
+      |-- setup_ssh_keys.sh       All nodes: SSH keys on shared FS
+      |-- setup_slurm_accounts.sh Controller only: Slurm accounting
 ```
 
 ## How It Works
@@ -193,9 +193,9 @@ add_users.sh (entrypoint)
 
 The script auto-detects whether it's running on a controller, compute, or login
 node by checking Slurm daemons:
-- `slurmctld` running → controller
-- `slurmd` running + hostname in `sinfo` → compute
-- `slurmd` running + hostname not in `sinfo` → login
+- `slurmctld` running |-- controller
+- `slurmd` running + hostname in `sinfo` |-- compute
+- `slurmd` running + hostname not in `sinfo` |-- login
 
 ### SSH Key Sharing
 
@@ -205,7 +205,7 @@ This ensures all nodes share the same keys for passwordless SSH.
 
 ### Idempotency
 
-All scripts are idempotent — safe to re-run without errors or duplicates:
+All scripts are idempotent |-- safe to re-run without errors or duplicates:
 - Users that already exist are skipped
 - Home directories that already exist are left alone
 - SSH keys that already exist are not regenerated

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/README.md
@@ -1,0 +1,250 @@
+# Add Users to SageMaker HyperPod Slurm Clusters
+
+Standalone extension script that adds users to SageMaker HyperPod Slurm clusters.
+Designed for use with the `OnInitComplete` lifecycle configuration (AMI-based clusters).
+
+## What It Does
+
+1. **Creates POSIX users** on all nodes with consistent UIDs
+2. **Sets up home directories** on the shared filesystem (FSx for Lustre or OpenZFS)
+3. **Generates SSH keypairs** on the shared filesystem for passwordless inter-node SSH
+4. **Registers users in Slurm accounting** so they can submit jobs (controller only)
+
+## Prerequisites
+
+- A SageMaker HyperPod Slurm cluster with AMI-based configuration
+- The cluster execution role must have S3 read access to the scripts bucket
+- A shared filesystem (FSx for Lustre or OpenZFS) is recommended but not required.
+  Without one, home directories and SSH keys are local to each node, and
+  passwordless cross-node SSH will not work.
+
+## Configuration
+
+The script supports two input formats. Copy the appropriate sample file,
+rename it, and edit it with your users:
+
+| Input File | Sample File | Format | Features |
+|------------|-------------|--------|----------|
+| `shared_users.txt` | `shared_users_sample.txt` | CSV | Legacy format, backward compatible with base LCS |
+| `shared_users.yaml` | `shared_users_sample.yaml` | YAML | Groups, per-group Slurm accounts, filesystem mounts |
+
+If both `shared_users.txt` and `shared_users.yaml` are present, the text file
+takes precedence (even if empty) for backward compatibility.
+
+### Legacy Format (shared_users.txt)
+
+Plain CSV — one user per line: `username,uid,home_directory`
+
+```
+alice,2001,/fsx/alice
+bob,2002,/fsx/bob
+carol,2003,/fsx/carol
+```
+
+This is the same format used by the base lifecycle scripts. All users are added
+to the `root` Slurm account. The home directory path (third field) is accepted
+for compatibility but the script auto-detects the shared filesystem mount.
+
+### YAML Simple Format (shared_users.yaml)
+
+A flat list of users — all get global defaults:
+
+```yaml
+users:
+  - username: alice
+    uid: 2001
+  - username: bob
+    uid: 2002
+
+# Optional global defaults:
+# shared_filesystem_mount: /fsx    # Default: auto-detect
+# slurm_account: root              # Default: root
+```
+
+### YAML Groups Format (shared_users.yaml)
+
+Users organized into groups with per-group Slurm accounts and filesystem mounts.
+Groups are purely organizational — they do not create Linux groups. Per-group
+settings override the global defaults.
+
+```yaml
+# Optional global defaults (used when a group doesn't specify its own):
+# shared_filesystem_mount: /fsx
+# slurm_account: root
+
+groups:
+  - name: research
+    slurm_account: research
+    users:
+      - username: alice
+        uid: 2001
+      - username: bob
+        uid: 2002
+
+  - name: platform
+    slurm_account: platform
+    users:
+      - username: carol
+        uid: 3001
+      - username: dave
+        uid: 3002
+```
+
+### Configuration Reference (YAML format)
+
+| Field | Required | Scope | Default | Description |
+|-------|----------|-------|---------|-------------|
+| `users` | Yes* | Global | — | Simple format: flat list of users. |
+| `groups` | Yes* | Global | — | Groups format: list of user groups. |
+| `groups[].name` | Yes | Group | — | Group name (organizational only, no Linux group created). |
+| `groups[].users` | Yes | Group | — | Users in this group. |
+| `groups[].slurm_account` | No | Group | `root` | Slurm account for this group. Overrides global default. |
+| `groups[].shared_filesystem_mount` | No | Group | auto-detect | Home directory path for this group. Overrides global default. |
+| `shared_filesystem_mount` | No | Global | auto-detect | Default home directory path for all users/groups. |
+| `slurm_account` | No | Global | `root` | Default Slurm account for all users/groups. |
+
+\* Use either `users` or `groups`, not both.
+
+### Filesystem Auto-Detection
+
+The script automatically detects which shared filesystem to use for home directories,
+matching the base lifecycle scripts' behavior:
+
+1. **OpenZFS at `/home`** (NFS mount) — preferred when present
+2. **FSx for Lustre at `/fsx`** — fallback
+
+When both OpenZFS and Lustre are mounted, home directories go on OpenZFS (`/home/<user>`)
+and a data directory is also created on Lustre (`/fsx/<user>`) for training data and
+checkpoints.
+
+Per-group `shared_filesystem_mount` overrides the auto-detection for that group.
+
+### Choosing UIDs
+
+- Use UIDs >= 2000 to avoid conflicts with system users
+- UIDs must be unique across the cluster and across all groups
+- UIDs must be consistent across all nodes (this script handles that)
+
+## Deployment
+
+1. Copy the appropriate sample file and edit it:
+   ```bash
+   # For YAML format:
+   cp shared_users_sample.yaml shared_users.yaml
+   # Or for legacy format:
+   cp shared_users_sample.txt shared_users.txt
+   ```
+2. Upload to S3:
+   ```bash
+   aws s3 cp add-users/ s3://<your-bucket>/add-users/ --recursive
+   ```
+3. Create or update your cluster with `OnInitComplete`:
+   ```json
+   {
+       "LifeCycleConfig": {
+           "OnInitComplete": "add_users.sh",
+           "SourceS3Uri": "s3://<your-bucket>/add-users/"
+       }
+   }
+   ```
+
+## Adding Users After Cluster Creation
+
+`OnInitComplete` only runs during node provisioning. To add users to existing nodes:
+
+1. Update your user file with the new users (keep existing users in the file)
+2. Upload to S3:
+   ```bash
+   aws s3 cp add-users/shared_users.yaml s3://<your-bucket>/add-users/shared_users.yaml
+   ```
+3. SSM into the controller and pull scripts to the shared filesystem:
+   ```bash
+   sudo mkdir -p /fsx/cluster-scripts/add-users
+   sudo aws s3 cp s3://<your-bucket>/add-users/ /fsx/cluster-scripts/add-users/ --recursive
+   sudo chmod +x /fsx/cluster-scripts/add-users/*.sh
+   ```
+4. Run on the controller:
+   ```bash
+   sudo bash /fsx/cluster-scripts/add-users/add_users.sh
+   ```
+5. Run on all compute nodes via srun:
+   ```bash
+   sudo srun --partition=<partition-name> bash /fsx/cluster-scripts/add-users/add_users.sh
+   ```
+
+Existing users are skipped — only new users are created. The scripts are fully idempotent.
+
+## Execution Order
+
+The scripts run in dependency order on every node, once per group:
+
+```
+add_users.sh (entrypoint)
+  └── For each group:
+      ├── create_posix_users.sh   All nodes: create POSIX users
+      ├── setup_home_dirs.sh      All nodes: home dirs on shared FS
+      ├── setup_ssh_keys.sh       All nodes: SSH keys on shared FS
+      └── setup_slurm_accounts.sh Controller only: Slurm accounting
+```
+
+## How It Works
+
+### Node Type Detection
+
+The script auto-detects whether it's running on a controller, compute, or login
+node by checking Slurm daemons:
+- `slurmctld` running → controller
+- `slurmd` running + hostname in `sinfo` → compute
+- `slurmd` running + hostname not in `sinfo` → login
+
+### SSH Key Sharing
+
+SSH keypairs are generated on the shared filesystem (e.g., `/fsx/<username>/.ssh/`).
+The first node to run creates the keypair; subsequent nodes find it already there.
+This ensures all nodes share the same keys for passwordless SSH.
+
+### Idempotency
+
+All scripts are idempotent — safe to re-run without errors or duplicates:
+- Users that already exist are skipped
+- Home directories that already exist are left alone
+- SSH keys that already exist are not regenerated
+- Slurm accounting associations that already exist are not duplicated
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `add_users.sh` | Entrypoint script (OnInitComplete target) |
+| `create_posix_users.sh` | Creates POSIX users |
+| `setup_home_dirs.sh` | Sets up home directories on shared filesystem |
+| `setup_ssh_keys.sh` | Generates SSH keypairs on shared filesystem |
+| `setup_slurm_accounts.sh` | Registers users in Slurm accounting |
+| `shared_users_sample.yaml` | Sample YAML config (copy to `shared_users.yaml`) |
+| `shared_users_sample.txt` | Sample legacy CSV config (copy to `shared_users.txt`) |
+| `.gitattributes` | Enforces LF line endings |
+
+## Troubleshooting
+
+### Logs
+
+All output is logged to `/var/log/provision/add_users.log` on each node.
+
+### Common Issues
+
+**"No shared filesystem detected"**: This is a warning, not an error. The script
+will still create users with local `/home` directories. However, passwordless
+cross-node SSH will not work. For shared home directories and SSH keys, configure
+FSx for Lustre or OpenZFS in your cluster's `InstanceStorageConfigs`.
+
+**"Neither slurmctld nor slurmd is running"**: The script must run after
+Slurm starts. With `OnInitComplete`, this is guaranteed. If running manually,
+ensure Slurm is started first.
+
+**Users can't submit jobs**: Check that Slurm accounting is set up by running
+`sacctmgr show user` on the controller. If the user is missing, re-run the
+script on the controller.
+
+**SSH between nodes fails**: Verify keys are on the shared filesystem:
+`ls -la /fsx/<username>/.ssh/`. If keys are on local disk instead, the home
+directory setup may not have completed before SSH key generation.

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/add_users.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/add_users.sh
@@ -1,0 +1,333 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Standalone script to add users to SageMaker HyperPod Slurm clusters.
+#
+# Designed for use as an OnInitComplete script with AMI-based configuration.
+# Creates POSIX users, sets up home directories on the shared filesystem,
+# generates SSH keypairs for passwordless inter-node access, and registers
+# users in Slurm accounting.
+#
+# Supports three config sources (checked in this order):
+#   1. shared_users.txt — legacy CSV format (username,uid,home) for backward
+#      compatibility with the base lifecycle scripts. If present (even if empty),
+#      shared_users.yaml is ignored.
+#   2. shared_users.yaml — YAML format with simple user list or groups with
+#      per-group Slurm accounts and filesystem mounts.
+#   3. If neither file exists, the script exits with an error.
+#
+# Prerequisites:
+#   - Slurm daemons must be started (included in AMI-based configuration)
+#   - shared_users.txt or shared_users.yaml must be configured with user definitions
+#   - A shared filesystem (FSx for Lustre or OpenZFS) is recommended but not required.
+#     Without one, home directories and SSH keys are local to each node.
+#
+# Usage:
+#   As OnInitComplete:
+#     Upload this directory to S3 and specify add_users.sh as OnInitComplete.
+#
+#   Manual execution on a running cluster:
+#     sudo bash add_users.sh
+
+set -e
+
+LOG_FILE="/var/log/provision/add_users.log"
+mkdir -p /var/log/provision
+touch "$LOG_FILE"
+
+logger() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+logger_err() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE" >&2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Detect node type from running Slurm daemons
+# ---------------------------------------------------------------------------
+detect_node_type() {
+    if systemctl is-active --quiet slurmctld 2>/dev/null; then
+        echo "controller"
+        return 0
+    fi
+
+    if ! systemctl is-active --quiet slurmd 2>/dev/null; then
+        logger_err "ERROR: Neither slurmctld nor slurmd is running."
+        exit 1
+    fi
+
+    local hostname
+    hostname=$(hostname -s)
+    local timeout=180
+    local interval=5
+    local elapsed=0
+
+    logger_err "Detecting compute vs login for $hostname..."
+    while [ $elapsed -lt $timeout ]; do
+        local sinfo_output
+        sinfo_output=$(sinfo -N --noheader 2>/dev/null || true)
+        if [ -n "$sinfo_output" ]; then
+            if echo "$sinfo_output" | grep -qw "$hostname"; then
+                echo "compute"
+            else
+                echo "login"
+            fi
+            return 0
+        fi
+        logger_err "sinfo not yet available. Retrying in ${interval}s... (${elapsed}s/${timeout}s)"
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+    logger_err "WARNING: sinfo timed out. Falling back to resource_config.json."
+    local rc_path="/opt/ml/config/resource_config.json"
+    if [ -f "$rc_path" ]; then
+        local my_ip
+        my_ip=$(hostname -I | awk '{print $1}')
+        local group_name
+        group_name=$(python3 -c "
+import json, sys
+with open('$rc_path') as f:
+    rc = json.load(f)
+for g in rc.get('InstanceGroups', []):
+    for inst in g.get('Instances', []):
+        if inst.get('CustomerIpAddress') == '$my_ip':
+            print(g['Name'])
+            sys.exit(0)
+print('')
+" 2>/dev/null)
+        if echo "$group_name" | grep -qi "login"; then
+            echo "login"
+        else
+            echo "compute"
+        fi
+    else
+        logger_err "WARNING: resource_config.json not found. Defaulting to compute."
+        echo "compute"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Detect shared filesystem mount
+# ---------------------------------------------------------------------------
+detect_shared_filesystem() {
+    local override="$1"
+
+    if [[ -n "$override" ]]; then
+        if mountpoint -q "$override" 2>/dev/null; then
+            echo "$override"
+            return 0
+        else
+            logger_err "WARNING: Configured mount $override is not a mountpoint. Auto-detecting..."
+        fi
+    fi
+
+    # OpenZFS at /home takes priority (matches base LCS behavior)
+    if mountpoint -q "/home" 2>/dev/null && grep -qsE '\s/home\s+nfs4?\s' /proc/mounts; then
+        echo "/home"
+        return 0
+    fi
+
+    # Fallback: FSx for Lustre at /fsx
+    if mountpoint -q "/fsx" 2>/dev/null; then
+        echo "/fsx"
+        return 0
+    fi
+
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Determine user source: shared_users.txt (legacy) or config.yaml
+#
+# Priority: shared_users.txt takes precedence over config.yaml for backward
+# compatibility with the base lifecycle scripts. If shared_users.txt exists
+# (even if empty), config.yaml is ignored.
+# ---------------------------------------------------------------------------
+SHARED_USERS_FILE="$SCRIPT_DIR/shared_users.txt"
+CONFIG_FILE="$SCRIPT_DIR/shared_users.yaml"
+WORK_DIR=$(mktemp -d /tmp/add_users.XXXXXX)
+USE_LEGACY=false
+
+if [[ -f "$SHARED_USERS_FILE" ]]; then
+    USE_LEGACY=true
+    logger "Found shared_users.txt — using legacy format (shared_users.yaml ignored if present)."
+
+    if [[ ! -s "$SHARED_USERS_FILE" ]]; then
+        logger "shared_users.txt is empty. No users to configure."
+        rm -rf "$WORK_DIR"
+        exit 0
+    fi
+
+    # Convert legacy CSV (username,uid,home) to our internal format (username,uid)
+    # and build a single-group manifest with default settings
+    USERS_CSV="$WORK_DIR/users_default.csv"
+    while IFS="," read -r username uid home; do
+        username=$(echo "$username" | xargs)
+        uid=$(echo "$uid" | xargs)
+        [[ -z "$username" ]] || [[ -z "$uid" ]] && continue
+        echo "$username,$uid" >> "$USERS_CSV"
+    done < "$SHARED_USERS_FILE"
+
+    if [[ ! -s "$USERS_CSV" ]]; then
+        logger "No valid users in shared_users.txt. Nothing to do."
+        rm -rf "$WORK_DIR"
+        exit 0
+    fi
+
+    USER_COUNT=$(wc -l < "$USERS_CSV")
+    python3 -c "
+import json, os
+manifest = [{
+    'name': 'default',
+    'slurm_account': 'root',
+    'shared_filesystem_mount': '',
+    'users_file': '$USERS_CSV',
+    'user_count': $USER_COUNT
+}]
+with open(os.path.join('$WORK_DIR', 'manifest.json'), 'w') as f:
+    json.dump(manifest, f)
+"
+    logger "Parsed $USER_COUNT user(s) from shared_users.txt."
+
+elif [[ -f "$CONFIG_FILE" ]]; then
+    logger "Using shared_users.yaml for user definitions."
+
+    python3 - "$CONFIG_FILE" "$WORK_DIR" << 'PYEOF'
+import yaml, json, os, sys
+
+config_file = sys.argv[1]
+work_dir = sys.argv[2]
+
+with open(config_file) as f:
+    config = yaml.safe_load(f)
+
+global_slurm_account = config.get('slurm_account', 'root')
+global_fs_mount = config.get('shared_filesystem_mount', '')
+
+groups = config.get('groups', [])
+users = config.get('users', [])
+
+if groups and users:
+    print("ERROR: shared_users.yaml has both 'groups' and 'users' at top level. Use one or the other.")
+    sys.exit(1)
+
+if not groups and not users:
+    print("WARNING: No users or groups defined in shared_users.yaml.")
+    sys.exit(0)
+
+if users and not groups:
+    groups = [{
+        'name': 'default',
+        'slurm_account': global_slurm_account,
+        'shared_filesystem_mount': global_fs_mount,
+        'users': users
+    }]
+else:
+    for g in groups:
+        g.setdefault('slurm_account', global_slurm_account)
+        g.setdefault('shared_filesystem_mount', global_fs_mount)
+
+manifest = []
+for g in groups:
+    name = g['name']
+    group_users = g.get('users', [])
+    if not group_users:
+        continue
+
+    users_file = os.path.join(work_dir, f'users_{name}.csv')
+    with open(users_file, 'w') as uf:
+        for u in group_users:
+            uf.write(f"{u['username']},{u['uid']}\n")
+
+    manifest.append({
+        'name': name,
+        'slurm_account': g['slurm_account'],
+        'shared_filesystem_mount': g['shared_filesystem_mount'],
+        'users_file': users_file,
+        'user_count': len(group_users)
+    })
+
+with open(os.path.join(work_dir, 'manifest.json'), 'w') as mf:
+    json.dump(manifest, mf)
+
+total = sum(g['user_count'] for g in manifest)
+print(f"Parsed {total} user(s) in {len(manifest)} group(s).")
+PYEOF
+
+else
+    logger "ERROR: Neither shared_users.txt nor shared_users.yaml found in $SCRIPT_DIR"
+    rm -rf "$WORK_DIR"
+    exit 1
+fi
+
+MANIFEST="$WORK_DIR/manifest.json"
+if [[ ! -f "$MANIFEST" ]]; then
+    logger "No users to configure. Exiting."
+    rm -rf "$WORK_DIR"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Detect node type
+# ---------------------------------------------------------------------------
+NODE_TYPE=$(detect_node_type)
+logger "Detected node type: $NODE_TYPE"
+
+# ---------------------------------------------------------------------------
+# Process each group
+# ---------------------------------------------------------------------------
+GROUP_COUNT=$(python3 -c "import json; print(len(json.load(open('$MANIFEST'))))")
+logger "Processing $GROUP_COUNT group(s)..."
+
+for (( i=0; i<GROUP_COUNT; i++ )); do
+    eval "$(python3 -c "
+import json
+m = json.load(open('$MANIFEST'))[$i]
+print(f\"GROUP_NAME='{m['name']}'\")
+print(f\"USERS_FILE='{m['users_file']}'\")
+print(f\"SLURM_ACCOUNT='{m['slurm_account']}'\")
+print(f\"FS_OVERRIDE='{m['shared_filesystem_mount']}'\")
+print(f\"USER_COUNT={m['user_count']}\")
+")"
+
+    logger "--- Group: $GROUP_NAME ($USER_COUNT users) ---"
+
+    SHARED_FS_MOUNT=$(detect_shared_filesystem "$FS_OVERRIDE" || true)
+    if [[ -z "$SHARED_FS_MOUNT" ]]; then
+        SHARED_FS_MOUNT="/home"
+        logger "WARNING: No shared filesystem detected for group $GROUP_NAME."
+        logger "WARNING: Using local /home for home directories. SSH keys will be per-node only."
+        logger "WARNING: Passwordless cross-node SSH will NOT work without a shared filesystem."
+    else
+        logger "Shared filesystem for $GROUP_NAME: $SHARED_FS_MOUNT"
+    fi
+
+    export LUSTRE_MOUNT=""
+    if [[ "$SHARED_FS_MOUNT" != "/fsx" ]] && mountpoint -q "/fsx" 2>/dev/null; then
+        LUSTRE_MOUNT="/fsx"
+    fi
+
+    logger "  Step 1: Creating POSIX users"
+    bash "$SCRIPT_DIR/create_posix_users.sh" "$USERS_FILE" "$SHARED_FS_MOUNT" 2>&1 | tee -a "$LOG_FILE"
+
+    logger "  Step 2: Setting up home directories on $SHARED_FS_MOUNT"
+    bash "$SCRIPT_DIR/setup_home_dirs.sh" "$USERS_FILE" "$SHARED_FS_MOUNT" 2>&1 | tee -a "$LOG_FILE"
+
+    logger "  Step 3: Setting up SSH keys"
+    bash "$SCRIPT_DIR/setup_ssh_keys.sh" "$USERS_FILE" "$SHARED_FS_MOUNT" 2>&1 | tee -a "$LOG_FILE"
+
+    if [[ "$NODE_TYPE" == "controller" ]]; then
+        logger "  Step 4: Setting up Slurm accounting (account: $SLURM_ACCOUNT)"
+        bash "$SCRIPT_DIR/setup_slurm_accounts.sh" "$USERS_FILE" "$SLURM_ACCOUNT" 2>&1 | tee -a "$LOG_FILE"
+    else
+        logger "  Step 4: Skipping Slurm accounting (not controller)"
+    fi
+done
+
+rm -rf "$WORK_DIR"
+logger "Add users complete for $NODE_TYPE node."

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/add_users.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/add_users.sh
@@ -10,15 +10,15 @@
 # users in Slurm accounting.
 #
 # Supports three config sources (checked in this order):
-#   1. shared_users.txt — legacy CSV format (username,uid,home) for backward
+#   1. shared_users.txt |-- legacy CSV format (username,uid,home) for backward
 #      compatibility with the base lifecycle scripts. If present (even if empty),
 #      shared_users.yaml is ignored.
-#   2. shared_users.yaml — YAML format with simple user list or groups with
+#   2. shared_users.yaml |-- YAML format with simple user list or groups with
 #      per-group Slurm accounts and filesystem mounts.
 #   3. If neither file exists, the script exits with an error.
 #
 # Prerequisites:
-#   - Slurm daemons must be started (included in AMI-based configuration)
+#   - /opt/ml/config/nodeinfo.json must exist (run detect-node/detect_node.sh first)
 #   - shared_users.txt or shared_users.yaml must be configured with user definitions
 #   - A shared filesystem (FSx for Lustre or OpenZFS) is recommended but not required.
 #     Without one, home directories and SSH keys are local to each node.
@@ -47,69 +47,18 @@ logger_err() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ---------------------------------------------------------------------------
-# Detect node type from running Slurm daemons
+# Read node type from nodeinfo.json (written by detect-node/detect_node.sh).
+# Steps 1-3 run on all nodes. Only step 4 (Slurm accounting) is controller-only.
 # ---------------------------------------------------------------------------
-detect_node_type() {
-    if systemctl is-active --quiet slurmctld 2>/dev/null; then
-        echo "controller"
-        return 0
-    fi
-
-    if ! systemctl is-active --quiet slurmd 2>/dev/null; then
-        logger_err "ERROR: Neither slurmctld nor slurmd is running."
-        exit 1
-    fi
-
-    local hostname
-    hostname=$(hostname -s)
-    local timeout=180
-    local interval=5
-    local elapsed=0
-
-    logger_err "Detecting compute vs login for $hostname..."
-    while [ $elapsed -lt $timeout ]; do
-        local sinfo_output
-        sinfo_output=$(sinfo -N --noheader 2>/dev/null || true)
-        if [ -n "$sinfo_output" ]; then
-            if echo "$sinfo_output" | grep -qw "$hostname"; then
-                echo "compute"
-            else
-                echo "login"
-            fi
-            return 0
-        fi
-        logger_err "sinfo not yet available. Retrying in ${interval}s... (${elapsed}s/${timeout}s)"
-        sleep $interval
-        elapsed=$((elapsed + interval))
-    done
-
-    logger_err "WARNING: sinfo timed out. Falling back to resource_config.json."
-    local rc_path="/opt/ml/config/resource_config.json"
-    if [ -f "$rc_path" ]; then
-        local my_ip
-        my_ip=$(hostname -I | awk '{print $1}')
-        local group_name
-        group_name=$(python3 -c "
-import json, sys
-with open('$rc_path') as f:
-    rc = json.load(f)
-for g in rc.get('InstanceGroups', []):
-    for inst in g.get('Instances', []):
-        if inst.get('CustomerIpAddress') == '$my_ip':
-            print(g['Name'])
-            sys.exit(0)
-print('')
-" 2>/dev/null)
-        if echo "$group_name" | grep -qi "login"; then
-            echo "login"
-        else
-            echo "compute"
-        fi
-    else
-        logger_err "WARNING: resource_config.json not found. Defaulting to compute."
-        echo "compute"
-    fi
-}
+NODEINFO_FILE="/opt/ml/config/nodeinfo.json"
+if [[ -f "$NODEINFO_FILE" ]]; then
+    NODE_TYPE=$(python3 -c "import json; print(json.load(open('$NODEINFO_FILE'))['node_type'])")
+    logger "Node type from nodeinfo.json: $NODE_TYPE"
+else
+    logger "WARNING: $NODEINFO_FILE not found. Run detect-node/detect_node.sh first."
+    logger "Falling back: assuming not controller (Slurm accounting will be skipped)."
+    NODE_TYPE="unknown"
+fi
 
 # ---------------------------------------------------------------------------
 # Detect shared filesystem mount
@@ -155,7 +104,7 @@ USE_LEGACY=false
 
 if [[ -f "$SHARED_USERS_FILE" ]]; then
     USE_LEGACY=true
-    logger "Found shared_users.txt — using legacy format (shared_users.yaml ignored if present)."
+    logger "Found shared_users.txt |-- using legacy format (shared_users.yaml ignored if present)."
 
     if [[ ! -s "$SHARED_USERS_FILE" ]]; then
         logger "shared_users.txt is empty. No users to configure."
@@ -273,12 +222,6 @@ if [[ ! -f "$MANIFEST" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Detect node type
-# ---------------------------------------------------------------------------
-NODE_TYPE=$(detect_node_type)
-logger "Detected node type: $NODE_TYPE"
-
-# ---------------------------------------------------------------------------
 # Process each group
 # ---------------------------------------------------------------------------
 GROUP_COUNT=$(python3 -c "import json; print(len(json.load(open('$MANIFEST'))))")
@@ -330,4 +273,4 @@ print(f\"USER_COUNT={m['user_count']}\")
 done
 
 rm -rf "$WORK_DIR"
-logger "Add users complete for $NODE_TYPE node."
+logger "Add users complete."

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/add_users.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/add_users.sh
@@ -91,11 +91,11 @@ detect_shared_filesystem() {
 }
 
 # ---------------------------------------------------------------------------
-# Determine user source: shared_users.txt (legacy) or config.yaml
+# Determine user source: shared_users.txt (legacy) or shared_users.yaml
 #
-# Priority: shared_users.txt takes precedence over config.yaml for backward
-# compatibility with the base lifecycle scripts. If shared_users.txt exists
-# (even if empty), config.yaml is ignored.
+# Priority: shared_users.txt takes precedence over shared_users.yaml for
+# backward compatibility with the base lifecycle scripts. If shared_users.txt
+# exists (even if empty), shared_users.yaml is ignored.
 # ---------------------------------------------------------------------------
 SHARED_USERS_FILE="$SCRIPT_DIR/shared_users.txt"
 CONFIG_FILE="$SCRIPT_DIR/shared_users.yaml"

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/create_posix_users.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/create_posix_users.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Creates POSIX users from the provided users list file.
+# Must run on all nodes so UIDs are consistent cluster-wide.
+#
+# Usage: create_posix_users.sh <users_file> <shared_fs_mount>
+
+set -e
+
+USERS_FILE="$1"
+SHARED_FS_MOUNT="$2"
+
+if [[ -z "$USERS_FILE" ]] || [[ -z "$SHARED_FS_MOUNT" ]]; then
+    echo "Usage: create_posix_users.sh <users_file> <shared_fs_mount>"
+    exit 1
+fi
+
+create_user() {
+    local username="$1"
+    local uid="$2"
+    local home_dir="${SHARED_FS_MOUNT}/${username}"
+
+    if id -u "$username" >/dev/null 2>&1; then
+        echo "[INFO] User $username already exists. Skipping."
+        return 0
+    fi
+
+    if getent passwd "$uid" >/dev/null 2>&1; then
+        echo "[WARN] UID $uid is already in use. Skipping user $username."
+        return 0
+    fi
+
+    if useradd -m "$username" --uid "$uid" -d "$home_dir" --shell /bin/bash; then
+        echo "[INFO] Created user $username (uid=$uid, home=$home_dir)"
+    else
+        echo "[ERROR] Failed to create user $username (uid=$uid)"
+        return 1
+    fi
+}
+
+while IFS="," read -r username uid; do
+    username=$(echo "$username" | xargs)
+    uid=$(echo "$uid" | xargs)
+    [[ -z "$username" ]] || [[ -z "$uid" ]] && continue
+    create_user "$username" "$uid"
+done < "$USERS_FILE"
+
+echo "[INFO] POSIX user creation complete."

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/setup_home_dirs.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/setup_home_dirs.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Sets up user home directories on the shared filesystem.
+# When OpenZFS is the home filesystem and Lustre is also available,
+# a /fsx/<username> directory is created for data access.
+#
+# Usage: setup_home_dirs.sh <users_file> <shared_fs_mount>
+
+set -e
+
+USERS_FILE="$1"
+SHARED_FS_MOUNT="$2"
+LUSTRE_MOUNT="${LUSTRE_MOUNT:-}"
+
+if [[ -z "$USERS_FILE" ]] || [[ -z "$SHARED_FS_MOUNT" ]]; then
+    echo "Usage: setup_home_dirs.sh <users_file> <shared_fs_mount>"
+    exit 1
+fi
+
+setup_home() {
+    local username="$1"
+    local target_home="${SHARED_FS_MOUNT}/${username}"
+
+    if ! id -u "$username" >/dev/null 2>&1; then
+        echo "[WARN] User $username does not exist. Skipping home setup."
+        return 0
+    fi
+
+    if [[ ! -d "$target_home" ]]; then
+        if sudo -u "$username" mkdir -p "$target_home" 2>/dev/null; then
+            sudo -u "$username" chmod 750 "$target_home" 2>/dev/null || true
+            echo "[INFO] Created home directory $target_home (as $username)"
+        elif mkdir -p "$target_home" 2>/dev/null; then
+            chown "$username:$username" "$target_home"
+            chmod 750 "$target_home"
+            echo "[INFO] Created home directory $target_home (as root)"
+        else
+            echo "[WARN] Failed to create $target_home. Skipping."
+            return 0
+        fi
+    else
+        chown "$username:$username" "$target_home" 2>/dev/null || true
+        echo "[INFO] Home directory $target_home already exists."
+    fi
+
+    local current_home
+    current_home=$(getent passwd "$username" | cut -d: -f6)
+
+    if [[ "$current_home" == "$target_home" ]]; then
+        echo "[INFO] Home for $username already set to $target_home"
+    else
+        if [[ -d "$current_home" ]] && [[ "$current_home" != "$target_home" ]]; then
+            echo "[INFO] Copying contents from $current_home to $target_home"
+            rsync -a "$current_home/" "$target_home/" 2>/dev/null || true
+            chown -R "$username:$username" "$target_home" 2>/dev/null || true
+        fi
+        usermod -d "$target_home" "$username"
+        echo "[INFO] Updated home for $username to $target_home"
+    fi
+
+    if [[ -n "$LUSTRE_MOUNT" ]]; then
+        local lustre_dir="${LUSTRE_MOUNT}/${username}"
+        if [[ ! -d "$lustre_dir" ]]; then
+            mkdir -p "$lustre_dir"
+            chown "$username:$username" "$lustre_dir"
+            echo "[INFO] Created Lustre data directory $lustre_dir"
+        fi
+    fi
+}
+
+while IFS="," read -r username uid; do
+    username=$(echo "$username" | xargs)
+    [[ -z "$username" ]] && continue
+    setup_home "$username"
+done < "$USERS_FILE"
+
+echo "[INFO] Home directory setup complete."

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/setup_slurm_accounts.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/setup_slurm_accounts.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Registers users in Slurm accounting so they can submit jobs.
+# Runs only on the controller node. Waits for slurmdbd to be ready.
+#
+# Usage: setup_slurm_accounts.sh <users_file> <slurm_account>
+
+set -e
+
+USERS_FILE="$1"
+SLURM_ACCOUNT="${2:-root}"
+
+if [[ -z "$USERS_FILE" ]]; then
+    echo "Usage: setup_slurm_accounts.sh <users_file> [slurm_account]"
+    exit 1
+fi
+
+wait_for_slurmdbd() {
+    local max_attempts=30
+    local attempt=0
+    while [ $attempt -lt $max_attempts ]; do
+        if systemctl is-active --quiet slurmdbd; then
+            echo "[INFO] slurmdbd is active"
+            sleep 3
+            return 0
+        fi
+        echo "[INFO] Waiting for slurmdbd... (attempt $((attempt+1))/$max_attempts)"
+        sleep 2
+        attempt=$((attempt + 1))
+    done
+    echo "[ERROR] slurmdbd failed to start within timeout"
+    return 1
+}
+
+echo "[INFO] Setting up Slurm accounting associations"
+
+wait_for_slurmdbd
+
+sacctmgr -i add account "$SLURM_ACCOUNT" Description="$SLURM_ACCOUNT account" 2>/dev/null || true
+echo "[INFO] Ensured Slurm account '$SLURM_ACCOUNT' exists"
+
+while IFS="," read -r username uid; do
+    username=$(echo "$username" | xargs)
+    [[ -z "$username" ]] && continue
+
+    if ! id -u "$username" >/dev/null 2>&1; then
+        echo "[WARN] User $username does not exist on this node. Skipping."
+        continue
+    fi
+
+    sacctmgr -i add user "$username" account="$SLURM_ACCOUNT" 2>/dev/null || true
+    echo "[INFO] Added $username to Slurm account '$SLURM_ACCOUNT'"
+done < "$USERS_FILE"
+
+echo "[INFO] Slurm accounting setup complete."

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/setup_ssh_keys.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/setup_ssh_keys.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Generates SSH keypairs on the shared filesystem for passwordless inter-node SSH.
+# First node to run creates the keypair; subsequent nodes find it already there.
+#
+# Usage: setup_ssh_keys.sh <users_file> <shared_fs_mount>
+
+set -e
+
+USERS_FILE="$1"
+SHARED_FS_MOUNT="$2"
+
+if [[ -z "$USERS_FILE" ]] || [[ -z "$SHARED_FS_MOUNT" ]]; then
+    echo "Usage: setup_ssh_keys.sh <users_file> <shared_fs_mount>"
+    exit 1
+fi
+
+setup_ssh() {
+    local username="$1"
+    local ssh_dir="${SHARED_FS_MOUNT}/${username}/.ssh"
+
+    if ! id -u "$username" >/dev/null 2>&1; then
+        echo "[WARN] User $username does not exist. Skipping SSH setup."
+        return 0
+    fi
+
+    mkdir -p "$ssh_dir"
+
+    if [[ ! -f "$ssh_dir/id_rsa" ]]; then
+        echo "[INFO] Generating SSH keypair for $username on shared filesystem"
+        ssh-keygen -t rsa -b 4096 -q -f "$ssh_dir/id_rsa" -N "" 2>/dev/null || true
+        cat "$ssh_dir/id_rsa.pub" >> "$ssh_dir/authorized_keys"
+    else
+        echo "[INFO] SSH keypair for $username already exists on shared filesystem"
+        if [[ -f "$ssh_dir/id_rsa.pub" ]]; then
+            if ! grep -qF "$(cat "$ssh_dir/id_rsa.pub")" "$ssh_dir/authorized_keys" 2>/dev/null; then
+                cat "$ssh_dir/id_rsa.pub" >> "$ssh_dir/authorized_keys"
+            fi
+        fi
+    fi
+
+    chmod 700 "$ssh_dir"
+    chmod 600 "$ssh_dir/id_rsa" 2>/dev/null || true
+    chmod 644 "$ssh_dir/id_rsa.pub" 2>/dev/null || true
+    touch "$ssh_dir/authorized_keys"
+    chmod 600 "$ssh_dir/authorized_keys"
+    chown -R "$username:$username" "$ssh_dir"
+
+    local user_home
+    user_home=$(getent passwd "$username" | cut -d: -f6)
+
+    if [[ "$user_home" == "${SHARED_FS_MOUNT}/${username}" ]]; then
+        local local_home="/home/$username"
+        if [[ -d "$local_home" ]] && [[ "$local_home" != "$user_home" ]]; then
+            if [[ -L "$local_home/.ssh" ]]; then
+                echo "[INFO] Symlink $local_home/.ssh already exists"
+            elif [[ -d "$local_home/.ssh" ]]; then
+                rm -rf "$local_home/.ssh"
+                ln -s "$ssh_dir" "$local_home/.ssh"
+                chown -h "$username:$username" "$local_home/.ssh"
+                echo "[INFO] Replaced $local_home/.ssh with symlink to $ssh_dir"
+            else
+                ln -s "$ssh_dir" "$local_home/.ssh"
+                chown -h "$username:$username" "$local_home/.ssh"
+                echo "[INFO] Created symlink $local_home/.ssh -> $ssh_dir"
+            fi
+        fi
+    fi
+
+    echo "[INFO] SSH setup complete for $username"
+}
+
+while IFS="," read -r username uid; do
+    username=$(echo "$username" | xargs)
+    [[ -z "$username" ]] && continue
+    setup_ssh "$username"
+done < "$USERS_FILE"
+
+echo "[INFO] SSH key setup complete."

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/shared_users_sample.txt
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/shared_users_sample.txt
@@ -1,0 +1,4 @@
+user1,2001,/fsx/user1
+user2,2002,/fsx/user2
+user3,2003,/fsx/user3
+user4,2004,/fsx/user4

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/shared_users_sample.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/add-users/shared_users_sample.yaml
@@ -1,0 +1,58 @@
+# =============================================================================
+# Add Users Configuration
+# =============================================================================
+#
+# Two formats are supported:
+#
+# 1. Simple: flat list of users (all get global defaults)
+# 2. Groups: users organized into groups with per-group Slurm accounts
+#    and filesystem mounts
+#
+# You can use either format, but not both in the same config file.
+#
+# To use this file, copy it to shared_users.yaml and edit it.
+# =============================================================================
+
+# --- Simple format (no groups) ---
+users:
+  - username: user1
+    uid: 2001
+  - username: user2
+    uid: 2002
+
+# --- Global optional settings ---
+
+# Path where user home directories are created.
+# Must be a shared filesystem mounted on all nodes (e.g., FSx for Lustre or OpenZFS).
+# Default: auto-detect (OpenZFS at /home preferred, then Lustre at /fsx)
+# shared_filesystem_mount: /fsx
+
+# Slurm accounting account to add users to.
+# Default: root
+# slurm_account: root
+
+# --- Groups format (uncomment below and remove the 'users' section above) ---
+#
+# Groups are an organizational concept for mapping users to different
+# Slurm accounts and filesystem mounts. They do not create Linux groups.
+# Per-group settings override the global defaults above.
+#
+# groups:
+#   - name: research
+#     # Optional: Slurm account for this group (default: global slurm_account or 'root')
+#     slurm_account: research
+#     # Optional: Home directory path for this group (default: global shared_filesystem_mount or auto-detect)
+#     # shared_filesystem_mount: /fsx
+#     users:
+#       - username: alice
+#         uid: 2001
+#       - username: bob
+#         uid: 2002
+#
+#   - name: platform
+#     slurm_account: platform
+#     users:
+#       - username: carol
+#         uid: 3001
+#       - username: dave
+#         uid: 3002

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/detect-node/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/detect-node/README.md
@@ -13,18 +13,11 @@ compute nodes.
 
 ### Why Not Detect via Slurm Services?
 
-A common approach is to check which Slurm daemon is running (`slurmctld` for
-controller, `slurmd` for compute/login). This is unreliable because:
-
-- **OnInitComplete runs in parallel with Slurm startup.** The Slurm daemons
-  may not be started yet when your script runs, especially during scale-up.
-- **slurmd can flap during scale-up.** New compute nodes may briefly start
-  `slurmd`, then restart it as the node joins the cluster. A script that
-  checks `systemctl is-active slurmd` can see it active one moment and
-  inactive the next.
-- **sinfo depends on the controller.** Using `sinfo` to distinguish compute
-  from login nodes requires the controller to be reachable, which isn't
-  guaranteed during cluster creation when all nodes start simultaneously.
+Detecting node type by checking Slurm daemons (e.g., `systemctl is-active
+slurmctld`) is unreliable because `OnInitComplete` and lifecycle scripts can
+run before or in parallel with Slurm service startup. Using the platform
+config files is the recommended approach — it is deterministic, instant, and
+has no dependency on Slurm or any other service being ready.
 
 ### The Reliable Method: Platform Config Files
 

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/detect-node/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/detect-node/README.md
@@ -1,0 +1,111 @@
+# Node Detection for SageMaker HyperPod Extensions
+
+Utility script that detects the node type and writes node-specific information
+to `/opt/ml/config/nodeinfo.json`. Designed to run once at the start of
+`OnInitComplete`, before other extensions that need to know the node type.
+
+## Why This Exists
+
+HyperPod extension scripts often need to know whether they're running on a
+controller, compute, or login node. For example, Slurm accounting setup should
+only run on the controller, while GPU metric exporters should only run on
+compute nodes.
+
+### Why Not Detect via Slurm Services?
+
+A common approach is to check which Slurm daemon is running (`slurmctld` for
+controller, `slurmd` for compute/login). This is unreliable because:
+
+- **OnInitComplete runs in parallel with Slurm startup.** The Slurm daemons
+  may not be started yet when your script runs, especially during scale-up.
+- **slurmd can flap during scale-up.** New compute nodes may briefly start
+  `slurmd`, then restart it as the node joins the cluster. A script that
+  checks `systemctl is-active slurmd` can see it active one moment and
+  inactive the next.
+- **sinfo depends on the controller.** Using `sinfo` to distinguish compute
+  from login nodes requires the controller to be reachable, which isn't
+  guaranteed during cluster creation when all nodes start simultaneously.
+
+### The Reliable Method: Platform Config Files
+
+HyperPod writes two JSON config files to `/opt/ml/config/` on every node
+**before** any lifecycle scripts run:
+
+- `provisioning_parameters.json` |-- contains `controller_group` and
+  `login_group` field names that identify which instance groups serve
+  which roles.
+- `resource_config.json` |-- contains all instance groups with their instances,
+  including each instance's `CustomerIpAddress`.
+
+The detection algorithm:
+1. Get this node's IP address (via UDP socket |-- no network call needed)
+2. Find which instance group contains this IP in `resource_config.json`
+3. Compare that group's name to `provisioning_parameters.json`:
+   - Matches `controller_group`  **controller**
+   - Matches `login_group`  **login**
+   - Otherwise  **compute**
+
+This is deterministic, instant, and has zero dependency on Slurm or any
+other service. It works during initial cluster creation, scale-up, and
+node replacement.
+
+## Output
+
+The script writes `/opt/ml/config/nodeinfo.json`:
+
+```json
+{
+  "node_type": "controller",
+  "instance_group_name": "controller",
+  "instance_name": "controller-1",
+  "instance_id": "i-042a465749062463f",
+  "instance_type": "ml.t3.medium",
+  "ip_address": "10.1.197.201",
+  "cluster_name": "my-cluster",
+  "cluster_arn": "arn:aws:sagemaker:us-east-1:123456789012:cluster/abc123"
+}
+```
+
+## Usage
+
+### In run_extensions.sh
+
+Run `detect_node.sh` first, before other extensions:
+
+```bash
+# Detect node type (writes /opt/ml/config/nodeinfo.json)
+run_feature "detect-node" "$SCRIPT_DIR/detect-node/detect_node.sh"
+
+# Other extensions can now read nodeinfo.json
+run_feature "add-users" "$SCRIPT_DIR/add-users/add_users.sh"
+run_feature "observability" "$SCRIPT_DIR/observability/setup_observability.sh"
+```
+
+### Reading nodeinfo.json from bash
+
+```bash
+NODE_TYPE=$(python3 -c "import json; print(json.load(open('/opt/ml/config/nodeinfo.json'))['node_type'])")
+
+if [[ "$NODE_TYPE" == "controller" ]]; then
+    echo "Running on controller"
+fi
+```
+
+### Reading nodeinfo.json from Python
+
+```python
+import json
+
+with open('/opt/ml/config/nodeinfo.json') as f:
+    nodeinfo = json.load(f)
+
+if nodeinfo['node_type'] == 'controller':
+    print("Running on controller")
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `detect_node.sh` | Node detection script (writes nodeinfo.json) |
+| `README.md` | This documentation |

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/detect-node/detect_node.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/detect-node/detect_node.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Detects node type and writes node-specific information to nodeinfo.json.
+#
+# This script reads the HyperPod platform config files at /opt/ml/config/
+# (provisioning_parameters.json and resource_config.json) to determine the
+# node type (controller, compute, or login) and extract node-specific details.
+#
+# Output: /opt/ml/config/nodeinfo.json
+#
+# Usage:
+#   Run once at the start of OnInitComplete (before other extensions):
+#     sudo bash detect_node.sh
+#
+#   Other scripts can then read the output:
+#     NODE_TYPE=$(python3 -c "import json; print(json.load(open('/opt/ml/config/nodeinfo.json'))['node_type'])")
+
+set -e
+
+CONFIG_DIR="/opt/ml/config"
+PP_FILE="$CONFIG_DIR/provisioning_parameters.json"
+RC_FILE="$CONFIG_DIR/resource_config.json"
+OUTPUT_FILE="$CONFIG_DIR/nodeinfo.json"
+
+LOG_FILE="/var/log/provision/detect_node.log"
+mkdir -p /var/log/provision
+touch "$LOG_FILE"
+
+logger() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Validate platform config files exist
+# ---------------------------------------------------------------------------
+if [[ ! -f "$PP_FILE" ]]; then
+    logger "ERROR: $PP_FILE not found. This script must run on a HyperPod cluster node."
+    exit 1
+fi
+
+if [[ ! -f "$RC_FILE" ]]; then
+    logger "ERROR: $RC_FILE not found. This script must run on a HyperPod cluster node."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Detect node type and write nodeinfo.json using Python
+# ---------------------------------------------------------------------------
+python3 - "$PP_FILE" "$RC_FILE" "$OUTPUT_FILE" << 'PYEOF'
+import json
+import socket
+import sys
+import time
+
+pp_file = sys.argv[1]
+rc_file = sys.argv[2]
+output_file = sys.argv[3]
+
+def get_ip_address():
+    """Get this node's IP address using the UDP socket trick (no network call)."""
+    max_retries = 7
+    retry_delay = 5
+    for attempt in range(max_retries):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(('10.254.254.254', 1))
+            ip = s.getsockname()[0]
+            s.close()
+            return ip
+        except Exception as e:
+            if attempt < max_retries - 1:
+                time.sleep(retry_delay)
+                retry_delay *= 2
+            else:
+                return '127.0.0.1'
+
+# Read platform config files
+with open(pp_file) as f:
+    pp = json.load(f)
+
+with open(rc_file) as f:
+    rc = json.load(f)
+
+# Get this node's IP
+my_ip = get_ip_address()
+
+# Find this node in resource_config
+my_group = None
+my_instance = None
+for group in rc.get('InstanceGroups', []):
+    for inst in group.get('Instances', []):
+        if inst.get('CustomerIpAddress') == my_ip:
+            my_group = group
+            my_instance = inst
+            break
+    if my_group:
+        break
+
+if not my_group or not my_instance:
+    print(f"ERROR: Could not find instance with IP {my_ip} in resource_config.json", file=sys.stderr)
+    sys.exit(1)
+
+# Determine node type by comparing group name to provisioning_parameters
+group_name = my_group.get('Name', '')
+controller_group = pp.get('controller_group', '')
+login_group = pp.get('login_group', '') or ''
+
+if group_name == controller_group:
+    node_type = 'controller'
+elif group_name == login_group:
+    node_type = 'login'
+else:
+    node_type = 'compute'
+
+# Extract cluster info
+cluster_config = rc.get('ClusterConfig', {})
+
+# Build nodeinfo
+nodeinfo = {
+    "node_type": node_type,
+    "instance_group_name": group_name,
+    "instance_name": my_instance.get('InstanceName', ''),
+    "instance_id": my_instance.get('InstanceId', ''),
+    "instance_type": my_group.get('InstanceType', ''),
+    "ip_address": my_ip,
+    "cluster_name": cluster_config.get('ClusterName', ''),
+    "cluster_arn": cluster_config.get('ClusterArn', ''),
+}
+
+# Write output
+with open(output_file, 'w') as f:
+    json.dump(nodeinfo, f, indent=2)
+
+print(f"Node type: {node_type} (group: {group_name}, ip: {my_ip}, instance: {my_instance.get('InstanceId', '')})")
+PYEOF
+
+EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 0 ]]; then
+    logger "ERROR: Node detection failed with exit code $EXIT_CODE"
+    exit $EXIT_CODE
+fi
+
+# Log the result
+NODE_TYPE=$(python3 -c "import json; print(json.load(open('$OUTPUT_FILE'))['node_type'])")
+logger "Node info written to $OUTPUT_FILE (node_type=$NODE_TYPE)"

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/.gitattributes
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/.gitattributes
@@ -1,0 +1,7 @@
+# Force LF line endings for all scripts — these run on Linux.
+*.sh text eol=lf
+*.py text eol=lf
+*.yaml text eol=lf
+*.csv text eol=lf
+*.json text eol=lf
+*.txt text eol=lf

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/LICENSE_SLURM_EXPORTER.txt
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/LICENSE_SLURM_EXPORTER.txt
@@ -1,0 +1,29 @@
+This package depends on and may incorporate or retrieve a number of third-party
+software packages (such as open source packages) at install-time or build-time
+or run-time ("External Dependencies"). The External Dependencies are subject to
+license terms that you must accept in order to use this package. If you do not
+accept all of the applicable license terms, you should not use this package. We
+recommend that you consult your company's open source approval policy before
+proceeding.
+
+Provided below is a list of External Dependencies and the applicable license
+identification as indicated by the documentation associated with the External
+Dependencies as of Amazon's most recent review.
+
+THIS INFORMATION IS PROVIDED FOR CONVENIENCE ONLY. AMAZON DOES NOT PROMISE THAT
+THE LIST OR THE APPLICABLE TERMS AND CONDITIONS ARE COMPLETE, ACCURATE, OR
+UP-TO-DATE, AND AMAZON WILL HAVE NO LIABILITY FOR ANY INACCURACIES. YOU SHOULD
+CONSULT THE DOWNLOAD SITES FOR THE EXTERNAL DEPENDENCIES FOR THE MOST COMPLETE
+AND UP-TO-DATE LICENSING INFORMATION.
+
+YOUR USE OF THE EXTERNAL DEPENDENCIES IS AT YOUR SOLE RISK. IN NO EVENT WILL
+AMAZON BE LIABLE FOR ANY DAMAGES, INCLUDING WITHOUT LIMITATION ANY DIRECT,
+INDIRECT, CONSEQUENTIAL, SPECIAL, INCIDENTAL, OR PUNITIVE DAMAGES (INCLUDING
+FOR ANY LOSS OF GOODWILL, BUSINESS INTERRUPTION, LOST PROFITS OR DATA, OR
+COMPUTER FAILURE OR MALFUNCTION) ARISING FROM OR RELATING TO THE EXTERNAL
+DEPENDENCIES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, EVEN
+IF AMAZON HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+AND DISCLAIMERS APPLY EXCEPT TO THE EXTENT PROHIBITED BY APPLICABLE LAW.
+
+- slurm_exporter: https://github.com/SckyzO/slurm_exporter.git
+  GPLv3 - https://github.com/SckyzO/slurm_exporter/blob/master/LICENSE

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/README.md
@@ -1,0 +1,653 @@
+# Observability for SageMaker HyperPod Slurm Clusters
+
+This standalone sample installs a metrics collection and export pipeline on
+SageMaker HyperPod Slurm clusters. It deploys per-node metric exporters and an
+OpenTelemetry (OTel) collector that ships metrics to
+[Amazon Managed Service for Prometheus (AMP)](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html),
+where they can be visualized with
+[Amazon Managed Grafana](https://docs.aws.amazon.com/grafana/latest/userguide/what-is-Amazon-Managed-Service-Grafana.html).
+
+## Architecture
+
+Each cluster node runs its own set of metric exporters and an OTel collector.
+The OTel collector scrapes the local exporters and remote-writes metrics to
+AMP using SigV4 authentication (via the cluster execution role). There is no
+central Prometheus server -- each node independently ships its own metrics.
+
+```
+  Controller Node              Compute Node (GPU)          Login Node
+  +------------------+        +------------------+        +------------------+
+  | Node Exporter    |        | Node Exporter    |        | Node Exporter    |
+  | Slurm Exporter   |        | DCGM Exporter    |        +--------+---------+
+  +--------+---------+        | EFA Exporter     |                 |
+           |                  +--------+---------+                 |
+           v                           |                           v
+  +------------------+                 |                  +------------------+
+  | OTel Collector   |                 |                  | OTel Collector   |
+  +--------+---------+                 |                  +--------+---------+
+           |                           |                           |
+           |    +----------------------+                           |
+           |    |                                                  |
+           |    |  (When NCCL metrics enabled)                     |
+           |    |  +---------------------------+                   |
+           |    |  | Slurm Job (GPU training)  |                   |
+           |    |  |  NCCL Inspector Plugin    |                   |
+           |    |  |    |                      |                   |
+           |    |  |    v                      |                   |
+           |    |  |  textfile (.prom files)   |                   |
+           |    |  |  /var/lib/node_exporter/  |                   |
+           |    |  |  nccl_inspector/          |                   |
+           |    |  +----------+----------------+                   |
+           |    |             |                                    |
+           |    |             v (textfile collector)               |
+           |    +---> Node Exporter                                |
+           |                  |                                    |
+           |                  v                                    |
+           |         +------------------+                          |
+           |         | OTel Collector   |                          |
+           |         +--------+---------+                          |
+           |                  |                                    |
+           +--------+---------+------------------------------------+
+                    |
+                    v
+          +-------------------+
+          | Amazon Managed    |
+          | Prometheus (AMP)  |
+          +--------+----------+
+                   |
+                   v
+          +-------------------+
+          | Amazon Managed    |
+          | Grafana           |
+          +-------------------+
+```
+
+## What gets installed
+
+The stack is node-type aware. The entrypoint script (`setup_observability.sh`)
+auto-detects whether a node is a controller, compute, or login node by
+checking which Slurm daemon is running, then installs the appropriate
+exporters.
+
+| Component | Controller | Compute | Login | Port | Description |
+| --- | :---: | :---: | :---: | --- | --- |
+| Node Exporter | Y | Y | Y | 9100 | OS-level metrics (CPU, memory, disk, network) |
+| DCGM Exporter | | Y | | 9400 | NVIDIA GPU metrics with Slurm job-ID mapping |
+| EFA Exporter | | Y | | 9109 | Elastic Fabric Adapter network metrics |
+| Slurm Exporter | Y | | | 9341 | Slurm scheduler metrics (jobs, nodes, partitions) |
+| OTel Collector | Y | Y | Y | 4317/4318 | Scrapes all local exporters and remote-writes to AMP |
+
+Node type detection logic:
+- `slurmctld` running -> controller
+- `slurmd` running + hostname in `sinfo` output -> compute
+- `slurmd` running + hostname NOT in `sinfo` output -> login
+
+On compute nodes, DCGM Exporter gracefully skips installation if no NVIDIA
+GPU is detected (CPU-only compute nodes).
+
+### GPU-to-job-ID mapping (DCGM + Slurm Prolog/Epilog)
+
+When a Slurm job allocates GPUs, it's useful to know which job is using
+which GPU so that GPU metrics (temperature, utilization, errors) can be
+attributed to specific training jobs. This is handled by Slurm
+Prolog/Epilog scripts that the HyperPod AMI provides automatically.
+
+The flow works like this:
+
+1. A user submits a GPU job (e.g., `sbatch --gres=gpu:1 ...`)
+2. Slurm allocates GPUs and runs the **Prolog** script before the job starts
+3. The Prolog writes the job ID to a mapping file named after the GPU index
+   (e.g., `/run/slurm/dcgm-job-mapping/0` contains `"42"` for job 42)
+4. DCGM Exporter reads this directory and adds an `hpc_job` label to all
+   GPU metrics for that device
+5. When the job ends, the **Epilog** script removes the job ID from the
+   mapping file
+
+The result is that DCGM metrics in AMP/Grafana include the `hpc_job` label:
+
+```
+DCGM_FI_DEV_GPU_TEMP{gpu="0",...,hpc_job="42"} 27
+```
+
+This lets you filter GPU dashboards by job ID, correlate GPU utilization
+with specific training runs, and identify which jobs are causing thermal
+or error issues.
+
+The Prolog/Epilog scripts are provided by the HyperPod AMI at:
+- `/opt/slurm/etc/prolog.d/700_dcgm_job_map_register.sh`
+- `/opt/slurm/etc/epilog.d/700_dcgm_job_map_cleanup.sh`
+
+They use file locking (`flock`) for safe concurrent access and are designed
+to never return non-zero exit codes Ã¢â‚¬â€ a prolog failure would block the job
+from starting, and an epilog failure would drain the node, both of which
+are too disruptive for a metrics-only feature.
+
+> **Note:** When using AMI-based configuration (`OnInitComplete`), the
+> Prolog/Epilog scripts and the mapping directory are set up automatically.
+> No action is needed. When using `OnCreate` with custom lifecycle scripts,
+> ensure your `start_slurm.sh` configures `Prolog` and `Epilog` in
+> `slurm.conf` and that the DCGM Exporter mounts
+> `/run/slurm/dcgm-job-mapping` (with hyphens, not underscores).
+
+## Prerequisites
+
+### 1. Enable IAM Identity Center
+
+IAM Identity Center is required for Amazon Managed Grafana authentication.
+Follow the instructions in
+[Enabling IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/get-set-up-for-idc.html)
+and create an admin user account.
+
+### 2. Create the observability infrastructure
+
+Deploy the CloudFormation stack that provisions an AMP workspace and an
+Amazon Managed Grafana workspace:
+
+```bash
+wget https://raw.githubusercontent.com/aws-samples/awsome-distributed-training/main/4.validation_and_observability/4.prometheus-grafana/cluster-observability.yaml
+
+aws cloudformation create-stack \
+    --stack-name hyperpod-observability \
+    --template-body file://cluster-observability.yaml \
+    --capabilities CAPABILITY_NAMED_IAM
+```
+
+After the stack completes, note the `AMPRemoteWriteURL` from the outputs:
+
+```bash
+aws cloudformation describe-stacks \
+    --stack-name hyperpod-observability \
+    --query "Stacks[0].Outputs[?OutputKey=='AMPRemoteWriteURL'].OutputValue" \
+    --output text
+```
+
+This URL goes into `config.json` as `prometheus_remote_write_url`.
+
+If you already have existing AMP and Grafana workspaces, pass their IDs:
+
+```bash
+aws cloudformation create-stack \
+    --stack-name hyperpod-observability \
+    --template-body file://cluster-observability.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameters \
+        ParameterKey=PrometheusExistingWorkspaceId,ParameterValue=ws-abc123 \
+        ParameterKey=GrafanaExistingWorkspaceId,ParameterValue=g-xyz789
+```
+
+Alternatively, you can create just an AMP workspace without Grafana:
+
+```bash
+aws amp create-workspace --alias hyperpod-observability \
+    --tags Environment=dev
+```
+
+The remote write URL is:
+`https://aps-workspaces.<region>.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write`
+
+### 3. Add AMP remote write permissions to the cluster execution role
+
+The HyperPod cluster execution role must have `aps:RemoteWrite` permission.
+Attach an inline policy:
+
+```bash
+aws iam put-role-policy \
+    --role-name <your-execution-role> \
+    --policy-name AMPRemoteWritePolicy \
+    --policy-document '{
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Action": ["aps:RemoteWrite"],
+            "Resource": "arn:aws:aps:<region>:<account-id>:workspace/<workspace-id>"
+        }]
+    }'
+```
+
+### 4. Network requirements
+
+- The VPC must allow outbound internet access (NAT gateway) for the
+  controller node to download Go and build the Slurm Exporter from source.
+- All nodes need HTTPS access to the AMP endpoint for remote write.
+- All nodes need HTTPS access to ECR (`602401143452.dkr.ecr.<region>.amazonaws.com`)
+  to pull the exporter container images.
+- For SSM access to cluster nodes, create VPC endpoints for `ssm`,
+  `ssmmessages`, and `ec2messages` in the cluster's VPC and subnet.
+
+### 5. S3 bucket
+
+Upload the observability scripts to an S3 bucket. The bucket name must start
+with `sagemaker-` to be accessible by the
+`AmazonSageMakerClusterInstanceRolePolicy` managed policy.
+
+```bash
+aws s3 sync ./observability s3://sagemaker-<your-bucket>/observability/
+```
+
+> **Important:** If editing scripts on Windows, ensure all files have LF
+> (Unix) line endings before uploading. CRLF line endings will cause
+> `$'\r': command not found` errors on Linux. The included `.gitattributes`
+> file enforces LF endings when using Git.
+
+
+## Usage
+
+### Option A: OnInitComplete (recommended for new clusters)
+
+Use this when creating a cluster with AMI-based configuration (no
+`LifeCycleConfig` or `OnCreate`). HyperPod sets up Slurm and Docker
+automatically, then runs your extension script.
+
+1. Edit `config.json` with your AMP remote write URL:
+
+   > **Important:** The `config.json` file ships with placeholder values
+   > (`<region>`, `<workspace-id>`). You **must** replace
+   > `prometheus_remote_write_url` with your actual AMP workspace URL
+   > before uploading to S3. The setup script validates this at runtime
+   > and will fail with an error if placeholder values are detected.
+   > Cluster creation with `OnInitComplete` will fail if the script
+   > exits non-zero.
+
+   ```json
+   {
+       "prometheus_remote_write_url": "https://aps-workspaces.<region>.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write",
+       "advanced_metrics": false,
+       "nccl_metrics_enabled": false,
+       "nccl_metrics_dump_interval_seconds": 30,
+       "nccl_profiler_plugin_path": "/opt/aws/hyperpod/observability/lib/libnccl-profiler-inspector.so"
+   }
+   ```
+
+2. Upload to S3:
+   ```bash
+   aws s3 sync ./observability s3://sagemaker-<your-bucket>/observability/
+   ```
+
+3. Create the cluster with `OnInitComplete` on each instance group. Here is
+   a complete `CreateCluster` example:
+
+   ```json
+   {
+       "ClusterName": "my-hyperpod-cluster",
+       "InstanceGroups": [
+           {
+               "InstanceGroupName": "controller",
+               "InstanceType": "ml.c5.xlarge",
+               "InstanceCount": 1,
+               "SlurmConfig": { "NodeType": "Controller" },
+               "LifeCycleConfig": {
+                   "OnInitComplete": "setup_observability.sh",
+                   "SourceS3Uri": "s3://sagemaker-<your-bucket>/observability/"
+               },
+               "ExecutionRole": "arn:aws:iam::<account-id>:role/<execution-role>",
+               "InstanceStorageConfigs": [
+                   { "EbsVolumeConfig": { "VolumeSizeInGB": 500 } }
+               ]
+           },
+           {
+               "InstanceGroupName": "login",
+               "InstanceType": "ml.m5.xlarge",
+               "InstanceCount": 1,
+               "SlurmConfig": { "NodeType": "Login" },
+               "LifeCycleConfig": {
+                   "OnInitComplete": "setup_observability.sh",
+                   "SourceS3Uri": "s3://sagemaker-<your-bucket>/observability/"
+               },
+               "ExecutionRole": "arn:aws:iam::<account-id>:role/<execution-role>"
+           },
+           {
+               "InstanceGroupName": "gpu-workers",
+               "InstanceType": "ml.p4d.24xlarge",
+               "InstanceCount": 4,
+               "SlurmConfig": {
+                   "NodeType": "Compute",
+                   "PartitionNames": ["gpu-training"]
+               },
+               "LifeCycleConfig": {
+                   "OnInitComplete": "setup_observability.sh",
+                   "SourceS3Uri": "s3://sagemaker-<your-bucket>/observability/"
+               },
+               "ExecutionRole": "arn:aws:iam::<account-id>:role/<execution-role>"
+           }
+       ],
+       "Orchestrator": {
+           "Slurm": { "SlurmConfigStrategy": "Managed" }
+       },
+       "VpcConfig": {
+           "SecurityGroupIds": ["sg-<your-sg>"],
+           "Subnets": ["subnet-<your-subnet>"]
+       },
+       "NodeRecovery": "Automatic"
+   }
+   ```
+
+   Submit with:
+   ```bash
+   aws sagemaker create-cluster --cli-input-json file://create_cluster.json
+   ```
+
+   > **Note:** `OnInitComplete` and `SlurmConfig` are new API fields. If
+   > your AWS CLI version does not recognize them, update the CLI or use
+   > boto3/SDK to call the API directly.
+
+### Option B: Manual execution on a running cluster
+
+Connect to each node via SSM and run the script. The SSM target format for
+HyperPod nodes is:
+
+```
+sagemaker-cluster:<cluster-id>_<instance-group-name>-<instance-id>
+```
+
+Find the cluster ID and instance IDs:
+```bash
+aws sagemaker describe-cluster --cluster-name <cluster-name> --query "ClusterArn"
+# Extract the ID after the last slash, e.g., "abc123def456"
+
+aws sagemaker list-cluster-nodes --cluster-name <cluster-name>
+```
+
+Connect and run:
+```bash
+aws ssm start-session \
+    --target sagemaker-cluster:<cluster-id>_<group-name>-<instance-id> \
+    --region <region>
+
+# Once connected:
+sudo aws s3 sync s3://sagemaker-<your-bucket>/observability/ /tmp/observability/
+sudo bash /tmp/observability/setup_observability.sh
+```
+
+### Option C: OnCreate (legacy lifecycle scripts)
+
+If you are using full custom lifecycle scripts with `OnCreate`, call
+`setup_observability.sh` from your `lifecycle_script.py` after Slurm has
+been started. Add the following to your `lifecycle_script.py`:
+
+```python
+# After ExecuteBashScript("./start_slurm.sh").run(...)
+# Install observability
+if Config.enable_observability:
+    ExecuteBashScript("./utils/install_docker.sh").run()
+    subprocess.run(
+        ["bash", "./observability/setup_observability.sh"],
+        check=True
+    )
+```
+
+Ensure the `observability/` directory is uploaded alongside your other
+lifecycle scripts in the same S3 prefix.
+
+
+## Configuration
+
+All configuration is in `config.json`:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `prometheus_remote_write_url` | string | (required) | AMP workspace remote write endpoint |
+| `advanced_metrics` | bool | `false` | Enable extended metrics (see below) |
+| `nccl_metrics_enabled` | bool | `false` | Enable NCCL Inspector metrics via Slurm task prolog |
+| `nccl_metrics_dump_interval_seconds` | int | `30` | NCCL metrics dump interval in seconds |
+| `nccl_profiler_plugin_path` | string | `/opt/aws/hyperpod/observability/lib/libnccl-profiler-inspector.so` | Path to the NCCL Inspector `.so` plugin |
+
+### Advanced metrics
+
+When `advanced_metrics` is `true`:
+- Node Exporter enables additional collectors: `cgroups`, `ksmd`,
+  `meminfo_numa`, `ethtool`, `mountstats`, `network_route`, `processes`,
+  `tcpstat`
+- DCGM Exporter uses the advanced metrics CSV which adds: ECC errors,
+  retired pages, NVLink error counters, per-link bandwidth, SM occupancy,
+  FP16/FP32/FP64 pipe activity, and additional throttling violation counters
+- EFA Exporter enables the `amazonefa` collector with detailed per-device
+  metrics
+
+### NCCL metrics
+
+[NCCL (NVIDIA Collective Communications Library)](https://github.com/NVIDIA/nccl)
+is the library that powers multi-GPU and multi-node communication in
+distributed training. Operations like AllReduce, AllGather, and
+ReduceScatter are NCCL collectives that move data between GPUs during
+training. Monitoring NCCL performance is critical for identifying
+communication bottlenecks in large-scale training jobs.
+
+The [NCCL Inspector](https://github.com/NVIDIA/nccl/tree/master/plugins/profiler/inspector)
+is an NCCL profiler plugin that hooks into NCCL collective and P2P
+operations at runtime and exports per-operation performance metrics. When
+configured in Prometheus mode, it writes metrics as textfiles that Node
+Exporter scrapes and the OTel Collector ships to AMP.
+
+#### How it works
+
+The NCCL metrics data flow has these components:
+
+1. **Slurm TaskProlog** (`/opt/slurm/etc/task_prolog.sh`) -- A script that
+   Slurm runs before every task. It sets environment variables that tell
+   NCCL to load the Inspector plugin and output Prometheus-format metrics.
+
+2. **NCCL Inspector Plugin** (`.so` library) -- Loaded by NCCL at runtime
+   via `NCCL_PROFILER_PLUGIN`. It intercepts collective and P2P operations,
+   measures bandwidth and execution time, and periodically dumps metrics as
+   Prometheus textfiles.
+
+3. **Textfile directory** (`/var/lib/node_exporter/nccl_inspector/`) -- The
+   Inspector writes `.prom` files here, one per GPU. Each file contains
+   gauge metrics with labels identifying the job, GPU, collective type,
+   message size, and algorithm.
+
+4. **Node Exporter textfile collector** -- Node Exporter's
+   `--collector.textfile` flag scrapes the textfile directory and exposes
+   the NCCL metrics on port 9100 alongside OS metrics.
+
+5. **OTel Collector** -- Scrapes Node Exporter and remote-writes all
+   metrics (including NCCL) to AMP.
+
+#### What gets configured
+
+When `nccl_metrics_enabled` is `true`, the setup script:
+
+1. Creates `/var/lib/node_exporter/nccl_inspector/` on compute nodes
+   (mode 777 so any Slurm job user can write)
+2. Starts Node Exporter with `--collector.textfile` pointing to that
+   directory
+3. Creates `/opt/slurm/etc/task_prolog.sh` that outputs the following
+   environment variables for every Slurm task:
+
+   | Variable | Value | Purpose |
+   | --- | --- | --- |
+   | `NCCL_PROFILER_PLUGIN` | Path to `.so` | Tells NCCL to load the Inspector |
+   | `NCCL_INSPECTOR_ENABLE` | `1` | Activates the Inspector |
+   | `NCCL_INSPECTOR_PROM_DUMP` | `1` | Outputs Prometheus format (not JSON) |
+   | `NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS` | Configurable (default 30s) | How often metrics are written |
+   | `NCCL_INSPECTOR_DUMP_DIR` | `/var/lib/node_exporter/nccl_inspector/` | Where textfiles are written |
+
+4. Adds `TaskProlog=/opt/slurm/etc/task_prolog.sh` to `slurm.conf` on the
+   controller and runs `scontrol reconfigure` to push the config to all
+   compute nodes
+
+The NCCL Inspector plugin is pre-installed on the HyperPod AMI at
+`/opt/aws/hyperpod/observability/lib/libnccl-profiler-inspector.so`.
+If using a custom AMI, build from
+[NCCL source](https://github.com/NVIDIA/nccl/tree/master/plugins/profiler/inspector)
+(requires NCCL v2.28.3+).
+
+#### Exported NCCL metrics
+
+The Inspector exports these Prometheus metrics:
+
+| Metric | Description |
+| --- | --- |
+| `nccl_bus_bandwidth_gbs` | Bus bandwidth in GB/s for collective operations |
+| `nccl_collective_exec_time_microseconds` | Execution time in microseconds for collectives |
+| `nccl_p2p_bus_bandwidth_gbs` | P2P bus bandwidth in GB/s (Send/Recv) |
+| `nccl_p2p_exec_time_microseconds` | P2P execution time in microseconds |
+
+Each metric carries labels:
+
+| Label | Description |
+| --- | --- |
+| `slurm_job_id` | Slurm job ID |
+| `node` | Hostname |
+| `gpu` | GPU identifier (e.g., `GPU0`) |
+| `comm_name` | NCCL communicator name (e.g., `DP Group 0`) |
+| `n_nodes` | Number of nodes (`1` = intra-node NVLink, `>1` = multi-node) |
+| `nranks` | Total number of ranks |
+| `collective` | Collective type: `AllReduce`, `AllGather`, `ReduceScatter`, etc. |
+| `message_size` | Bucketed size range (e.g., `4-5GB`, `512-513MB`) |
+| `algo_proto` | Algorithm/protocol (e.g., `Ring_ll`) |
+| `p2p_operation` | `Send` or `Recv` (P2P metrics only) |
+
+Example metric output:
+```
+nccl_bus_bandwidth_gbs{slurm_job_id="42",node="ip-10-1-35-255",gpu="GPU0",comm_name="DP Group 0",n_nodes="1",nranks="4",collective="AllReduce",message_size="4-5GB",algo_proto="Ring_ll"} 678.263
+nccl_collective_exec_time_microseconds{slurm_job_id="42",node="ip-10-1-35-255",gpu="GPU0",comm_name="DP Group 0",n_nodes="1",nranks="4",collective="AllReduce",message_size="4-5GB",algo_proto="Ring_ll"} 9498.47
+```
+
+#### NCCL Grafana dashboard
+
+NVIDIA provides an official Grafana dashboard template for NCCL Inspector
+metrics at
+[`nccl-inspector-job-performance-template.json`](https://github.com/NVIDIA/nccl/tree/master/plugins/profiler/inspector/grafana).
+The dashboard shows:
+
+| Panel Row | Metrics |
+| --- | --- |
+| P2P [Recv] | Recv bus bandwidth and exec time (NVLink-only and multi-node) |
+| P2P [Send] | Send bus bandwidth and exec time (NVLink-only and multi-node) |
+| ReduceScatter | ReduceScatter bus bandwidth and exec time |
+| AllReduce | AllReduce bus bandwidth and exec time |
+| AllGather | AllGather bus bandwidth and exec time |
+
+Each row splits into NVLink-only (`n_nodes="1"`) and network
+(`n_nodes!="1"`) views.
+
+To import: download the template JSON from the NCCL repo and import it in
+Grafana via **Dashboards > New > Import**. Configure the Prometheus data
+source to point to your AMP workspace.
+
+#### NCCL metrics requirements
+
+- Multi-GPU compute nodes (NCCL collectives require 2+ GPUs)
+- A running distributed training job that uses NCCL (e.g., PyTorch DDP,
+  FSDP, Megatron-LM)
+- Metrics are only produced while NCCL operations are active; idle GPUs
+  produce no NCCL metrics
+
+## Validating the setup
+
+After the cluster reaches `InService` status (typically 10-15 minutes),
+verify the observability stack is running.
+
+### Check CloudWatch lifecycle logs
+
+```bash
+aws logs filter-log-events \
+    --log-group-name /aws/sagemaker/Clusters/<cluster-name>/<cluster-id> \
+    --filter-pattern "lifecycle scripts"
+```
+
+All instance groups should show `The lifecycle scripts succeeded.`
+
+### Check exporters on the controller node
+
+```bash
+# Connect via SSM
+aws ssm start-session \
+    --target sagemaker-cluster:<cluster-id>_controller-<instance-id> \
+    --region <region>
+
+# Verify containers and services
+sudo docker ps --format 'table {{.Names}}\t{{.Status}}'
+systemctl is-active slurm_exporter
+
+# Verify metrics endpoints
+curl -s http://localhost:9100/metrics | head -5    # Node Exporter
+curl -s http://localhost:9341/metrics | grep slurm | head -5  # Slurm Exporter
+```
+
+### Check exporters on a compute node
+
+```bash
+sudo docker ps --format 'table {{.Names}}\t{{.Status}}'
+
+curl -s http://localhost:9100/metrics | head -5    # Node Exporter
+curl -s http://localhost:9400/metrics | grep DCGM | head -5   # DCGM Exporter
+curl -s http://localhost:9109/metrics | head -5    # EFA Exporter
+```
+
+### Verify metrics in AMP
+
+Open Grafana and run a PromQL query `up` in the Explore view. You should
+see targets from all cluster nodes with `job` labels like `node_exporter`,
+`slurm_exporter`, `dcgm_exporter`, and `efa_exporter`.
+
+### Import Grafana dashboards
+
+Import the following community dashboards via **Dashboards > New > Import**:
+
+| Dashboard | Grafana ID | URL |
+| --- | --- | --- |
+| Slurm Dashboard | 4323 | `https://grafana.com/grafana/dashboards/4323-slurm-dashboard/` |
+| Node Exporter Full | 1860 | `https://grafana.com/grafana/dashboards/1860-node-exporter-full/` |
+| NVIDIA DCGM Exporter | 12239 | `https://grafana.com/grafana/dashboards/12239-nvidia-dcgm-exporter-dashboard/` |
+| EFA Metrics | 20579 | `https://grafana.com/grafana/dashboards/20579-efa-metrics-dev/` |
+| FSx for Lustre | 20906 | `https://grafana.com/grafana/dashboards/20906-fsx-lustre/` |
+
+Ensure the AMP workspace is configured as a Prometheus data source in
+Grafana: **Apps > AWS Data Sources > Data sources**, select your region,
+and choose the AMP workspace.
+
+## Stopping observability
+
+To stop all observability containers and services on a node:
+```bash
+sudo python3 stop_observability.py --node-type controller  # or compute, login
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `$'\r': command not found` in lifecycle logs | CRLF line endings (edited on Windows) | Convert all files to LF before uploading to S3. Use `.gitattributes` or `dos2unix`. |
+| GPU worker detected as `login` node | `sinfo` not available during cluster creation (controller still starting) | Fixed in `setup_observability.sh` with retry loop. If using an older version, re-run the script manually after the cluster is `InService`. |
+| NCCL env vars not injected into jobs | `scontrol reconfigure` not run after adding `TaskProlog` | Run `sudo scontrol reconfigure` on the controller. Fixed in current version. |
+| DCGM Exporter not running on GPU node | No NVIDIA GPU detected | Expected on CPU-only compute nodes. DCGM Exporter exits gracefully. |
+| Slurm Exporter stuck in `activating` | Binary not copied due to previous partial install | Run `sudo rm -rf /usr/bin/slurm_exporter` then re-run `setup_observability.sh`. Fixed in current version with clean build directory. |
+| Metrics not appearing in AMP | OTel Collector can't reach AMP endpoint | Check VPC has NAT gateway or AMP VPC endpoint. Check execution role has `aps:RemoteWrite`. |
+| `docker pull` fails | Can't reach ECR | Check VPC has NAT gateway or ECR VPC endpoints. |
+
+## File structure
+
+```
+observability/
+|-- README.md                            # This file
+|-- config.json                          # User configuration (edit before deploying)
+|-- .gitattributes                       # Enforces LF line endings
+|-- setup_observability.sh               # Entrypoint script (OnInitComplete)
+|-- install_observability.py             # Orchestrator (called by setup_observability.sh)
+|-- install_node_exporter.sh             # Node Exporter (all nodes)
+|-- install_dcgm_exporter.sh             # DCGM Exporter (compute nodes with GPU)
+|-- install_efa_exporter.sh              # EFA Exporter (compute nodes)
+|-- install_slurm_exporter.sh            # Slurm Exporter (controller node)
+|-- install_otel_collector.sh            # OTel Collector (all nodes)
+|-- stop_observability.py                # Stop all observability services
+|-- LICENSE_SLURM_EXPORTER.txt           # License for Slurm Exporter dependency (GPLv3)
+|-- otel_config/
+|   |-- config-head-template.yaml        # OTel config template for controller
+|   |-- config-compute-template.yaml     # OTel config template for compute
+|   +-- config-login-template.yaml       # OTel config template for login
++-- dcgm_metrics_config/
+    |-- dcgm-metrics-basic.csv           # Basic DCGM metrics (default)
+    +-- dcgm-metrics-advanced.csv        # Advanced DCGM metrics (when advanced_metrics=true)
+```
+
+## Related resources
+
+- [SageMaker HyperPod cluster resources monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-cluster-observability-slurm.html)
+- [Getting started with SageMaker HyperPod using the AWS CLI](https://docs.aws.amazon.com/sagemaker/latest/dg/smcluster-getting-started-slurm-cli.html)
+- [Customizing SageMaker HyperPod clusters using lifecycle scripts](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-lifecycle-best-practices-slurm.html)
+- [Slurm Dashboard for Grafana](https://grafana.com/grafana/dashboards/4323-slurm-dashboard/)
+- [NVIDIA DCGM Exporter Dashboard for Grafana](https://grafana.com/grafana/dashboards/12239-nvidia-dcgm-exporter-dashboard/)
+- [EFA Metrics Dashboard for Grafana](https://grafana.com/grafana/dashboards/20579-efa-metrics-dev/)
+- [NCCL Inspector source](https://github.com/NVIDIA/nccl/tree/master/plugins/profiler/inspector)

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/README.md
@@ -118,7 +118,7 @@ The Prolog/Epilog scripts are provided by the HyperPod AMI at:
 - `/opt/slurm/etc/epilog.d/700_dcgm_job_map_cleanup.sh`
 
 They use file locking (`flock`) for safe concurrent access and are designed
-to never return non-zero exit codes Ã¢â‚¬â€ a prolog failure would block the job
+to never return non-zero exit codes -- a prolog failure would block the job
 from starting, and an epilog failure would drain the node, both of which
 are too disruptive for a metrics-only feature.
 
@@ -185,10 +185,13 @@ aws amp create-workspace --alias hyperpod-observability \
 The remote write URL is:
 `https://aps-workspaces.<region>.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write`
 
-### 3. Add AMP remote write permissions to the cluster execution role
+### 3. Add required permissions to the cluster execution role
 
-The HyperPod cluster execution role must have `aps:RemoteWrite` permission.
-Attach an inline policy:
+The HyperPod cluster execution role needs two additional policies beyond
+the base `AmazonSageMakerClusterInstanceRolePolicy`:
+
+**a) AMP remote write** -- Required for the OTel Collector to ship metrics
+to Amazon Managed Prometheus:
 
 ```bash
 aws iam put-role-policy \
@@ -203,6 +206,33 @@ aws iam put-role-policy \
         }]
     }'
 ```
+
+**b) ECR image pull** -- Required for pulling the exporter container images
+(Node Exporter, DCGM Exporter, EFA Exporter, OTel Collector) from the
+HyperPod ECR registry (`602401143452.dkr.ecr.<region>.amazonaws.com`):
+
+```bash
+aws iam put-role-policy \
+    --role-name <your-execution-role> \
+    --policy-name ECRPullPolicy \
+    --policy-document '{
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Action": [
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer"
+            ],
+            "Resource": "*"
+        }]
+    }'
+```
+
+> **Important:** Both policies are required. Without the ECR policy, the
+> exporter container images cannot be pulled and the observability setup
+> will fail. Without the AMP policy, metrics cannot be shipped to
+> Prometheus.
 
 ### 4. Network requirements
 

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/config.json
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/config.json
@@ -1,0 +1,7 @@
+{
+    "prometheus_remote_write_url": "https://aps-workspaces.<region>.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write",
+    "advanced_metrics": false,
+    "nccl_metrics_enabled": false,
+    "nccl_metrics_dump_interval_seconds": 30,
+    "nccl_profiler_plugin_path": "/opt/aws/hyperpod/observability/lib/libnccl-profiler-inspector.so"
+}

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/dcgm_metrics_config/dcgm-metrics-advanced.csv
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/dcgm_metrics_config/dcgm-metrics-advanced.csv
@@ -1,0 +1,74 @@
+# Clocks
+DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
+DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+
+# Temperature
+DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
+DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
+
+# Power
+DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
+DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
+
+# PCIE
+DCGM_FI_PROF_PCIE_TX_BYTES,  counter, Total number of bytes transmitted through PCIe TX via NVML.
+DCGM_FI_PROF_PCIE_RX_BYTES,  counter, Total number of bytes received through PCIe RX via NVML.
+DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
+
+# Utilization (the sample period varies depending on the product)
+DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
+DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
+DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
+DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
+
+# Errors and violations
+DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
+DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
+DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
+DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
+DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
+DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
+DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
+
+# Memory usage
+DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+
+# ECC
+DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
+DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
+DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
+DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
+
+# Retired pages
+DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
+DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
+DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
+
+# NVLink
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
+DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
+
+# VGPU License status
+DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
+
+# Remapped rows
+DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
+DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
+DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
+
+# DCP metrics
+DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active.
+DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned.
+DCGM_FI_PROF_SM_OCCUPANCY,       gauge, The ratio of number of warps resident on an SM.
+DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active.
+DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data.
+DCGM_FI_PROF_PIPE_FP64_ACTIVE,   gauge, Ratio of cycles the fp64 pipes are active.
+DCGM_FI_PROF_PIPE_FP32_ACTIVE,   gauge, Ratio of cycles the fp32 pipes are active.
+DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
+DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
+DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/dcgm_metrics_config/dcgm-metrics-basic.csv
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/dcgm_metrics_config/dcgm-metrics-basic.csv
@@ -1,0 +1,47 @@
+# Clocks
+DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
+DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+
+# Temperature
+DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
+DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
+
+# Power
+DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
+DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
+
+# PCIE
+DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
+
+# Utilization (the sample period varies depending on the product)
+DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
+DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
+DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
+DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
+
+# Errors and violations
+DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
+DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
+DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
+
+# Memory usage
+DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+
+# NVLink
+DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
+
+# VGPU License status
+DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
+
+# Remapped rows
+DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
+DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
+DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
+
+# DCP metrics
+DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active.
+DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active.
+DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data.
+DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
+DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_dcgm_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_dcgm_exporter.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Define the container name and image version
+CONTAINER_NAME="dcgm-exporter"
+ECR_ACCOUNT_ID=602401143452
+DCGM_EXPORTER_VERSION=4.1.1-4.0.4-ubi9
+IMAGE="$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/hyperpod/dcgm_exporter:${DCGM_EXPORTER_VERSION}"
+METRICS_CSV_DIR="/etc/dcgm-exporter"
+METRICS_CSV_FILE="/etc/dcgm-exporter/dcgm-metrics.csv"
+JOB_ID_MAP_DIR="/run/slurm/dcgm-job-mapping"
+
+# Maximum number of retries
+MAX_RETRIES=5
+RETRY_DELAY=5  # Initial delay in seconds
+
+# Check if the container exists and is running
+if docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" | grep -q "$CONTAINER_NAME"; then
+    echo "Container $CONTAINER_NAME is already running."
+    exit 0
+else
+    echo "Container $CONTAINER_NAME is not running or does not exist..."
+    echo "Checking if $CONTAINER_NAME container exists but is not running. If yes, removing it..."
+    docker rm -f $CONTAINER_NAME && echo "Container $CONTAINER_NAME has been removed."
+    echo "Proceeding with script..."
+fi
+
+# Check for GPU, then proceed with script
+if nvidia-smi > /dev/null 2>&1; then
+    echo "NVIDIA GPU found. Proceeding with script..."
+
+    # Get the instance-type from EC2 instance metadata
+    TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+    INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-type)
+
+    echo "Instance Type is recognized as $INSTANCE_TYPE, setting DCGM_EXPORTER_VERSION to $DCGM_EXPORTER_VERSION"
+
+    # Retry logic for pulling the image
+    attempt=0
+    delay=$RETRY_DELAY
+    while [ $attempt -lt $MAX_RETRIES ]; do
+        echo "Attempting to pull image ($((attempt + 1))/$MAX_RETRIES)..."
+
+        aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+
+        if sudo docker pull "$IMAGE"; then
+            echo "Successfully pulled image."
+            break
+        else
+            attempt=$((attempt + 1))
+            if [ $attempt -lt $MAX_RETRIES ]; then
+                echo "Pull failed. Retrying in $delay seconds..."
+                sleep $delay
+                delay=$((delay * 2))  # Exponential backoff
+            else
+                echo "Failed to pull Docker image after $MAX_RETRIES attempts. Exiting..."
+                exit 1
+            fi
+        fi
+    done
+
+    # Run the DCGM Exporter Docker container with the custom metrics
+    if sudo docker run -d --restart always \
+        --name $CONTAINER_NAME \
+        --gpus all \
+        --net host \
+        --cap-add SYS_ADMIN \
+        -v "$METRICS_CSV_DIR:$METRICS_CSV_DIR" \
+        -v "$JOB_ID_MAP_DIR:/etc/dcgm-exporter/hpc" \
+        $IMAGE \
+        -f "$METRICS_CSV_FILE" \
+        --hpc-job-mapping-dir "/etc/dcgm-exporter/hpc"; then
+        echo "Running DCGM exporter in a Docker container on port 9400..."
+    else
+        echo "Failed to run DCGM Exporter Docker container"
+        exit 1
+    fi
+else
+    echo "NVIDIA GPU not found. DCGM Exporter was not installed. If this is a controller node, you can safely ignore this warning. Exiting gracefully..."
+    exit 0
+fi

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_efa_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_efa_exporter.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Define the container name
+CONTAINER_NAME="efa-exporter"
+
+ECR_ACCOUNT_ID=602401143452
+VERSION=1.0.0
+IMAGE="$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/hyperpod/efa_exporter:${VERSION}"
+
+# Maximum number of retries
+MAX_RETRIES=5
+RETRY_DELAY=5  # Initial delay in seconds
+
+# Set additional flags for advanced metrics if ADVANCED is set to 1
+ADDITIONAL_FLAGS=""
+if [ "$ADVANCED" = "1" ]; then
+    ADDITIONAL_FLAGS="--collector.disable-defaults --collector.amazonefa"
+fi
+
+# Check if the container exists and is running
+if docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" | grep -q "$CONTAINER_NAME"; then
+    echo "Container $CONTAINER_NAME is already running."
+    exit 0
+else
+    echo "Container $CONTAINER_NAME is not running or does not exist..."
+    echo "Checking if $CONTAINER_NAME container exists but is not running. If yes, removing it..."
+    docker rm -f $CONTAINER_NAME && echo "Container $CONTAINER_NAME has been removed."
+    echo "Proceeding with script..."
+fi
+
+# Retry logic for pulling the image
+attempt=0
+while [ $attempt -lt $MAX_RETRIES ]; do
+    echo "Attempting to pull image ($attempt/$MAX_RETRIES)..."
+
+    aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+
+    if sudo docker pull "$IMAGE"; then
+        echo "Successfully pulled image."
+        break
+    else
+        attempt=$((attempt + 1))
+        if [ $attempt -lt $MAX_RETRIES ]; then
+            echo "Pull failed. Retrying in $RETRY_DELAY seconds..."
+            sleep $RETRY_DELAY
+            RETRY_DELAY=$((RETRY_DELAY * 2))  # Exponential backoff
+        else
+            echo "Failed to pull Docker image after $MAX_RETRIES attempts. Exiting..."
+            exit 1
+        fi
+    fi
+done
+
+# Run the Docker container with appropriate configurations
+if sudo docker run -d --restart always \
+    --name=$CONTAINER_NAME \
+    --net="host" \
+    --pid="host" \
+    -v "/:/host:ro,rslave" \
+    $IMAGE \
+    --path.rootfs=/host \
+    --web.listen-address=:9109 \
+    $ADDITIONAL_FLAGS; then
+    echo "Successfully started EFA Exporter on node"
+    exit 0
+else
+    echo "Failed to run Docker container"
+    exit 1
+fi

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_node_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_node_exporter.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Define the container name
+CONTAINER_NAME="node-exporter"
+
+ECR_ACCOUNT_ID=602401143452
+VERSION=v1.9.1
+IMAGE="$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/hyperpod/node_exporter:${VERSION}"
+
+# Maximum number of retries
+MAX_RETRIES=5
+RETRY_DELAY=5  # Initial delay in seconds
+
+# Set additional flags for advanced metrics if ADVANCED is set to 1
+ADDITIONAL_FLAGS=""
+if [ "$ADVANCED" = "1" ]; then
+    ADDITIONAL_FLAGS="--collector.cgroups --collector.ksmd --collector.meminfo_numa --collector.ethtool --collector.mountstats --collector.network_route --collector.processes --collector.tcpstat"
+fi
+
+# Check if the container exists and is running
+if docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" | grep -q "$CONTAINER_NAME"; then
+    echo "Container $CONTAINER_NAME is already running."
+    exit 0
+else
+    echo "Container $CONTAINER_NAME is not running or does not exist..."
+    echo "Checking if $CONTAINER_NAME container exists but is not running. If yes, removing it..."
+    docker rm -f $CONTAINER_NAME && echo "Container $CONTAINER_NAME has been removed."
+    echo "Proceeding with script..."
+fi
+
+# Retry logic for pulling the image
+attempt=0
+while [ $attempt -lt $MAX_RETRIES ]; do
+    echo "Attempting to pull image ($attempt/$MAX_RETRIES)..."
+
+    aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+
+    if sudo docker pull "$IMAGE"; then
+        echo "Successfully pulled image."
+        break
+    else
+        attempt=$((attempt + 1))
+        if [ $attempt -lt $MAX_RETRIES ]; then
+            echo "Pull failed. Retrying in $RETRY_DELAY seconds..."
+            sleep $RETRY_DELAY
+            RETRY_DELAY=$((RETRY_DELAY * 2))  # Exponential backoff
+        else
+            echo "Failed to pull Docker image after $MAX_RETRIES attempts. Exiting..."
+            exit 1
+        fi
+    fi
+done
+
+# Add textfile collector for NCCL metrics if the inspector directory exists
+NCCL_VOLUME=""
+NCCL_FLAGS=""
+if [ -d "/var/lib/node_exporter/nccl_inspector" ]; then
+    NCCL_VOLUME="-v /var/lib/node_exporter:/var/lib/node_exporter:ro"
+    NCCL_FLAGS="--collector.textfile --collector.textfile.directory=/var/lib/node_exporter/nccl_inspector"
+fi
+
+# Run the Docker container with appropriate configurations
+if sudo docker run -d --restart always \
+    --name=$CONTAINER_NAME \
+    --net="host" \
+    --pid="host" \
+    -v "/:/host:ro,rslave" \
+    $NCCL_VOLUME \
+    $IMAGE \
+    --path.rootfs=/host \
+    $ADDITIONAL_FLAGS \
+    $NCCL_FLAGS; then
+    echo "Successfully started Node Exporter on node"
+    exit 0
+else
+    echo "Failed to run Docker container"
+    exit 1
+fi

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_observability.py
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_observability.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Orchestrator script that installs the observability stack on a HyperPod node.
+# Called by setup_observability.sh after node type detection and config parsing.
+
+import os
+import json
+import shutil
+import argparse
+import subprocess
+import socket
+
+
+def get_region_from_resource_config():
+    """Extract the AWS region from the HyperPod resource_config.json."""
+    filepath = "/opt/ml/config/resource_config.json"
+    with open(filepath, "r") as f:
+        d = json.load(f)
+    cluster_arn = d["ClusterConfig"]["ClusterArn"]
+    region = cluster_arn.split(":")[3]
+    return region
+
+
+def create_file_from_template(template_path, output_path, replacements):
+    """Render an OTel config template with the given replacements."""
+    with open(template_path, "r") as template_file:
+        template = template_file.read()
+    content = template.format(**replacements)
+    with open(output_path, "w") as output_file:
+        output_file.write(content)
+
+
+def install_observability(node_type, prometheus_remote_write_url, advanced=False, nccl_metrics=False):
+    region = get_region_from_resource_config()
+    hostname = socket.gethostname()
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    env_vars = os.environ.copy()
+    env_vars["REGION"] = region
+    env_vars["ADVANCED"] = "1" if advanced else "0"
+
+    if nccl_metrics and node_type == "compute":
+        path = "/var/lib/node_exporter/nccl_inspector"
+        os.makedirs(path, exist_ok=True)
+        os.chmod(path, 0o777)
+
+    otel_config_dir = os.path.join(script_dir, "otel_config")
+    replacements = {
+        "REGION": region,
+        "AMPREMOTEWRITEURL": prometheus_remote_write_url,
+        "HOSTNAME": hostname,
+    }
+
+    if node_type == "controller":
+        os.makedirs("/etc/otel", exist_ok=True)
+        create_file_from_template(
+            os.path.join(otel_config_dir, "config-head-template.yaml"),
+            "/etc/otel/config.yaml",
+            replacements,
+        )
+        subprocess.run(["bash", os.path.join(script_dir, "install_node_exporter.sh")], env=env_vars, check=True)
+        subprocess.run(["bash", os.path.join(script_dir, "install_slurm_exporter.sh")], env=env_vars, check=True)
+        subprocess.run(["bash", os.path.join(script_dir, "install_otel_collector.sh")], env=env_vars, check=True)
+
+    elif node_type == "compute":
+        os.makedirs("/etc/dcgm-exporter", exist_ok=True)
+        dcgm_config_dir = os.path.join(script_dir, "dcgm_metrics_config")
+        if advanced:
+            shutil.copy(os.path.join(dcgm_config_dir, "dcgm-metrics-advanced.csv"), "/etc/dcgm-exporter/dcgm-metrics.csv")
+        else:
+            shutil.copy(os.path.join(dcgm_config_dir, "dcgm-metrics-basic.csv"), "/etc/dcgm-exporter/dcgm-metrics.csv")
+
+        os.makedirs("/etc/otel", exist_ok=True)
+        create_file_from_template(
+            os.path.join(otel_config_dir, "config-compute-template.yaml"),
+            "/etc/otel/config.yaml",
+            replacements,
+        )
+        subprocess.run(["bash", os.path.join(script_dir, "install_node_exporter.sh")], env=env_vars, check=True)
+        subprocess.run(["bash", os.path.join(script_dir, "install_dcgm_exporter.sh")], env=env_vars, check=True)
+        subprocess.run(["bash", os.path.join(script_dir, "install_efa_exporter.sh")], env=env_vars, check=True)
+        subprocess.run(["bash", os.path.join(script_dir, "install_otel_collector.sh")], env=env_vars, check=True)
+
+    elif node_type == "login":
+        os.makedirs("/etc/otel", exist_ok=True)
+        create_file_from_template(
+            os.path.join(otel_config_dir, "config-login-template.yaml"),
+            "/etc/otel/config.yaml",
+            replacements,
+        )
+        subprocess.run(["bash", os.path.join(script_dir, "install_node_exporter.sh")], env=env_vars, check=True)
+        subprocess.run(["bash", os.path.join(script_dir, "install_otel_collector.sh")], env=env_vars, check=True)
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser(description="Install HyperPod observability stack")
+    argparser.add_argument("--node-type", required=True, help="Node type (controller, login, compute)")
+    argparser.add_argument("--prometheus-remote-write-url", required=True, help="AMP remote write URL")
+    argparser.add_argument("--advanced", action="store_true", default=False, help="Enable advanced metrics")
+    argparser.add_argument("--nccl-metrics", action="store_true", default=False, help="Enable NCCL metrics collection")
+    args = argparser.parse_args()
+
+    assert args.node_type in ["controller", "login", "compute"]
+
+    print("Starting observability installation")
+    install_observability(args.node_type, args.prometheus_remote_write_url, args.advanced, args.nccl_metrics)
+    print("---")
+    print("Finished observability installation")

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_otel_collector.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_otel_collector.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Define the container name
+CONTAINER_NAME="otel-collector"
+
+ECR_ACCOUNT_ID=602401143452
+VERSION=v1754424030352
+IMAGE="$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/hyperpod/otel_collector:${VERSION}"
+
+# Maximum number of retries
+MAX_RETRIES=5
+RETRY_DELAY=5  # Initial delay in seconds
+
+# Check if the container exists and is running
+if docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" | grep -q "$CONTAINER_NAME"; then
+    echo "Container $CONTAINER_NAME is already running."
+    exit 0
+else
+    echo "Container $CONTAINER_NAME is not running or does not exist..."
+    echo "Checking if $CONTAINER_NAME container exists but is not running. If yes, removing it..."
+    docker rm -f $CONTAINER_NAME && echo "Container $CONTAINER_NAME has been removed."
+    echo "Proceeding with script..."
+fi
+
+# Retry logic for pulling the image
+attempt=0
+while [ $attempt -lt $MAX_RETRIES ]; do
+    echo "Attempting to pull image ($attempt/$MAX_RETRIES)..."
+
+    aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+
+    if sudo docker pull "$IMAGE"; then
+        echo "Successfully pulled image."
+        break
+    else
+        attempt=$((attempt + 1))
+        if [ $attempt -lt $MAX_RETRIES ]; then
+            echo "Pull failed. Retrying in $RETRY_DELAY seconds..."
+            sleep $RETRY_DELAY
+            RETRY_DELAY=$((RETRY_DELAY * 2))  # Exponential backoff
+        else
+            echo "Failed to pull Docker image after $MAX_RETRIES attempts. Exiting..."
+            exit 1
+        fi
+    fi
+done
+
+# Run the Docker container with appropriate configurations
+if sudo docker run -d --restart always \
+    --name=$CONTAINER_NAME \
+    --net="host" \
+    --pid="host" \
+    -v /etc/otel:/etc/otel \
+    -p 4317:4317 -p 4318:4318 -p 8889:8889 \
+    $IMAGE \
+    --config=/etc/otel/config.yaml ; then
+    echo "Successfully started OTEL Collector on node"
+    exit 0
+else
+    echo "Failed to run Docker container"
+    exit 1
+fi

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_slurm_exporter.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/install_slurm_exporter.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Check if Slurm ctld service is running to identify controller node:
+if systemctl is-active --quiet slurmctld; then
+    # Check if Go is installed, if not, install it
+    if ! command -v go &> /dev/null; then
+        echo "Go is not installed. Installing Go..."
+        rm -rf /usr/local/go
+        wget -q https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -O /tmp/go1.22.2.linux-amd64.tar.gz
+        tar -C /usr/local -xzf /tmp/go1.22.2.linux-amd64.tar.gz
+        rm -f /tmp/go1.22.2.linux-amd64.tar.gz
+        export PATH=$PATH:/usr/local/go/bin
+    else
+        echo "Go is already installed."
+    fi
+
+    # Environment variable HOME is not set in LCS. It is needed for Go.
+    # Setting it only for this script & child processes.
+    export HOME=$(pwd)
+
+    # Install SLURM exporter from source.
+    # slurm_exporter is licensed under GPLv3. See LICENSE_SLURM_EXPORTER.txt as well.
+    echo "This was identified as the controller node because Slurmctld is running. Begining SLURM Exporter Installation"
+
+    SLURM_EXPORTER_DIR="/tmp/slurm_exporter_build"
+
+    if [ -d "$SLURM_EXPORTER_DIR" ]; then
+        echo "Previous build directory found. Removing for clean build..."
+        rm -rf "$SLURM_EXPORTER_DIR"
+    fi
+
+    git clone -b v1.1.0 https://github.com/SckyzO/slurm_exporter.git "$SLURM_EXPORTER_DIR"
+    cd "$SLURM_EXPORTER_DIR"
+
+    make build
+
+    # Remove any stale file or directory at the target path before copying
+    rm -rf /usr/bin/slurm_exporter
+    cp bin/slurm_exporter /usr/bin/slurm_exporter
+    tee /etc/systemd/system/slurm_exporter.service > /dev/null <<EOF
+[Unit]
+Description=Prometheus SLURM Exporter
+
+[Service]
+Environment=PATH=/opt/slurm/bin:\$PATH
+ExecStart=/usr/bin/slurm_exporter
+Restart=on-failure
+RestartSec=15
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl enable --now slurm_exporter
+    echo "Prometheus SLURM Exporter installation completed successfully."
+else
+    echo "This was identified as a worker node because Slurmctld is not running. Did not begin Prometheus SLURM Exporter installation. Exiting gracefully."
+    exit 0
+fi

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/otel_config/config-compute-template.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/otel_config/config-compute-template.yaml
@@ -1,0 +1,58 @@
+## Compute Node OTEL Config (with GPU)
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+        evaluation_interval: 15s
+      scrape_configs:
+        - job_name: 'node_exporter'
+          file_sd_configs:
+            - files:
+                - /etc/otel/targets.json
+              refresh_interval: 5s
+          static_configs:
+            - targets: ['localhost:9100']
+          relabel_configs:
+            - target_label: instance
+              replacement: '{HOSTNAME}'
+        - job_name: 'dcgm_exporter'
+          static_configs:
+            - targets: ['localhost:9400']
+          relabel_configs:
+            - target_label: instance
+              replacement: '{HOSTNAME}'
+        - job_name: 'efa_exporter'
+          file_sd_configs:
+            - files:
+                - /etc/otel/targets.json
+              refresh_interval: 5s
+          static_configs:
+            - targets: ['localhost:9109']
+          relabel_configs:
+              - target_label: instance
+                replacement: '{HOSTNAME}'
+            
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+exporters:
+  prometheusremotewrite:
+    endpoint: {AMPREMOTEWRITEURL}
+    auth:
+      authenticator: sigv4auth
+
+extensions:
+  sigv4auth:
+    region: {REGION}
+    service: aps
+
+service:
+  extensions: [sigv4auth]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [prometheusremotewrite]   

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/otel_config/config-head-template.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/otel_config/config-head-template.yaml
@@ -1,0 +1,44 @@
+## Controller Node OTEL Config
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+        evaluation_interval: 15s
+      scrape_configs:
+        - job_name: 'node_exporter'
+          static_configs:
+            - targets: ['localhost:9100']
+          relabel_configs:
+            - target_label: instance
+              replacement: '{HOSTNAME}'
+        - job_name: 'slurm_exporter'
+          static_configs:
+            - targets: ['localhost:9341']
+          relabel_configs:
+            - target_label: instance
+              replacement: '{HOSTNAME}'  
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+exporters:
+  prometheusremotewrite:
+    endpoint: {AMPREMOTEWRITEURL}
+    auth:
+      authenticator: sigv4auth
+
+extensions:
+  sigv4auth:
+    region: {REGION}
+    service: aps
+
+service:
+  extensions: [sigv4auth]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [prometheusremotewrite]

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/otel_config/config-login-template.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/otel_config/config-login-template.yaml
@@ -1,0 +1,38 @@
+## Login Node OTEL Config
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+        evaluation_interval: 15s
+      scrape_configs:
+        - job_name: 'node_exporter'
+          static_configs:
+            - targets: ['localhost:9100']
+          relabel_configs:
+            - target_label: instance
+              replacement: '{HOSTNAME}'
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+exporters:
+  prometheusremotewrite:
+    endpoint: {AMPREMOTEWRITEURL}
+    auth:
+      authenticator: sigv4auth
+
+extensions:
+  sigv4auth:
+    region: {REGION}
+    service: aps
+
+service:
+  extensions: [sigv4auth]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [prometheusremotewrite]

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/setup_observability.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/setup_observability.sh
@@ -66,81 +66,113 @@ wait_for_scontrol() {
 }
 
 # ---------------------------------------------------------------------------
-# Detect node type from running Slurm daemons
+# Detect node type
 #
-# During cluster creation, OnInitComplete may run on compute/login nodes
-# before the controller is fully ready. sinfo depends on the controller,
-# so we retry with a timeout before deciding.
+# Primary: read from /opt/ml/config/nodeinfo.json (written by detect-node
+# utility in run_extensions.sh before this script runs).
 #
-# Fallback: if sinfo never responds, we check resource_config.json which
-# HyperPod generates with instance group names.
+# Fallback: read resource_config.json + provisioning_parameters.json
+# directly (same algorithm as detect-node, for standalone use without
+# run_extensions.sh).
+#
+# This approach is deterministic, instant, and has zero dependency on
+# Slurm services being running -- which matters during scale-up when
+# slurmd may not be started yet.
 # ---------------------------------------------------------------------------
 detect_node_type() {
-    if systemctl is-active --quiet slurmctld 2>/dev/null; then
-        echo "controller"
-        return 0
+    local nodeinfo="/opt/ml/config/nodeinfo.json"
+
+    # Primary: nodeinfo.json (written by detect-node utility)
+    if [ -f "$nodeinfo" ]; then
+        local node_type
+        node_type=$(python3 -c "import json; print(json.load(open('$nodeinfo'))['node_type'])" 2>/dev/null)
+        if [ -n "$node_type" ]; then
+            logger_err "Node type from nodeinfo.json: $node_type"
+            echo "$node_type"
+            return 0
+        fi
     fi
 
-    if ! systemctl is-active --quiet slurmd 2>/dev/null; then
-        logger_err "ERROR: Neither slurmctld nor slurmd is running. Cannot detect node type."
-        logger_err "Ensure Slurm is started before running this script."
+    # Fallback: detect from platform config files directly
+    logger_err "nodeinfo.json not found, detecting from platform config files..."
+    local pp_file="/opt/ml/config/provisioning_parameters.json"
+    local rc_file="/opt/ml/config/resource_config.json"
+
+    if [ ! -f "$rc_file" ]; then
+        logger_err "ERROR: $rc_file not found. Cannot detect node type."
         exit 1
     fi
 
-    # slurmd is running -- determine if this is compute or login.
-    # Compute nodes appear in sinfo; login nodes do not.
-    local hostname
-    hostname=$(hostname -s)
-    local timeout=180
-    local interval=5
-    local elapsed=0
+    local node_type
+    node_type=$(python3 -c "
+import json, socket, sys, time
 
-    logger_err "Detecting compute vs login for $hostname (waiting for sinfo)..."
-    while [ $elapsed -lt $timeout ]; do
-        local sinfo_output
-        sinfo_output=$(sinfo -N --noheader 2>/dev/null || true)
-        if [ -n "$sinfo_output" ]; then
-            if echo "$sinfo_output" | grep -qw "$hostname"; then
-                echo "compute"
-                return 0
-            else
-                echo "login"
-                return 0
-            fi
-        fi
-        logger_err "sinfo not yet available. Retrying in ${interval}s... (${elapsed}s/${timeout}s)"
-        sleep $interval
-        elapsed=$((elapsed + interval))
-    done
+rc_file = '$rc_file'
+pp_file = '$pp_file'
 
-    # Timed out -- fall back to resource_config.json
-    logger_err "WARNING: sinfo did not return data within ${timeout}s."
-    logger_err "Falling back to resource_config.json for node type detection."
-    local rc_path="/opt/ml/config/resource_config.json"
-    if [ -f "$rc_path" ]; then
-        local my_ip
-        my_ip=$(hostname -I | awk '{print $1}')
-        local group_name
-        group_name=$(python3 -c "
-import json, sys
-with open('$rc_path') as f:
+# Get this node's IP
+def get_ip():
+    for attempt in range(5):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(('10.254.254.254', 1))
+            ip = s.getsockname()[0]
+            s.close()
+            return ip
+        except:
+            time.sleep(2)
+    return '127.0.0.1'
+
+my_ip = get_ip()
+
+with open(rc_file) as f:
     rc = json.load(f)
+
+# Find this node's instance group
+group_name = ''
 for g in rc.get('InstanceGroups', []):
     for inst in g.get('Instances', []):
-        if inst.get('CustomerIpAddress') == '$my_ip':
-            print(g['Name'])
-            sys.exit(0)
-print('')
+        if inst.get('CustomerIpAddress') == my_ip:
+            group_name = g.get('Name', '')
+            break
+    if group_name:
+        break
+
+if not group_name:
+    print('compute', end='')
+    sys.exit(0)
+
+# Compare to provisioning_parameters if available
+try:
+    with open(pp_file) as f:
+        pp = json.load(f)
+    controller_group = pp.get('controller_group', '')
+    login_group = pp.get('login_group', '') or ''
+    if group_name == controller_group:
+        print('controller', end='')
+    elif group_name == login_group:
+        print('login', end='')
+    else:
+        print('compute', end='')
+except FileNotFoundError:
+    # No provisioning_parameters.json (API-driven config)
+    # Fall back to group name heuristics
+    lower = group_name.lower()
+    if 'controller' in lower or 'head' in lower:
+        print('controller', end='')
+    elif 'login' in lower:
+        print('login', end='')
+    else:
+        print('compute', end='')
 " 2>/dev/null)
-        if echo "$group_name" | grep -qi "login"; then
-            echo "login"
-        else
-            echo "compute"
-        fi
-    else
-        logger_err "WARNING: resource_config.json not found. Defaulting to compute."
-        echo "compute"
+
+    if [ -z "$node_type" ]; then
+        logger_err "WARNING: Node type detection failed. Defaulting to compute."
+        node_type="compute"
     fi
+
+    logger_err "Detected node type: $node_type (from platform config)"
+    echo "$node_type"
 }
 
 # ---------------------------------------------------------------------------

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/setup_observability.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/setup_observability.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Standalone observability extension script for SageMaker HyperPod Slurm clusters.
+#
+# Designed for use as an OnInitComplete script with AMI-based configuration.
+# Can also be used with OnCreate-based clusters by calling it after Slurm is started.
+#
+# This script auto-detects the node type (controller, compute, login) by checking
+# which Slurm daemon is running, reads configuration from config.json, and installs
+# the appropriate metric exporters and OpenTelemetry collector.
+#
+# Prerequisites:
+#   - Docker must be installed and running (included in AMI-based configuration)
+#   - Slurm daemons must be started (included in AMI-based configuration)
+#   - An Amazon Managed Service for Prometheus (AMP) workspace must exist
+#   - The cluster execution role must have permissions to remote-write to AMP
+#
+# Usage:
+#   As OnInitComplete:
+#     Upload this directory to S3 and specify setup_observability.sh as OnInitComplete.
+#
+#   Manual execution on a running cluster:
+#     sudo bash setup_observability.sh
+
+set -ex
+
+LOG_FILE="/var/log/provision/setup_observability.log"
+mkdir -p /var/log/provision
+touch "$LOG_FILE"
+
+logger() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+# Like logger but writes to stderr + log file. Use inside functions that
+# return values via stdout (e.g. detect_node_type).
+logger_err() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE" >&2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Wait for scontrol to return node data (controller only)
+# ---------------------------------------------------------------------------
+wait_for_scontrol() {
+    local timeout=120
+    local interval=5
+    local elapsed=0
+
+    logger "Waiting for scontrol to report registered nodes..."
+    while [ $elapsed -lt $timeout ]; do
+        if scontrol show nodes 2>/dev/null | grep -q "NodeName"; then
+            logger "Slurm nodes are registered. Proceeding."
+            return 0
+        fi
+        logger "No nodes registered yet. Retrying in ${interval}s... (${elapsed}s/${timeout}s)"
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+    logger "WARNING: scontrol did not report nodes within ${timeout}s. Proceeding anyway."
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Detect node type from running Slurm daemons
+#
+# During cluster creation, OnInitComplete may run on compute/login nodes
+# before the controller is fully ready. sinfo depends on the controller,
+# so we retry with a timeout before deciding.
+#
+# Fallback: if sinfo never responds, we check resource_config.json which
+# HyperPod generates with instance group names.
+# ---------------------------------------------------------------------------
+detect_node_type() {
+    if systemctl is-active --quiet slurmctld 2>/dev/null; then
+        echo "controller"
+        return 0
+    fi
+
+    if ! systemctl is-active --quiet slurmd 2>/dev/null; then
+        logger_err "ERROR: Neither slurmctld nor slurmd is running. Cannot detect node type."
+        logger_err "Ensure Slurm is started before running this script."
+        exit 1
+    fi
+
+    # slurmd is running -- determine if this is compute or login.
+    # Compute nodes appear in sinfo; login nodes do not.
+    local hostname
+    hostname=$(hostname -s)
+    local timeout=180
+    local interval=5
+    local elapsed=0
+
+    logger_err "Detecting compute vs login for $hostname (waiting for sinfo)..."
+    while [ $elapsed -lt $timeout ]; do
+        local sinfo_output
+        sinfo_output=$(sinfo -N --noheader 2>/dev/null || true)
+        if [ -n "$sinfo_output" ]; then
+            if echo "$sinfo_output" | grep -qw "$hostname"; then
+                echo "compute"
+                return 0
+            else
+                echo "login"
+                return 0
+            fi
+        fi
+        logger_err "sinfo not yet available. Retrying in ${interval}s... (${elapsed}s/${timeout}s)"
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+    # Timed out -- fall back to resource_config.json
+    logger_err "WARNING: sinfo did not return data within ${timeout}s."
+    logger_err "Falling back to resource_config.json for node type detection."
+    local rc_path="/opt/ml/config/resource_config.json"
+    if [ -f "$rc_path" ]; then
+        local my_ip
+        my_ip=$(hostname -I | awk '{print $1}')
+        local group_name
+        group_name=$(python3 -c "
+import json, sys
+with open('$rc_path') as f:
+    rc = json.load(f)
+for g in rc.get('InstanceGroups', []):
+    for inst in g.get('Instances', []):
+        if inst.get('CustomerIpAddress') == '$my_ip':
+            print(g['Name'])
+            sys.exit(0)
+print('')
+" 2>/dev/null)
+        if echo "$group_name" | grep -qi "login"; then
+            echo "login"
+        else
+            echo "compute"
+        fi
+    else
+        logger_err "WARNING: resource_config.json not found. Defaulting to compute."
+        echo "compute"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Read config.json
+# ---------------------------------------------------------------------------
+CONFIG_FILE="$SCRIPT_DIR/config.json"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    logger "ERROR: config.json not found at $CONFIG_FILE"
+    exit 1
+fi
+
+PROMETHEUS_REMOTE_WRITE_URL=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE'))['prometheus_remote_write_url'])")
+ADVANCED=$(python3 -c "import json; print('1' if json.load(open('$CONFIG_FILE')).get('advanced_metrics', False) else '0')")
+NCCL_METRICS=$(python3 -c "import json; print('1' if json.load(open('$CONFIG_FILE')).get('nccl_metrics_enabled', False) else '0')")
+NCCL_DUMP_INTERVAL=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('nccl_metrics_dump_interval_seconds', 30))")
+NCCL_PLUGIN_PATH=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('nccl_profiler_plugin_path', '/opt/nccl-inspector/libnccl-profiler-inspector.so'))")
+
+# Validate the AMP URL has been configured
+if echo "$PROMETHEUS_REMOTE_WRITE_URL" | grep -q '<workspace-id>'; then
+    logger "ERROR: prometheus_remote_write_url in config.json still contains placeholder values."
+    logger "Update config.json with your Amazon Managed Prometheus workspace URL before running."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Detect node type
+# ---------------------------------------------------------------------------
+NODE_TYPE=$(detect_node_type)
+logger "Detected node type: $NODE_TYPE"
+
+# ---------------------------------------------------------------------------
+# Ensure Docker is available
+# ---------------------------------------------------------------------------
+if ! command -v docker &>/dev/null; then
+    logger "ERROR: Docker is not installed. AMI-based configuration should have installed it."
+    exit 1
+fi
+
+if ! systemctl is-active --quiet docker 2>/dev/null; then
+    logger "Docker service is not running. Attempting to start..."
+    systemctl start docker
+fi
+
+# ---------------------------------------------------------------------------
+# Wait for scontrol on controller before installing exporters
+# ---------------------------------------------------------------------------
+if [[ "$NODE_TYPE" == "controller" ]]; then
+    wait_for_scontrol
+fi
+
+# ---------------------------------------------------------------------------
+# Run the observability installer
+# ---------------------------------------------------------------------------
+logger "Installing observability stack for node type: $NODE_TYPE"
+
+CMD=(
+    python3 -u "$SCRIPT_DIR/install_observability.py"
+    --node-type "$NODE_TYPE"
+    --prometheus-remote-write-url "$PROMETHEUS_REMOTE_WRITE_URL"
+)
+
+if [[ "$ADVANCED" == "1" ]]; then
+    CMD+=(--advanced)
+fi
+
+if [[ "$NCCL_METRICS" == "1" ]]; then
+    CMD+=(--nccl-metrics)
+fi
+
+set +e
+"${CMD[@]}" 2>&1 | tee -a "$LOG_FILE"
+INSTALL_EXIT_CODE=${PIPESTATUS[0]}
+set -e
+
+if [[ $INSTALL_EXIT_CODE -ne 0 ]]; then
+    logger "ERROR: Observability installation failed with exit code $INSTALL_EXIT_CODE"
+    exit $INSTALL_EXIT_CODE
+fi
+
+# ---------------------------------------------------------------------------
+# Configure NCCL Inspector task prolog (compute nodes only, if enabled)
+# ---------------------------------------------------------------------------
+if [[ "$NCCL_METRICS" == "1" ]] && [[ "$NODE_TYPE" == "compute" || "$NODE_TYPE" == "controller" ]]; then
+    logger "Configuring NCCL Inspector task prolog..."
+    DUMP_INTERVAL_MICROSECONDS=$((NCCL_DUMP_INTERVAL * 1000000))
+
+    cat > /opt/slurm/etc/task_prolog.sh << EOF
+#!/bin/bash
+if [ ! -f ${NCCL_PLUGIN_PATH} ]; then
+  echo "[WARN] NCCL Inspector plugin not found at ${NCCL_PLUGIN_PATH}, skipping NCCL metrics" >&2
+  exit 0
+fi
+echo "export NCCL_PROFILER_PLUGIN=${NCCL_PLUGIN_PATH}"
+echo "export NCCL_INSPECTOR_ENABLE=1"
+echo "export NCCL_INSPECTOR_PROM_DUMP=1"
+echo "export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=${DUMP_INTERVAL_MICROSECONDS}"
+echo "export NCCL_INSPECTOR_DUMP_DIR=/var/lib/node_exporter/nccl_inspector/"
+EOF
+    chmod +x /opt/slurm/etc/task_prolog.sh
+
+    if [[ "$NODE_TYPE" == "controller" ]]; then
+        if ! grep -q "^TaskProlog=" /opt/slurm/etc/slurm.conf 2>/dev/null; then
+            # Ensure a newline before appending to avoid merging with the last line
+            sed -i -e '$a\' /opt/slurm/etc/slurm.conf
+            echo "TaskProlog=/opt/slurm/etc/task_prolog.sh" >> /opt/slurm/etc/slurm.conf
+            systemctl restart slurmctld
+            # Push updated config to compute nodes so slurmd picks up TaskProlog
+            sleep 2
+            scontrol reconfigure || logger "WARNING: scontrol reconfigure failed -- compute nodes may need manual reconfigure"
+            logger "Added TaskProlog to slurm.conf, restarted slurmctld, and reconfigured cluster"
+        fi
+    fi
+fi
+
+logger "Observability setup complete for $NODE_TYPE node."

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/observability/stop_observability.py
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/observability/stop_observability.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import os
+import shutil
+import argparse
+import subprocess
+import socket
+
+
+def stop_observability(node_type):
+
+    if node_type=="controller":
+
+        subprocess.run( ["systemctl", "stop", "slurm_exporter"] )
+        subprocess.run( ["docker", "stop", "node-exporter"] )
+        subprocess.run( ["docker", "stop", "otel-collector"] )
+
+    elif node_type=="compute":
+
+        subprocess.run( ["docker", "stop", "node-exporter"] )
+        subprocess.run( ["docker", "stop", "dcgm-exporter"] )
+        subprocess.run( ["docker", "stop", "efa-exporter"] )
+        subprocess.run( ["docker", "stop", "otel-collector"] )
+
+    elif node_type=="login":
+
+        subprocess.run( ["docker", "stop", "node-exporter"] )
+        subprocess.run( ["docker", "stop", "otel-collector"] )
+
+
+if __name__ == "__main__":
+
+    argparser = argparse.ArgumentParser(description="Script to stop HyperPod observability")
+    argparser.add_argument('--node-type', action="store", required=True, help='Node type (controller, login, compute)')
+    args = argparser.parse_args()
+
+    assert args.node_type in ["controller", "login", "compute"]
+
+    print("Stopping observability")
+
+    stop_observability(args.node_type)
+
+    print("---")
+    print("Stopping observability")

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/run_extensions.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/run_extensions.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Combined OnInitComplete entrypoint for SageMaker HyperPod Slurm clusters.
+#
+# This script orchestrates multiple standalone extensions. Enable or disable
+# each feature by setting the flags below. Each feature's directory must be
+# uploaded to S3 alongside this script.
+#
+# Expected S3 layout:
+#   s3://<bucket>/<prefix>/
+#   ├── run_extensions.sh          (this file -- OnInitComplete target)
+#   ├── add-users/                 (user management scripts + config.yaml)
+#   └── observability/             (observability scripts + config.json)
+#
+# Prerequisites:
+#   - AMI-based configuration (Slurm, Docker pre-installed)
+#   - Each enabled feature's config file must be populated (not placeholders)
+#
+# Usage:
+#   Specify this script as the OnInitComplete target in your cluster config.
+
+set -ex
+
+# ===========================================================================
+# Feature toggles -- set to "true" or "false"
+# ===========================================================================
+ENABLE_ADD_USERS="true"
+ENABLE_OBSERVABILITY="true"
+
+# ===========================================================================
+# Logging -- matches AMI on_create.sh pattern
+# ===========================================================================
+LOG_FILE="/var/log/provision/provisioning.log"
+mkdir -p /var/log/provision
+touch "$LOG_FILE"
+
+logger() {
+    echo "$@" | tee -a "$LOG_FILE"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ===========================================================================
+# Run a feature extension
+# ===========================================================================
+run_feature() {
+    local name="$1"
+    local script="$2"
+
+    if [ ! -f "$script" ]; then
+        logger "[warning] $name script not found at $script, skipping"
+        return 0
+    fi
+
+    logger "[start] $name"
+    if ! bash "$script" >> "$LOG_FILE" 2>&1; then
+        logger "[error] $name failed, waiting 60 seconds before exit, to make sure logs are uploaded"
+        sync
+        sleep 60
+        logger "[stop] run_extensions.sh with error"
+        exit 1
+    fi
+    logger "[stop] $name"
+}
+
+# ===========================================================================
+# Main
+# ===========================================================================
+logger "[start] run_extensions.sh"
+
+if [ "$ENABLE_ADD_USERS" = "true" ]; then
+    run_feature "add-users" "$SCRIPT_DIR/add-users/add_users.sh"
+fi
+
+if [ "$ENABLE_OBSERVABILITY" = "true" ]; then
+    run_feature "observability" "$SCRIPT_DIR/observability/setup_observability.sh"
+fi
+
+logger "[stop] run_extensions.sh"

--- a/1.architectures/5.sagemaker-hyperpod/Extensions/run_extensions.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/run_extensions.sh
@@ -10,9 +10,10 @@
 #
 # Expected S3 layout:
 #   s3://<bucket>/<prefix>/
-#   ├── run_extensions.sh          (this file -- OnInitComplete target)
-#   ├── add-users/                 (user management scripts + config.yaml)
-#   └── observability/             (observability scripts + config.json)
+#   |-- run_extensions.sh          (this file -- OnInitComplete target)
+#   |-- detect-node/               (node type detection utility)
+#   |-- add-users/                 (user management scripts + config)
+#   |-- observability/             (observability scripts + config.json)
 #
 # Prerequisites:
 #   - AMI-based configuration (Slurm, Docker pre-installed)
@@ -69,6 +70,9 @@ run_feature() {
 # Main
 # ===========================================================================
 logger "[start] run_extensions.sh"
+
+# Always run node detection first -- other extensions depend on nodeinfo.json
+run_feature "detect-node" "$SCRIPT_DIR/detect-node/detect_node.sh"
 
 if [ "$ENABLE_ADD_USERS" = "true" ]; then
     run_feature "add-users" "$SCRIPT_DIR/add-users/add_users.sh"


### PR DESCRIPTION
## Summary

Adds a modular Extensions framework under `1.architectures/5.sagemaker-hyperpod/Extensions/` for SageMaker HyperPod Slurm clusters using AMI-based configuration. Extensions run via `OnInitComplete` and can be independently enabled or disabled.

## What's Included

### run_extensions.sh (entrypoint)
Combined OnInitComplete entrypoint that orchestrates extension scripts. Each extension can be toggled on/off via feature flags. Handles logging, error handling, and execution ordering.

### detect-node/
Utility that detects node type (controller, compute, or login) using HyperPod platform config files (`provisioning_parameters.json` and `resource_config.json`). Writes results to `/opt/ml/config/nodeinfo.json` for use by downstream extensions. Runs first -- other extensions depend on its output.

### add-users/
User provisioning for HyperPod Slurm clusters:
- Creates POSIX users with consistent UIDs across all nodes
- Sets up home directories on shared filesystems (FSx for Lustre or OpenZFS)
- Generates SSH keypairs for passwordless inter-node access
- Registers users in Slurm accounting (controller only)
- Supports legacy CSV format (`shared_users.txt`) and YAML format (`shared_users.yaml`) with groups and per-group Slurm accounts

### observability/
Observability stack for HyperPod Slurm clusters:
- Node Exporter (system metrics)
- DCGM Exporter (GPU metrics)
- EFA Exporter (network fabric metrics)
- Slurm Exporter (job scheduler metrics)
- OpenTelemetry Collector with Amazon Managed Prometheus (AMP) remote write
- Node-type-aware configuration (different OTel configs for controller, compute, login nodes)

## Execution Order

```
run_extensions.sh
  |-- detect-node/detect_node.sh    (always runs first)
  |-- add-users/add_users.sh        (if ENABLE_ADD_USERS=true)
  |-- observability/setup_observability.sh  (if ENABLE_OBSERVABILITY=true)
```

## Deployment

Upload the Extensions directory to S3 and specify `run_extensions.sh` as the OnInitComplete target:
```json
{
    LifeCycleConfig: {
        OnInitComplete: run_extensions.sh,
        SourceS3Uri: s3://<bucket>/Extensions/
    }
}
```

## Testing

Tested on SageMaker HyperPod Slurm clusters with AMI-based configuration across controller, compute, and login node types.