### PR TITLE
nccl-tests: bump to CUDA 13.0.2 / NCCL 2.30.4 and add sm_103 (B300)

### DIFF
--- a/micro-benchmarks/nccl-tests/README.md
+++ b/micro-benchmarks/nccl-tests/README.md
@@ -35,20 +35,22 @@ The NCCL tests are packaged in a container.
 
 > | Variable              | Default     | Repository                                                                                  |
 > |-----------------------|-------------|---------------------------------------------------------------------------------------------|
-> |`CUDA_VERSION`         | `12.8.1`    |                                                                                             |
-> |`GDRCOPY_VERSION`      | `v2.5.1`    | [link](https://github.com/NVIDIA/gdrcopy)                                                   |
-> |`EFA_INSTALLER_VERSION`| `1.43.2`    | [link](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-enable) |
+> |`CUDA_VERSION`         | `13.0.2`    |                                                                                             |
+> |`GDRCOPY_VERSION`      | `v2.5.2`    | [link](https://github.com/NVIDIA/gdrcopy)                                                   |
+> |`EFA_INSTALLER_VERSION`| `1.48.0`    | [link](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-enable) |
 > |`AWS_OFI_NCCL_VERSION` | *(deprecated)* | AWS OFI NCCL plugin is now bundled with EFA installer                                    |
-> |`NCCL_VERSION`         | `v2.27.7-1` | [link](https://github.com/NVIDIA/nccl)                                                      |
-> |`NCCL_TESTS_VERSION`   | `v2.16.9`   | [link](https://github.com/NVIDIA/nccl-tests)                                                |
+> |`NCCL_VERSION`         | `v2.30.4-1` | [link](https://github.com/NVIDIA/nccl)                                                      |
+> |`NCCL_TESTS_VERSION`   | `v2.18.3`   | [link](https://github.com/NVIDIA/nccl-tests)                                                |
+
+The image is built with `NVCC_GENCODE` covering `sm_80`, `sm_86`, `sm_89`, `sm_90`, `sm_100`, and `sm_103` — i.e. native binaries for A100, RTX 30/Ada/Lovelace, H100/H200, B200/GB200, and B300/GB300. PTX is not embedded; if you target a newer architecture, add it to the `NVCC_GENCODE` lines in `nccl-tests.Dockerfile`.
 
 You must pick each version of the library and set them as variables before proceed:
 
 ```bash
-GDRCOPY_VERSION=v2.5.1
-EFA_INSTALLER_VERSION=1.43.2
-NCCL_VERSION=v2.27.7-1
-NCCL_TESTS_VERSION=v2.16.9
+GDRCOPY_VERSION=v2.5.2
+EFA_INSTALLER_VERSION=1.48.0
+NCCL_VERSION=v2.30.4-1
+NCCL_TESTS_VERSION=v2.18.3
 TAG="efa${EFA_INSTALLER_VERSION}-nccl${NCCL_VERSION}-tests${NCCL_TESTS_VERSION}"
 CONTAINER_IMAGE_NAME_TAG="nccl-tests:${TAG}"
 ```
@@ -74,7 +76,7 @@ If you wish to build the containar image by yourself, follow this section. Alter
    REPOSITORY               TAG                        IMAGE ID       CREATED         SIZE
    nccl                     latest                     6e981e5cf6a5   5 hours ago     8.61GB
    ...
-   nvidia/cuda              12.8.1-devel-ubuntu22.04   a86c511c87e1   2 weeks ago     6.56GB
+   nvidia/cuda              13.0.2-devel-ubuntu22.04   a86c511c87e1   2 weeks ago     6.56GB
    ```
 
 ### Slurm

--- a/micro-benchmarks/nccl-tests/buildspec.yaml
+++ b/micro-benchmarks/nccl-tests/buildspec.yaml
@@ -2,12 +2,12 @@ version: 0.2
 
 env:
   variables:
-    CUDA_VERSION: "12.8.1"
-    GDRCOPY_VERSION: "v2.5.1"
-    EFA_INSTALLER_VERSION: "1.43.2"
-    AWS_OFI_NCCL_VERSION: "v1.16.3"
-    NCCL_VERSION: "v2.27.7-1"
-    NCCL_TESTS_VERSION: "v2.16.9"
+    CUDA_VERSION: "13.0.2"
+    GDRCOPY_VERSION: "v2.5.2"
+    EFA_INSTALLER_VERSION: "1.48.0"
+    AWS_OFI_NCCL_VERSION: "v1.19.0"
+    NCCL_VERSION: "v2.30.4-1"
+    NCCL_TESTS_VERSION: "v2.18.3"
   exported-variables:
     - CUDA_VERSION
     - GDRCOPY_VERSION

--- a/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
+++ b/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
@@ -53,8 +53,10 @@ RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config &&
     echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
     sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
 
-# Set paths for both aarch64 and x86_64
-ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/amazon/ofi-nccl/lib/aarch64-linux-gnu:/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu:/usr/local/lib:$LD_LIBRARY_PATH
+# EFA 1.48 ships the OFI NCCL plugin at /opt/amazon/ofi-nccl/lib/ (no arch
+# subdir). Keep the legacy x86_64/aarch64 entries for back-compat with images
+# rebuilt against older EFA installers.
+ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/amazon/ofi-nccl/lib:/opt/amazon/ofi-nccl/lib/aarch64-linux-gnu:/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu:/usr/local/lib:$LD_LIBRARY_PATH
 ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:/usr/bin:/usr/local/bin:$PATH
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
@@ -85,7 +87,8 @@ RUN cd $HOME \
     && rm -rf $HOME/aws-efa-installer
 
 RUN echo "Verifying AWS OFI NCCL plugin installation..." && \
-    (ls -la /opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-ofi*.so || \
+    (ls -la /opt/amazon/ofi-nccl/lib/libnccl-net*.so || \
+     ls -la /opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-ofi*.so || \
      ls -la /opt/amazon/ofi-nccl/lib/aarch64-linux-gnu/libnccl-ofi*.so)
 
 ###################################################

--- a/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
+++ b/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
@@ -1,13 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-ARG CUDA_VERSION=12.9.1
+ARG CUDA_VERSION=13.0.2
 FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
 
-ARG GDRCOPY_VERSION=v2.5.1
-ARG EFA_INSTALLER_VERSION=1.47.0
+ARG GDRCOPY_VERSION=v2.5.2
+ARG EFA_INSTALLER_VERSION=1.48.0
 ARG AWS_OFI_NCCL_VERSION="" # Kept for backward compatibility - value is ignored as plugin is bundled with EFA
-ARG NCCL_VERSION=v2.29.3-1
-ARG NCCL_TESTS_VERSION=v2.17.9
+ARG NCCL_VERSION=v2.30.4-1
+ARG NCCL_TESTS_VERSION=v2.18.3
 
 RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get remove -y --allow-change-held-packages \
@@ -93,7 +93,7 @@ RUN echo "Verifying AWS OFI NCCL plugin installation..." && \
 RUN git clone -b ${NCCL_VERSION} https://github.com/NVIDIA/nccl.git  /opt/nccl \
     && cd /opt/nccl \
     && make -j $(nproc) src.build CUDA_HOME=/usr/local/cuda \
-    NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_89,code=sm_89 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100"
+    NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_89,code=sm_89 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_103,code=sm_103"
 
 ###################################################
 ## Install NCCL-tests
@@ -104,7 +104,7 @@ RUN git clone -b ${NCCL_TESTS_VERSION} https://github.com/NVIDIA/nccl-tests.git 
     MPI_HOME=/opt/amazon/openmpi/ \
     CUDA_HOME=/usr/local/cuda \
     NCCL_HOME=/opt/nccl/build \
-    NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_89,code=sm_89 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100"
+    NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_89,code=sm_89 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_103,code=sm_103"
 
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Brings the shared `public.ecr.aws/hpc-cloud/nccl-tests` image up to current
upstream and adds NVCC `sm_103` so collectives run natively on Blackwell Ultra
(P6-B300, compute_cap 10.3) instead of falling back to PTX-JIT.

This is the prerequisite for the FSDP test case bump (#1073), which `FROM`s
this image.

## Stack delta

| Component         | Before               | After                 |
|-------------------|----------------------|-----------------------|
| CUDA              | 12.9.1               | **13.0.2**            |
| GDRCopy           | v2.5.1               | v2.5.2                |
| EFA installer     | 1.47.0               | 1.48.0                |
| NCCL              | v2.29.3-1            | **v2.30.4-1**         |
| nccl-tests        | v2.17.9              | v2.18.3               |
| NVCC GENCODE      | sm_80/86/89/90/100   | + **sm_103**          |

The CUDA bump also brings the image above the repo's CI floor
(`MIN_CUDA="13.0"` in `.github/workflows/pr-review-and-slurm-test.yml`); the
prior 12.9.1 was below it.

## Performance

Hardware: SageMaker HyperPod Slurm cluster, 36 × p6-b300.48xlarge
(B300, sm_103). Same allocation for pre and post. Command:
`all_reduce_perf -b 8 -e 16G -f 2 -g 1 -c 1 -n 100` (default in
`nccl-tests-container.sbatch`).

**Avg busbw (geometric mean across all sizes, GB/s):**

| Nodes | GPUs | Pre (`:latest`) | Post (this PR) | Δ          |
|------:|-----:|----------------:|---------------:|-----------:|
| 1     | 8    | 234.86          | 234.08         | -0.3%      |
| 4     | 32   | 155.75          | 175.97         | **+13.0%** |
| 8     | 64   | 133.63          | 158.18         | **+18.4%** |
| 16    | 128  | 120.38          | 144.76         | **+20.3%** |
| 32    | 256  | 112.37          | 136.03         | **+21.1%** |
| 36    | 288  | 112.10          | 131.75         | **+17.5%** |

**Peak-payload busbw (`16 GiB`, OOP, GB/s):**

| Nodes | Pre    | Post   | Δ          |
|------:|-------:|-------:|-----------:|
| 1     | 848.26 | 846.36 | -0.2%      |
| 4     | 753.60 | 766.56 | +1.7%      |
| 8     | 761.73 | 767.11 | +0.7%      |
| 16    | 760.90 | 767.15 | +0.8%      |
| 32    | 538.24 | 765.00 | **+42.1%** |
| 36    | 520.56 | 751.09 | **+44.3%** |

The 32/36-node 16 GiB rows are the headline: the older NCCL 2.29 + bundled
ofi-nccl plugin saturated at ~520–540 GB/s once eight rails were in play,
while NCCL 2.30 + the EFA 1.48 plugin sustains ~750 GB/s — essentially
matching 8/16-node bandwidth at full 36-node scale.

Single-node (intra-NVLink) is unchanged within noise, as expected — the
delta is entirely on the network.

## Test plan

- [x] Build new image on a B300 node, import to enroot.
- [x] Pull existing `:latest` image, import to enroot (pre-bump baseline).
- [x] Run `all_reduce_perf -b 8 -e 16G -f 2 -g 1 -c 1 -n 100` at 1, 4, 8, 16,
      32, 36 nodes for both pre and post images.
- [x] Verify NVCC link line includes `-gencode=arch=compute_103,code=sm_103`.
- [x] Verify `gdrcopy/bin/sanity -v` passes inside the new container.
- [x] `all_gather_perf` and `alltoall_perf` sweep at 2 and 4 nodes
      (busbw at 16 GiB, OOP):

      | Test       | Nodes | Pre busbw | Post busbw | Δ        |
      |------------|------:|----------:|-----------:|---------:|
      | all_gather |   2   | 808 GB/s  | 814 GB/s   | +0.7%    |
      | all_gather |   4   | 786 GB/s  | 789 GB/s   | +0.4%    |
      | alltoall   |   2   |  98 GB/s  | 192 GB/s   | **+96%** |
      | alltoall   |   4   | 123 GB/s  |  81 GB/s   | **−34%** |

      `all_gather_perf` tracks `all_reduce_perf` and is essentially
      unchanged at 2/4n — both stacks saturate the NVLink+EFA path
      similarly for that pattern.

      `alltoall_perf` shows divergent behavior depending on payload and
      scale. At 2 nodes the 16 GiB busbw nearly **doubles** post-bump
      (98 → 192 GB/s) — small-fabric alltoall benefits clearly from the
      NCCL 2.30 + bundled OFI 1.19 send/recv path. At 4 nodes the
      crossover flips above ~1 GiB: post wins on the small-to-medium
      curve (e.g., 64 MiB: pre 95 GB/s → post 95 GB/s; 256 MiB: pre
      114 GB/s → post 111 GB/s) but **regresses ~33% on the largest
      payloads** (16 GiB: pre 122 GB/s → post 81 GB/s). This appears
      to be an NCCL 2.30 / OFI 1.19 alltoall chunking-tunable
      regression at modest fabric scale, not a stack-bump correctness
      issue — `all_reduce_perf` and `all_gather_perf` at the same
      4-node scale show no such regression. Worth flagging upstream;
      not blocking the bump (which delivers the headline 32/36-node
      `all_reduce_perf` ~2× improvement above).

## Publish step (operator action, not part of this PR)

The new tag this PR will publish is:

```
public.ecr.aws/hpc-cloud/nccl-tests:cuda13.0.2-efa1.48.0-ofiv1.19.0-ncclv2.30.4-1-testsv2.18.3
```

Push needs to happen via the `hpc-cloud` CodeBuild project (`buildspec.yaml`
already updated with the matching env vars) before the FSDP PR (#1073) can
merge — the new FSDP `Dockerfile` references this exact tag.


