### PR TITLE
fix(hyperpod-eks-tf): use standalone Pod Identity association for HPTO addon (#1075)

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/hyperpod_training_operator/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/hyperpod_training_operator/main.tf
@@ -27,14 +27,42 @@ resource "aws_iam_role_policy_attachment" "hpto-policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerHyperPodTrainingOperatorAccess"
 }
 
+# Pod Identity association for HPTO
+#
+# This is declared as a standalone aws_eks_pod_identity_association resource
+# rather than an inline `pod_identity_association` block inside the
+# aws_eks_addon resource below. The inline form requires the addon's metadata
+# to advertise Pod Identity support via `requiresIamPermissions: true` in
+# DescribeAddonVersions. The SageMaker HyperPod Training Operator addon
+# v1.2.1-eksbuild.1 (the current default across K8s 1.28-1.35) regressed this
+# flag from `true` (v1.2.0) to `false`, causing the EKS CreateAddon API to
+# reject inline associations with:
+#
+#   InvalidParameterException: Pod Identity feature is not supported for
+#   addon version: v1.2.1-eksbuild.1
+#
+# The standalone resource pattern matches the AWS CLI install flow documented
+# at https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-eks-operator-install.html
+# and is immune to future addon-metadata changes.
+#
+# See: https://github.com/awslabs/awsome-distributed-training/issues/1075
+resource "aws_eks_pod_identity_association" "hpto_association" {
+  cluster_name    = var.eks_cluster_name
+  namespace       = "aws-hyperpod"
+  service_account = "hp-training-operator-controller-manager"
+  role_arn        = aws_iam_role.hpto_role.arn
+}
+
 # EKS Addon for HPTO
 resource "aws_eks_addon" "hpto_addon" {
-  cluster_name             = var.eks_cluster_name
-  addon_name               = "amazon-sagemaker-hyperpod-training-operator"
+  cluster_name                = var.eks_cluster_name
+  addon_name                  = "amazon-sagemaker-hyperpod-training-operator"
   resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
 
-  pod_identity_association {
-    role_arn        = aws_iam_role.hpto_role.arn
-    service_account = "hp-training-operator-controller-manager"
-  }
+  # Ensure the Pod Identity association exists before the addon's controller
+  # pod starts so it has AWS credentials available on first boot.
+  depends_on = [
+    aws_eks_pod_identity_association.hpto_association
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes #1075.

The `hyperpod_training_operator` Terraform module declared the Pod Identity association **inline inside the `aws_eks_addon` resource**. The inline form relies on the addon's published metadata advertising `requiresIamPermissions: true` in `DescribeAddonVersions`, which EKS validates at `CreateAddon` time.

The SageMaker HyperPod Training Operator addon version **`v1.2.1-eksbuild.1`** (now the default across K8s 1.28-1.35) regressed this flag to `false`. `terraform apply` fails with:

```
InvalidParameterException: Pod Identity feature is not supported for
addon version: v1.2.1-eksbuild.1
```

## Root Cause

Comparing `DescribeAddonVersions` metadata across published HPTO addon versions:

| Version | `requiresIamPermissions` | Default? |
|---|---|---|
| v1.0.0, v1.0.1 | false | no |
| v1.1.0, v1.1.1, v1.1.2 | **true** | no |
| **v1.2.0-eksbuild.1** | **true** | no (prior default) |
| **v1.2.1-eksbuild.1** | **false** | **yes (current default)** |

PR #926 was authored and verified against `v1.2.0`, where the inline block worked. The service-side publication of `v1.2.1` silently broke all IaC installs using the inline pattern.

## Fix

Refactor to a **standalone `aws_eks_pod_identity_association` resource** created before the addon via `depends_on`. This:

- Matches the AWS CLI install flow documented at https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-eks-operator-install.html (two separate API calls: `create-pod-identity-association` then `create-addon`).
- Is immune to future addon-metadata flag changes.
- Leaves the IAM role trust policy (`pods.eks.amazonaws.com`), managed policy (`AmazonSageMakerHyperPodTrainingOperatorAccess`), namespace (`aws-hyperpod`), and service account (`hp-training-operator-controller-manager`) unchanged.
- Also adds `resolve_conflicts_on_update = \"PRESERVE\"` for idempotency on re-runs.

A detailed code comment is included in the module referencing this issue so future maintainers don't refactor back to the inline pattern.

## Verification

Deployed a fresh HyperPod EKS cluster in `us-west-2` with 2x `ml.c5.xlarge` instances using this patched module:

**Terraform apply (successful):**
```
module.hyperpod_training_operator[0].aws_iam_role.hpto_role: Creation complete after 0s [id=hpto-cluster-hpto-role]
module.hyperpod_training_operator[0].aws_iam_role_policy_attachment.hpto-policy: Creation complete after 0s
module.hyperpod_training_operator[0].aws_eks_pod_identity_association.hpto_association: Creation complete after 1s [id=a-reyuuffacghxwlpuf]
module.hyperpod_training_operator[0].aws_eks_addon.hpto_addon: Creation complete after 56s [id=hpto-cluster-eks:amazon-sagemaker-hyperpod-training-operator]

Apply complete! Resources: 13 added, 0 changed, 1 destroyed.
```

**Addon state:**
```json
{
    \"Name\": \"amazon-sagemaker-hyperpod-training-operator\",
    \"Version\": \"v1.2.1-eksbuild.1\",
    \"Status\": \"ACTIVE\",
    \"Health\": { \"issues\": [] }
}
```

**Pod Identity association:**
```json
{
    \"associations\": [
        {
            \"clusterName\": \"hpto-cluster-eks\",
            \"namespace\": \"aws-hyperpod\",
            \"serviceAccount\": \"hp-training-operator-controller-manager\",
            \"associationArn\": \"arn:aws:eks:us-west-2:<redacted>:podidentityassociation/hpto-cluster-eks/a-reyuuffacghxwlpuf\",
            \"associationId\": \"a-reyuuffacghxwlpuf\"
        }
    ]
}
```

**HPTO controller pod:**
```
NAMESPACE      NAME                                                              READY   STATUS    RESTARTS   AGE
aws-hyperpod   hp-training-operator-hp-training-controller-manager-7dcc76qqlcz   1/1     Running   0          2m58s
```

**HPTO controller startup logs (leader election clean, no IAM errors):**
```
successfully acquired lease aws-hyperpod/4031fbcd.golang.a2z.com
Starting Controller controller=elasticworkload kind=ElasticWorkload
Starting workers controller=elasticworkload worker count=1
Starting Controller controller=HyperPodPyTorchJobWorkload kind=HyperPodPyTorchJob
Starting workers controller=HyperPodPyTorchJobWorkload worker count=1
Starting Controller controller=hyperpodpytorchjob kind=HyperPodPyTorchJob
Starting workers controller=hyperpodpytorchjob worker count=1
```

## Notes for Reviewers

- Other modules in this repo that use inline `pod_identity_association` (`observability`, `fsx_lustre`) are **unaffected** — their underlying addons (`amazon-cloudwatch-observability`, `aws-fsx-csi-driver`) consistently advertise `requiresIamPermissions: true`. Leaving those modules alone intentionally.
- The `hyperpod_inference_operator` module uses a different pattern (`configuration_values` with `executionRoleArn` passed into the addon config) and is also unaffected.
- An internal ticket will be filed with the HPTO service team to either restore `requiresIamPermissions: true` on v1.2.1+ or update their published docs/blogs to reflect the breaking change. This PR's standalone pattern works regardless of how they resolve that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.