### PR TITLE
chore: Making observability setup false by default

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/Extensions/run_extensions.sh
+++ b/1.architectures/5.sagemaker-hyperpod/Extensions/run_extensions.sh
@@ -28,7 +28,7 @@ set -ex
 # Feature toggles -- set to "true" or "false"
 # ===========================================================================
 ENABLE_ADD_USERS="true"
-ENABLE_OBSERVABILITY="true"
+ENABLE_OBSERVABILITY="false"
 
 # ===========================================================================
 # Logging -- matches AMI on_create.sh pattern


### PR DESCRIPTION
## Purpose

* Observability is advanced feature where customer needs to do some prerequisites.
* This will be consistent with old LCS from Base Config LifeCycle scripts

## Changes

Making observability setup false by default

-

## Test Plan

Create cluster with same LCS by putting this change in S3 bucket and using it.

## Test Results

<img width="1285" height="747" alt="Screenshot 2026-05-04 at 5 19 59 PM" src="https://github.com/user-attachments/assets/a1a4b86b-4cb4-4f3e-9acf-392a4ac9ecb3" />

<img width="1245" height="961" alt="Screenshot 2026-05-04 at 5 23 54 PM" src="https://github.com/user-attachments/assets/68fe404d-96f6-44fe-b91c-f67a16b845bf" />

