### PR TITLE
blog: add PR gate workflow and content-branch docs blurbs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,8 @@
 # including all nested subdirectories and files.
 /1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config     @awslabs/hyperpod-lcs-dev
 /1.architectures/7.sagemaker-hyperpod-eks/LifecycleScripts/base-config @awslabs/hyperpod-lcs-dev
+
+# The blog PR gate runs with secrets via pull_request_target. Only blog
+# maintainers may modify it — this prevents a malicious edit from turning
+# the gate into a token-exfiltration vector.
+/.github/workflows/blog-pr-gate.yml                                    @awslabs/ad-blog-maintainers

--- a/.github/workflows/blog-pr-gate.yml
+++ b/.github/workflows/blog-pr-gate.yml
@@ -1,0 +1,51 @@
+# Auto-closes PRs from non-maintainers targeting the `content` (blog) branch.
+#
+# SECURITY — DO NOT MODIFY WITHOUT REVIEW:
+#   - Trigger MUST stay `pull_request_target`, NOT `pull_request`. The latter
+#     has no write permissions on fork PRs.
+#   - This workflow MUST NOT run `actions/checkout` of the PR's code. With
+#     `pull_request_target` we run in base-repo context with secrets;
+#     checking out attacker-controlled code from a fork would let it
+#     exfiltrate `BLOG_GATE_TOKEN`.
+#   - `permissions:` stays minimal: `pull-requests: write` only.
+#   - The PAT secret is read via `github-token`, not interpolated into the
+#     script body.
+#   - Per GitHub's docs, `pull_request_target` only triggers if the workflow
+#     file exists on the default branch — that's why this lives on `main`,
+#     not on `content`.
+
+name: Blog PR Gate
+
+on:
+  pull_request_target:
+    branches: [content]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BLOG_GATE_TOKEN }}
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const { data: team } = await github.rest.teams.listMembersInOrg({
+              org: 'awslabs',
+              team_slug: 'ad-blog-maintainers',
+            });
+            const allowed = team.map(u => u.login);
+            if (!allowed.includes(author)) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: "Thanks for the interest. The `content` branch is editorially curated by AWS authors and does not accept external PRs. Please open an issue with feedback or topic suggestions instead.",
+              });
+              await github.rest.pulls.update({
+                ...context.repo,
+                pull_number: context.issue.number,
+                state: 'closed',
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ To send us a pull request, please:
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
+### Blog content
+
+Blog posts live on the `content` branch and are AWS-authored. PRs from non-maintainers targeting `content` are auto-closed. If you have feedback or topic suggestions, please open an issue.
+
 
 ## Contributions format
 Assets in this repository are organized differently depending on their nature but regardless of that each test example, architecture must have the following:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ You can follow the workshops below to train models on AWS. Each contains example
 | [AI on SageMaker HyperPod](https://awslabs.github.io/ai-on-sagemaker-hyperpod/)   | Workshop for SageMaker HyperPod, shows how to deploy and monitor it |
 | [AWS ParallelCluster](https://catalog.workshops.aws/ml-on-aws-parallelcluster)     | Similar workshop as HyperPod but on ParallelCluster             |
 
+## Blog
+
+Posts about distributed ML training on AWS are published at <https://awslabs.github.io/awsome-distributed/>. The Hugo source lives on the [`content`](https://github.com/awslabs/awsome-distributed/tree/content) branch.
+
+Blog content is editorially curated by AWS authors. Code samples in this repo (`1.architectures/`, `3.test_cases/`, etc.) accept external contributions as usual — see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ## 1. Architectures
 
 Architectures are located in `1.architectures` and consist of utilities and service-related architectures.
@@ -94,8 +100,8 @@ Micro-benchmarks for evaluating network and communication performance are under 
 
 Thanks to all the contributors for building, reviewing and testing.
 
-[![Contributors](https://contrib.rocks/image?repo=awslabs/awsome-distributed-training)](https://github.com/awslabs/awsome-distributed-training/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=awslabs/awsome-distributed)](https://github.com/awslabs/awsome-distributed/graphs/contributors)
 
 ## 7. Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/awsome-distributed-training&type=Date)](https://star-history.com/#awslabs/awsome-distributed-training&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/awsome-distributed&type=Date)](https://star-history.com/#awslabs/awsome-distributed&Date)


### PR DESCRIPTION
## Summary

Companion changes on `main` for the Hugo blog hosted on the orphan `content` branch (live at https://awslabs.github.io/awsome-distributed/, first post merged in #1084).

- `.github/workflows/blog-pr-gate.yml` *(new)* — auto-closes fork PRs targeting `content`. Uses `pull_request_target` so it can reach `BLOG_GATE_TOKEN`. Lives on `main` because per GitHub's docs, `pull_request_target` only triggers if the workflow file exists on the **default branch**. Lands inert until `BLOG_GATE_TOKEN` is provisioned (missing secret → API call returns 403, no comment, no close — fail-open).
- `.github/CODEOWNERS` — adds path rule on the gate workflow itself so only `@awslabs/ad-blog-maintainers` can modify it. Prevents the gate from being silently turned into a token-exfiltration vector via a quiet edit to `main`.
- `README.md` — `## Blog` section between Workshops (§0) and Architectures (§1) pointing readers to the Pages URL and the `content` branch. Also fixes the Contributors and Star History badge URLs (still referenced the pre-rename name).
- `CONTRIBUTING.md` — `### Blog content` subsection under "Contributing via Pull Requests" describing the AWS-author-only policy.

## Security notes

The workflow file has a header comment block enumerating the security invariants:
- Trigger MUST stay `pull_request_target` (not `pull_request`)
- Workflow MUST NOT run `actions/checkout` of the PR's code
- `permissions:` stays minimal (`pull-requests: write` only)
- The PAT secret is read via `github-token`, not interpolated into script body

Future edits to this workflow are gated by the new CODEOWNERS rule.

## Test plan

- [ ] Existing `pr-review-and-slurm-test.yml` passes on this PR
- [ ] After merge, provision repo secret `BLOG_GATE_TOKEN` (fine-grained PAT, `awslabs` org, `Members: read`)
- [ ] Open a no-op PR from a non-maintainer account targeting `content` and confirm: templated comment posted within seconds, PR auto-closed, no maintainer notification
- [ ] Open a PR from a maintainer account targeting `content` and confirm: NOT auto-closed, CODEOWNERS review requested
- [ ] Open any PR to `main` (e.g., a code-sample change) and confirm: Blog PR Gate does NOT run for it