### PR TITLE
chore: rename blog title to "Awsome-Distributed Deep Dives by the AWS Frameworks Team"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# ADT Blog source
+# Awsome-Distributed Deep Dives — source
 
-This branch holds the Hugo source for the ADT blog, published at
+This branch holds the Hugo source for *Awsome-Distributed Deep Dives by
+the AWS Frameworks Team*, published at
 <https://awslabs.github.io/awsome-distributed/>.
 
 This branch is editorially curated by AWS authors. External PRs targeting

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "ADT Blog"
+title: "Awsome-Distributed Deep Dives by the AWS Frameworks Team"
 ---
 
 Posts about distributed ML training on AWS. The companion code lives on

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = "https://awslabs.github.io/awsome-distributed/"
 languageCode = "en-us"
-title = "ADT Blog"
+title = "Awsome-Distributed Deep Dives by the AWS Frameworks Team"
 theme = "PaperMod"
 
 [params]


### PR DESCRIPTION
## Summary

Renames the Hugo site title from the placeholder "ADT Blog" to the full name. Three files touched on `content`:

- `hugo.toml` — site title (rendered in PaperMod header and `<title>` tags)
- `content/_index.md` — landing-page title
- `README.md` — orientation header on the branch

## Verification (locally tested)

Local Hugo build with the new title:
- Home page `<title>`: `Awsome-Distributed Deep Dives by the AWS Frameworks Team`
- Post page `<title>`: `Building Blocks for Foundation Model Training and Inference on AWS | Awsome-Distributed Deep Dives by the AWS Frameworks Team`

After merge, the deploy workflow will republish the site with the new title.

## Out of scope

`main`'s `README.md` `## Blog` section refers to "the blog" generically rather than by name and doesn't need an update. If you want to add the full blog name there too, happy to follow up in a separate PR on `main`.