### PR TITLE
papermod: enable home-info mode and add Posts/Tags top nav

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -9,5 +9,25 @@ theme = "PaperMod"
   ShowShareButtons = false
   ShowPostNavLinks = true
 
+[params.homeInfoParams]
+  Title = "Distributed ML on AWS"
+  Content = """
+Posts on distributed training and inference — infrastructure, frameworks, and observability — from the AWS Frameworks Team.
+
+Companion to [`awslabs/awsome-distributed`](https://github.com/awslabs/awsome-distributed).
+"""
+
+[[menu.main]]
+  identifier = "posts"
+  name = "Posts"
+  url = "/posts/"
+  weight = 10
+
+[[menu.main]]
+  identifier = "tags"
+  name = "Tags"
+  url = "/tags/"
+  weight = 20
+
 [markup.goldmark.renderer]
   unsafe = true


### PR DESCRIPTION
## Summary

Two PaperMod features turned on:

- **homeInfoParams** — the home page was just a bare post list. This adds a Title + intro Content block at the top:
  - Title: *Distributed ML on AWS*
  - Content: one paragraph describing scope (training/inference, infrastructure/frameworks/observability, AWS Frameworks Team) and linking back to `awslabs/awsome-distributed`.
- **Top nav menu** — header now shows **Posts** and **Tags** links. Both URLs are auto-generated by Hugo (section page and tags taxonomy index), so they work without additional content files.

## Verification (locally tested)

Local Hugo 0.161.1 build:
- `<section class="home-info ...">` block renders at the top of the home page
- `<ul id="menu">` contains items: `Posts`, `Tags`
- Both menu URLs return 200 once deployed

## Out of scope

Archives and Search were in the original baseline I described but each needs its own `content/*.md` content page (Search additionally needs an `outputs` config). Happy to follow up in a separate PR if you want them.