### PR TITLE
fix(healthcheck): default
  NCCL_CONTAINER to docker:// scheme for Pyxis compatibility

### DIFF
--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/README.md
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/README.md
@@ -13,8 +13,8 @@ The suite provides two operational modes: **lightweight checks** for regular use
 | NVIDIA Driver | All GPU checks | Pre-installed on GPU AMIs |
 | [DCGM Toolkit](https://developer.nvidia.com/dcgm) | Checks 1, 4 | `apt install datacenter-gpu-manager` or via NVIDIA repo |
 | EFA Installer | Checks 2, 6 | [AWS EFA Installer](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html) |
-| NCCL Tests Container | Check 5 | `public.ecr.aws/hpc-cloud/nccl-tests:latest` |
-| [Pyxis](https://github.com/NVIDIA/pyxis) + [Enroot](https://github.com/NVIDIA/enroot) | Check 5 (container) | Optional -- falls back to local `all_reduce_perf` |
+| NCCL Tests Container | Check 5 | `docker://public.ecr.aws/hpc-cloud/nccl-tests:latest` |
+| [Pyxis](https://github.com/NVIDIA/pyxis) + [Enroot](https://github.com/NVIDIA/enroot) | Check 5 (container) | Optional -- falls back to local `all_reduce_perf`. Pyxis < v0.20 requires the explicit `docker://` scheme on the image reference; newer Pyxis auto-detects |
 | Python 3.6+ | Result parsing | Pre-installed on most Linux distributions |
 
 ### Installation
@@ -469,6 +469,24 @@ The guiding principle is **replace, don't repair**. On AWS, the primary remediat
 - Check container image availability: `enroot import docker://public.ecr.aws/hpc-cloud/nccl-tests:latest`
 - Verify inter-node connectivity: security groups must allow all traffic between nodes
 - Check for NCCL version compatibility with driver version
+
+#### Container image pull returns 401 Unauthorized from `registry-1.docker.io`
+
+Symptom in stderr:
+```
+URL https://registry-1.docker.io/v2/public.ecr.aws/hpc-cloud/nccl-tests/manifests/latest returned error code: 401 Unauthorized
+pyxis: failed to import docker image
+spank: required plugin spank_pyxis.so: task_init() failed with rc=-1
+```
+
+Cause: older Pyxis (< v0.20) does not auto-detect the registry hostname in bare image references and routes the pull through Docker Hub, which returns 401 for the `public.ecr.aws/...` path. Force the registry scheme explicitly:
+
+```bash
+NCCL_CONTAINER=docker://public.ecr.aws/hpc-cloud/nccl-tests:latest \
+  ./gpu-healthcheck.sh --suite intensive --exclusive
+```
+
+Or update Pyxis to v0.20 or newer. The script's default already uses the `docker://` scheme as of [PR #TBD](https://github.com/awslabs/awsome-distributed-ai/pulls); this troubleshooting note covers customers running older Pyxis with the previous default still pinned in their configuration.
 
 ### Topology shows disconnected GPUs
 

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/checks/5-nccl-allreduce.sh
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/checks/5-nccl-allreduce.sh
@@ -12,7 +12,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/common.sh"
 
 CHECK_NAME="5-nccl-allreduce"
-NCCL_CONTAINER="${NCCL_CONTAINER:-public.ecr.aws/hpc-cloud/nccl-tests:latest}"
+# NCCL_CONTAINER is consumed by `srun --container-image=...` (Pyxis/Enroot).
+# Older Pyxis releases (< v0.20) do not auto-detect non-Docker-Hub registries
+# from a bare image reference -- they route the pull through `registry-1.docker.io`
+# and 401 on private/non-DockerHub images such as `public.ecr.aws/...`. Setting
+# the explicit `docker://` scheme keeps the default working across all Pyxis
+# versions. Newer Pyxis treats `docker://` as a no-op, so this is a strict
+# improvement. The K8s code path does not consume this variable.
+NCCL_CONTAINER="${NCCL_CONTAINER:-docker://public.ecr.aws/hpc-cloud/nccl-tests:latest}"
 NCCL_TIMEOUT="${NCCL_TIMEOUT:-1800}"  # 30-minute timeout
 NCCL_ISOLATION_TESTS="${NCCL_ISOLATION_TESTS:-0}"
 NCCL_ISOLATION_TIMEOUT="${NCCL_ISOLATION_TIMEOUT:-600}"  # 10-minute timeout per isolation sub-test

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/slurm/sbatch-intensive.sh
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/slurm/sbatch-intensive.sh
@@ -24,8 +24,10 @@ HEALTHCHECK_DIR="${HEALTHCHECK_DIR:-/shared/gpu-health-checks}"
 # Results base directory
 RESULTS_BASE="${RESULTS_BASE:-/shared/healthcheck-results}"
 
-# NCCL test container image
-NCCL_CONTAINER="${NCCL_CONTAINER:-public.ecr.aws/hpc-cloud/nccl-tests:latest}"
+# NCCL test container image. The `docker://` scheme is required on older Pyxis
+# (< v0.20); newer Pyxis treats it as a no-op. See checks/5-nccl-allreduce.sh
+# for the rationale.
+NCCL_CONTAINER="${NCCL_CONTAINER:-docker://public.ecr.aws/hpc-cloud/nccl-tests:latest}"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # End User Variables


### PR DESCRIPTION
## Purpose

`5-nccl-allreduce.sh` and `slurm/sbatch-intensive.sh` default `NCCL_CONTAINER` to a bare ECR Public image reference. On Pyxis < v0.20 (which is still in the field — e.g. customer ParallelClusters on profile 1.7 EFA stacks), bare references route through Docker Hub and return `401 Unauthorized`, causing the whole intensive suite to fail before any NCCL test runs. The misleading "NCCL all_reduce failed" report then masks a healthy NCCL configuration as a fault.

Encountered in a customer engagement where the misleading failure prompted an investigation into EFA / NCCL transport selection that was not actually the problem.

## Changes

| File | Change |
|---|---|
| `checks/5-nccl-allreduce.sh` | Default `NCCL_CONTAINER` from `public.ecr.aws/hpc-cloud/nccl-tests:latest` → `docker://public.ecr.aws/hpc-cloud/nccl-tests:latest`. Comment explains the Pyxis < v0.20 rationale. |
| `slurm/sbatch-intensive.sh` | Same one-character change to the parallel default in the sbatch wrapper. |
| `README.md` (Prerequisites table) | NCCL Tests Container row updated to the `docker://` form; Pyxis row notes the < v0.20 caveat. |
| `README.md` (Troubleshooting) | New entry under "NCCL all_reduce fails" reproducing the 401 symptom and giving the explicit `NCCL_CONTAINER=docker://...` override for deployments still pinned to the old default. |

Newer Pyxis (≥ v0.20) treats the `docker://` scheme as a no-op (it auto-detects the registry hostname), so the change is a strict improvement — no Pyxis version regresses.

## Scope: why this is Slurm-only

`NCCL_CONTAINER` is consumed exclusively by `srun --container-image=...` calls in `checks/5-nccl-allreduce.sh` and `slurm/sbatch-intensive.sh`. The Kubernetes deployment does not read this variable:

- `kubernetes/README.md` line 258: *"Check 5 (NCCL all_reduce) is not included in the DaemonSet or sweeper because it requires multi-node coordination. Use an MPI Operator Job or similar for multi-node NCCL testing."*
- `kubernetes/agent.sh` defaults: `CHECKS_LIGHTWEIGHT="${CHECKS_LIGHTWEIGHT:-0 2 3}"` — the K8s agent runs checks 0, 2, 3 only.
- `grep -rE NCCL_CONTAINER` in the K8s subdirectory: zero hits.
- K8s pod-spec `image:` references (in `kubernetes/manifests/*.yaml`) use standard bare OCI references — `docker://` would be invalid in those.

So this change touches only the Slurm code path. K8s users are unaffected. Unifying check 5 across runtimes is a larger refactor and is tracked separately (see the linked issue if filed).

## Test Plan

**Environment:**
- AWS Service: ParallelCluster 3.15 (Slurm + Pyxis/Enroot)
- Instance type: `p6-b300.48xlarge` (validation also ran lightweight + check 6 on `p6-b200.48xlarge` via customer evidence)
- Number of nodes: 2

**Test commands (reproduce the 401 with the old default, confirm fix with new default):**

```bash
# Old default (reproduces the 401 on Pyxis < v0.20):
NCCL_CONTAINER=public.ecr.aws/hpc-cloud/nccl-tests:latest \
  ./gpu-healthcheck.sh --suite intensive --exclusive

# New default (or explicit override on older deployments):
NCCL_CONTAINER=docker://public.ecr.aws/hpc-cloud/nccl-tests:latest \
  ./gpu-healthcheck.sh --suite intensive --exclusive

# Equivalently after this PR merges (no override needed):
./gpu-healthcheck.sh --suite intensive --exclusive
```

## Test Results

**Old default on the affected Pyxis version (reproduction from customer evidence bundle):**
```
[ERROR] URL https://registry-1.docker.io/v2/public.ecr.aws/hpc-cloud/nccl-tests/manifests/latest
        returned error code: 401 Unauthorized
[ERROR] pyxis: failed to import docker image
[ERROR] pyxis: couldn't start container
[ERROR] spank: required plugin spank_pyxis.so: task_init() failed with rc=-1
...
[FAIL] 5-nccl-allreduce: NCCL all_reduce failed (exit 1)
```

**With `docker://` prefix (this PR's default):** image pull succeeds, NCCL test runs, report reflects actual NCCL bandwidth.

### Manual reviewer test plan

- [ ] On a Slurm + Pyxis ≥ v0.20 cluster, run `./gpu-healthcheck.sh --suite intensive --exclusive` and confirm the NCCL test runs normally (regression check).
- [ ] On a Slurm + Pyxis < v0.20 cluster (or by overriding `NCCL_CONTAINER` to the old bare form to simulate), confirm the 401 reproduces with the bare form and disappears with the `docker://` form.
- [ ] Confirm `--dry-run` output reflects the new default.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`). *(Image reference unchanged; only the URI scheme is added.)*
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure). *(N/A — this is a check-script default fix, not a new test case.)*
