### PR TITLE
Add Qwen3.6-35B-A3B MoE LoRA function-calling test case (Megatron-Bridge + Kubeflow PyTorchJob)

### DIFF
--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/.gitignore
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/.gitignore
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+# Local environment file — users copy env.example to env.sh with real values.
+kubernetes/scripts/env.sh

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/README.md
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/README.md
@@ -1,0 +1,249 @@
+# Qwen3.6-35B-A3B Function-Calling LoRA on Kubernetes
+
+End-to-end LoRA fine-tuning of Qwen3.6-35B-A3B, a 256-expert Mixture-of-Experts
+model, for structured tool-call generation on the xLAM-60k dataset. Runs on 2×
+p5e.48xlarge (16× H200) using Megatron-Bridge with tensor, expert, and data
+parallelism; serves the trained adapter with vLLM; evaluates against the base
+model on hand-crafted edge cases and LLM-as-judge over held-out validation.
+
+Works on any Kubernetes cluster with the NVIDIA device plugin and the EFA
+device plugin — tested on **Amazon SageMaker HyperPod (EKS mode)** and plain
+**Amazon EKS** with FSx for Lustre storage.
+
+
+## Model, dataset, and result
+
+| | |
+|---|---|
+| Base model | [`Qwen/Qwen3.6-35B-A3B`](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) (256 experts, top-8 routing, ~3B active) |
+| Dataset | [`minpeter/xlam-function-calling-60k-parsed`](https://huggingface.co/datasets/minpeter/xlam-function-calling-60k-parsed) (58.8k train / 1.2k val, 3,673 unique tool schemas) |
+| Technique | LoRA rank 64, alpha 128, target `linear_qkv` + `linear_proj` only |
+| Parallelism | TP=2, PP=1, EP=4, DP=2 on 16 H200 |
+| Trained | 4,200 iterations, ~413M tokens, ~3.43 epochs |
+| Reference adapter | [`ying2022/qwen3-6-35b-xlam-tools-lora`](https://huggingface.co/ying2022/qwen3-6-35b-xlam-tools-lora) (108 MB, published) |
+| Observed wall-clock | 2h 12min end-to-end |
+| Gate 1 result | Base 6/10 → LoRA 9/10 (+30 pp absolute) |
+| Gate 2 result | LoRA wins 47/50 (94%) judged by Claude Opus 4.7 |
+
+You can skip training entirely and serve the published adapter from
+HuggingFace by setting `LORA_SOURCE=hf` in your environment (see step 6).
+
+## Prerequisites
+
+- **Kubernetes cluster** with 2× p5e.48xlarge (or p5.48xlarge) GPU nodes in the
+  same availability zone. Both EKS and HyperPod EKS work; reference setup for
+  HyperPod EKS is in
+  [`1.architectures/7.sagemaker-hyperpod-eks/`](../../../../../1.architectures/7.sagemaker-hyperpod-eks/).
+- **NVIDIA device plugin** and **EFA device plugin** installed on the cluster.
+- **Kubeflow Training Operator v1.9.0** or later
+  (`kubectl apply -k "github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=v1.9.1"`).
+- **FSx for Lustre CSI driver**
+  (`helm install fsx-csi -n kube-system aws-fsx-csi-driver/aws-fsx-csi-driver`) and
+  an AWS subnet + security group that allows Lustre protocol (TCP 988, 1021-1023).
+- **AWS CLI + kubectl + envsubst + helm** locally.
+- **Optional**: HuggingFace token for gated models, stored as a Kubernetes
+  Secret named `hf-token` in the target namespace.
+- **Optional (for Gate 2 eval)**: IAM role with `bedrock:InvokeModel` permission
+  on the Claude Opus 4.7 inference profile, attached via IRSA to the default
+  ServiceAccount in the test-case namespace.
+
+## Instance options
+
+| Instance | GPUs | HBM per GPU | Notes |
+|---|---|---|---|
+| `ml.p5e.48xlarge` × 2 | 8× H200 | 141 GB | Reference configuration; best MFU |
+| `ml.p5.48xlarge` × 2 | 8× H100 | 80 GB | Works; slightly tighter memory headroom |
+| `ml.p4de.24xlarge` × 2 | 8× A100 | 80 GB | Works; ~2-3× slower (no FP8, older SM) |
+
+For p5 or p4de, update `NODE_INSTANCE_TYPE` and `EFA_PER_NODE` in
+`kubernetes/scripts/env.sh` (p5 has 32 EFA NICs like p5e; p4de has 4).
+
+## Walkthrough
+
+Every step is a numbered script in `kubernetes/scripts/`. Each script is
+idempotent — re-running applies updated manifests without tearing down
+existing state.
+
+```bash
+cd 3.test_cases/megatron/megatron-lm/qwen36-moe-lora
+cp kubernetes/scripts/env.example kubernetes/scripts/env.sh
+# edit kubernetes/scripts/env.sh: set FSX_SUBNET_ID, FSX_SECURITY_GROUP, node type, etc.
+source kubernetes/scripts/env.sh
+```
+
+### 0. Setup storage (~15 min, one-time)
+
+```bash
+./kubernetes/scripts/0.setup-storage.sh
+```
+
+Creates namespace, FSx Lustre StorageClass (version 2.15 — **critical**: the
+FSx default of 2.10 is incompatible with the p5e AMI's Lustre client), PVC
+`qwen-moe-lustre`, and a ConfigMap holding the Python scripts.
+
+### 1. Pre-cache base weights (~30 min, one-time)
+
+```bash
+./kubernetes/scripts/1.precache-weights.sh
+```
+
+Downloads the ~70 GB Qwen3.6-35B safetensors to Lustre. Subsequent training
+runs and inference deployments read from here instead of re-downloading.
+
+### 2. Prepare dataset (~2 min)
+
+```bash
+./kubernetes/scripts/2.prep-dataset.sh
+```
+
+Converts the HuggingFace xLAM-60k parquet into
+`/fsx/datasets/training.jsonl` + `/fsx/datasets/validation.jsonl` in the
+format Megatron-Bridge's `llm-finetune-preloaded` dataset builder expects.
+
+### 3. Convert HF weights to Megatron-Bridge format (~25 min, one-time)
+
+```bash
+./kubernetes/scripts/3.convert-to-bridge.sh
+```
+
+Megatron-Bridge reads its own distributed checkpoint format
+(`metadata.json` + sharded `.distcp` files), not HuggingFace safetensors. This
+script runs `convert_checkpoints_multi_gpu.py import` with the same TP/PP/EP
+sharding the training job will use.
+
+The output at `/fsx/qwen36-bridge/` is reusable — as long as you don't change
+`TP`, `PP`, or `EP`, you can re-train without rerunning this step.
+
+### 4. Train (~2h 12min on 16× H200)
+
+```bash
+./kubernetes/scripts/4.train.sh
+```
+
+Submits a Kubeflow `PyTorchJob` with `replicas=NUM_NODES` Workers, each
+running `torchrun --nproc_per_node=GPU_PER_NODE` for a total of 16 ranks.
+Refreshes the ConfigMap before submission so any local edits to
+`src/xlam_runner.py` are picked up.
+
+Watch with:
+
+```bash
+kubectl -n $NAMESPACE logs -f qwen36-xlam-train-worker-0
+```
+
+The training prints `Step Time: Xs GPU utilization: Y MODEL_TFLOP/s/GPU` every
+10 iterations and saves a checkpoint every 500 iterations to
+`/fsx/qwen36-xlam-runs/checkpoints/iter_XXXXXXX`.
+
+### 5. Export adapter to HuggingFace PEFT format (~10 min)
+
+```bash
+./kubernetes/scripts/5.export-adapter.sh
+```
+
+Converts the Megatron distributed checkpoint to a standard HF PEFT adapter
+(`adapter_config.json` + `adapter_model.safetensors`, total ~108 MB) at
+`/fsx/qwen36-xlam-runs/adapter_hf/`. This artifact is portable — you can
+upload it to the HuggingFace Hub and load it from any PEFT-compatible runtime.
+
+### 6. Deploy inference (~8 min cold start)
+
+```bash
+./kubernetes/scripts/6.deploy-inference.sh
+```
+
+Creates a vLLM Deployment + ClusterIP Service serving the base model with
+the adapter loaded under the alias `tools`. Exposes an OpenAI-compatible API
+at `http://qwen-inference.$NAMESPACE.svc.cluster.local:8000/v1/`.
+
+**To skip training and use the published reference adapter** instead, set in
+`env.sh`:
+
+```bash
+export LORA_SOURCE=hf
+export LORA_REPO=ying2022/qwen3-6-35b-xlam-tools-lora
+```
+
+### 7. Run evaluation
+
+```bash
+# Gate 1 (10 prompts, ~2 min, no external dependencies):
+export GATE=1
+./kubernetes/scripts/7.run-eval.sh
+
+# Gate 2 (50 prompts via Claude Opus 4.7, ~4 min, requires Bedrock):
+export GATE=2
+./kubernetes/scripts/7.run-eval.sh
+
+# Both gates:
+export GATE=all
+./kubernetes/scripts/7.run-eval.sh
+```
+
+Results print at the end of the Job's logs:
+
+```
+=== Summary ===
+  gate1_base             6/10
+  gate1_lora             9/10
+  gate2_lora_wins        47/50
+  gate2_win_rate         94%
+```
+
+### Cleanup
+
+```bash
+./kubernetes/scripts/cleanup.sh
+# Preserves the Lustre PVC (and all cached weights, checkpoints, adapter).
+# To also delete the filesystem:
+kubectl -n $NAMESPACE delete pvc qwen-moe-lustre
+```
+
+## Directory layout
+
+```
+qwen36-moe-lora/
+├── README.md                       # this file
+├── src/                            # platform-agnostic Python (training, eval, export)
+│   ├── prep_xlam_dataset.py        # xLAM parquet → Megatron JSONL
+│   ├── xlam_runner.py              # Megatron-Bridge training driver
+│   ├── export_lora_adapter.py      # distcp → HF PEFT converter
+│   └── eval_function_calling.py    # Gate 1 + Gate 2 eval
+├── docs/
+│   ├── PERFORMANCE.md              # observed step time, MFU, memory, EP topology
+│   ├── EVALUATION.md               # 2-gate methodology + full results
+│   └── TROUBLESHOOTING.md          # common failure modes and fixes
+└── kubernetes/
+    ├── manifests/
+    │   ├── storage.yaml-template
+    │   ├── 0.precache-weights.yaml-template
+    │   ├── 1.prep-dataset.yaml-template
+    │   ├── 2.convert-to-bridge.yaml-template
+    │   ├── 3.pytorchjob-train.yaml-template
+    │   ├── 4.export-adapter.yaml-template
+    │   ├── 5.inference-vllm.yaml-template
+    │   └── 6.eval-job.yaml-template
+    └── scripts/
+        ├── env.example             # copy to env.sh; holds cluster-specific config
+        ├── 0.setup-storage.sh
+        ├── 1.precache-weights.sh
+        ├── 2.prep-dataset.sh
+        ├── 3.convert-to-bridge.sh
+        ├── 4.train.sh
+        ├── 5.export-adapter.sh
+        ├── 6.deploy-inference.sh
+        ├── 7.run-eval.sh
+        └── cleanup.sh
+```
+
+## Further reading
+
+- [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md) — observed performance, MFU,
+  memory usage, and EP topology analysis
+- [`docs/EVALUATION.md`](docs/EVALUATION.md) — evaluation methodology and the
+  reference run's full results
+- [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) — common failures
+  during bring-up (FSx Lustre version mismatch, tokenizer defaults, etc.)
+- [Megatron-Bridge repo](https://github.com/NVIDIA/Megatron-Bridge) for the
+  recipe catalog and API reference
+- [xLAM paper](https://arxiv.org/abs/2409.03215) — dataset provenance

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/docs/EVALUATION.md
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/docs/EVALUATION.md
@@ -1,0 +1,129 @@
+# Evaluation methodology and reference results
+
+Two complementary gates evaluate the fine-tuned adapter against the base
+model, targeting different failure modes.
+
+## Inference setup
+
+Both models are served by a single vLLM instance via the OpenAI-compatible
+`/v1/chat/completions` API. The base is loaded by model name
+(`Qwen/Qwen3.6-35B-A3B`); the adapter is loaded under the alias `tools` via
+`--lora-modules tools=<path>` and queried by passing `model="tools"`.
+
+All eval requests set `temperature=0.1` (near-deterministic), `max_tokens=512`,
+and `chat_template_kwargs={"enable_thinking": False}` to disable Qwen's
+`<think>` CoT preamble. Without the thinking-off flag, both models exhaust
+token budget on reasoning prose and never emit a tool call.
+
+## Tool-call output format
+
+Qwen3.6 emits tool calls in Qwen-Agent XML form:
+
+```
+<tool_call>
+<function=search_flights>
+<parameter=origin>JFK</parameter>
+<parameter=destination>SFO</parameter>
+</function>
+</tool_call>
+```
+
+This is NOT the format vLLM's `--tool-call-parser hermes` expects (Hermes
+wants JSON-in-XML). In practice, vLLM leaves the `tool_calls` field empty and
+the XML lands in `content`. The eval harness (`src/eval_function_calling.py`)
+parses the XML itself with a regex, so scoring works regardless of whether
+vLLM surfaces structured `tool_calls` on a given request.
+
+## Gate 1 — Hand-crafted edge cases
+
+Ten prompts exercising specific function-calling behaviors that a correctly
+trained model should handle but base models often miss:
+
+| # | Category |
+|---|---|
+| 1 | Simple single tool |
+| 2 | camelCase schema (getUserProfile vs get_user_profile) |
+| 3 | Nested object argument |
+| 4 | Enum argument (celsius vs fahrenheit) |
+| 5 | Multi-tool required (flight + hotel) |
+| 6 | Array argument (list of emails) |
+| 7 | Integer-type argument |
+| 8 | Boolean flag |
+| 9 | Ambiguous — should NOT call a tool |
+| 10 | Decimal + currency |
+
+A prompt passes if the model emits a parseable tool call with the expected
+function name (or no tool call, for prompt #9). Runtime: ~2 minutes total.
+
+### Reference results (reference run)
+
+| Prompt | Base | LoRA |
+|---|---|---|
+| 1. Simple single tool | ❌ | ✅ |
+| 2. camelCase schema | ✅ | ✅ |
+| 3. Nested object | ✅ | ❌ |
+| 4. Enum argument | ❌ | ✅ |
+| 5. Multi-tool required | ❌ | ✅ |
+| 6. Array argument | ✅ | ✅ |
+| 7. Integer type | ✅ | ✅ |
+| 8. Boolean flag | ✅ | ✅ |
+| 9. Ambiguous | ✅ | ✅ |
+| 10. Decimal + currency | ❌ | ✅ |
+| **Total** | **6 / 10** | **9 / 10** |
+
+LoRA wins on 4 prompts (1, 4, 5, 10), loses on 1 (3 — nested object). Net
+improvement +3 prompts (+30 percentage points absolute).
+
+The regression on prompt 3 is called out explicitly — fine-tuned adapters
+often sharpen common patterns at the cost of rare ones. Mitigations discussed
+in the TROUBLESHOOTING doc.
+
+## Gate 2 — LLM-as-judge on xLAM validation
+
+Sample 50 prompts from the xLAM held-out validation split
+(`/fsx/datasets/validation.jsonl`). For each:
+
+1. Send to base and to LoRA, collect both outputs.
+2. **Randomize A/B position** (coin flip) — eliminates judge position bias.
+3. Ask Claude Opus 4.7 via Bedrock: "which is better on (1) valid JSON/format,
+   (2) correct tool + args, (3) no extraneous prose — A, B, or TIE?"
+4. Map back to BASE / LORA / TIE.
+
+Judge: `us.anthropic.claude-opus-4-7` (US cross-region inference profile).
+Note: Opus 4.7 deprecated the `temperature` parameter — do not pass it in the
+request body. Runtime: ~4 minutes for 50 samples.
+
+### Reference results
+
+| Outcome | Count | Share |
+|---|---|---|
+| LoRA wins | **47** | **94%** |
+| Base wins | 3 | 6% |
+| Ties | 0 | 0% |
+| Errors | 0 | 0% |
+
+Zero ties is striking — outputs were qualitatively distinguishable on every
+prompt. The 94% win rate is in-distribution (xLAM validation shares the
+training distribution's style), so it represents a near-best-case; Gate 1's
++30 pp on out-of-distribution edge cases is a more conservative signal.
+
+## Reproducing
+
+```bash
+# With the published reference adapter (no training required):
+export LORA_SOURCE=hf
+export LORA_REPO=ying2022/qwen3-6-35b-xlam-tools-lora
+./scripts/6.deploy-inference.sh
+export GATE=all
+./scripts/7.run-eval.sh
+
+# Sample output:
+# === Summary ===
+#   gate1_base             6/10
+#   gate1_lora             9/10
+#   gate2_lora_wins        47/50
+#   gate2_win_rate         94%
+```
+
+Expect small run-to-run variation on Gate 2 (±2 wins) due to judge stochasticity
+even at `max_tokens=8`; Gate 1 is fully deterministic.

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/docs/PERFORMANCE.md
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/docs/PERFORMANCE.md
@@ -1,0 +1,117 @@
+# Performance notes
+
+Observed on 2× `ml.p5e.48xlarge` (16× H200 141 GB) during the 4,200-iteration
+reference run. Container: `nvcr.io/nvidia/nemo:26.04` (Megatron-Bridge 0.4.0rc0,
+Megatron-Core 0.17.0rc0, NeMo 26.04).
+
+## Training throughput
+
+| Metric | Value |
+|---|---|
+| Wall-clock, 4,200 iterations | 2h 12min |
+| Step time (average) | 1.73 s/step |
+| Step time (range) | 1.5-2.2 s |
+| Tokens per step | 98,304 (global_batch 48 × seq 2048) |
+| Total tokens trained | 413 M |
+| Epochs over 58.8k train samples | 3.43 |
+| Per-GPU throughput (avg) | ~77 MODEL TFLOP/s |
+| Aggregate throughput | ~1.2 PFLOPS |
+| H200 peak bf16 | 990 TFLOPS |
+| Model FLOPs utilization (MFU) | ~7.7% |
+
+MFU is dominated by MoE all-to-all synchronization, not matrix-multiplication
+throughput, which is typical for expert-parallel training. Power draw was
+200-230 W per GPU (of 700 W TDP) — compute-light, collective-bound.
+
+## Memory usage
+
+Per GPU during steady-state training (sampled via `nvidia-smi`):
+
+| Item | Observed |
+|---|---|
+| HBM used per GPU | 56-68 GB |
+| HBM available per GPU (H200) | 141 GB |
+| Utilization | 40-48% |
+| Free per GPU | 70-80 GB |
+
+We were **not** memory-constrained. Two levers for higher utilization in a
+follow-on run:
+
+- `MICRO_BS=3 → 6` should approximately halve step time
+- `SEQ_LENGTH=2048 → 4096` increases arithmetic intensity per token
+
+Both fit within the observed memory headroom. QLoRA (4-bit quantization) is
+explicitly **not** needed — the base model fits comfortably in bf16.
+
+## Parallelism topology
+
+```
+16 ranks = TP(2) × PP(1) × EP(4) × DP(2)
+```
+
+With Megatron's default rank-ordering (`tp-ep-dp`, TP innermost), the 16 ranks
+map to the two nodes as:
+
+```
+Node A (ranks 0-7)                Node B (ranks 8-15)
+  rank 0-6 (even): EP group #1      rank 8-14 (even): EP group #3
+  rank 1-7 (odd):  EP group #2      rank 9-15 (odd):  EP group #4
+```
+
+Each EP group holds all 256 experts sharded across 4 ranks (64 experts per
+rank). EP groups #1 and #2 are TP twins on node A; #3 and #4 are TP twins on
+node B. EP groups #{1,3} and #{2,4} are DP replicas — they process different
+training examples and sync gradients at step end.
+
+### What runs over NVLink vs EFA
+
+| Collective | Axis | Path | Observed |
+|---|---|---|---|
+| Attention forward/backward | TP | intra-node NVLink | high bandwidth, low latency |
+| MoE token dispatch (all-to-all) | EP | **intra-node NVLink** | fits in one node per EP group |
+| MoE token combine (all-to-all) | EP | **intra-node NVLink** | same |
+| Gradient all-reduce | DP | **inter-node EFA GDRDMA** | confirmed in NCCL logs |
+
+### Making MoE all-to-all actually cross EFA
+
+The reference configuration keeps MoE a2a intra-node. To exercise inter-node
+MoE all-to-all (e.g., for an EFA stress benchmark), set `EP × TP > GPU_PER_NODE`
+(i.e., 8 on p5e). Options:
+
+- `TP=1, EP=16, DP=1` on 2× p5e — one EP group spans both nodes
+- `TP=2, EP=8, DP=1` on 2× p5e — same span via Megatron rank-order override
+- Scale to 4 nodes with `EP=16, DP=2` — EP group must cross
+
+The base checkpoint has to be reconverted (`./scripts/3.convert-to-bridge.sh`)
+to match the new sharding.
+
+## Router load imbalance
+
+Sampled GPU utilization per rank during steady-state (16 ranks):
+
+| Range | Count |
+|---|---|
+| 90-100% | 2-3 ranks |
+| 60-89% | 5-6 ranks |
+| 30-59% | 3-4 ranks |
+| 0-29% | 1-2 ranks |
+
+This variance is the MoE "heavy expert" pattern — on any given step some
+experts receive many tokens, others few. The collective barrier at each MoE
+layer's all-to-all syncs everything to the slowest rank. `moe_aux_loss_coeff`
+(0.001 default in the Qwen3.5-VL recipe) is the regularizer that drives the
+router toward balance; raising to 0.01 typically tightens the distribution at
+a small loss-quality cost.
+
+## Tokenizer and model sizes
+
+| | Value |
+|---|---|
+| Base weights (bf16, full) | 70 GB |
+| Bridge distcp checkpoint | 68 GB (sharded TP=2, EP=4) |
+| LoRA adapter (bf16, rank 64 on attention only) | 108 MB |
+| HF tokenizer vocab (real) | 248,077 tokens |
+| HF tokenizer vocab (padded to multiple for TP) | 248,320 |
+
+The adapter-to-base ratio is ~1:650 — this is what LoRA buys: serving many
+specialized variants of the same base model with tiny incremental storage.

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/docs/TROUBLESHOOTING.md
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/docs/TROUBLESHOOTING.md
@@ -1,0 +1,189 @@
+# Troubleshooting
+
+Failure modes encountered during the reference run's bring-up, grouped by
+phase. Each entry gives the symptom, root cause, and fix.
+
+## Storage
+
+### PVC stuck in Pending with FSx 2.10 error
+
+Symptom in `kubectl describe pvc qwen-moe-lustre`:
+
+```
+Warning  ProvisioningFailed  ... filesystem version 2.10 not supported
+```
+
+**Root cause**: the default `fileSystemTypeVersion` on the FSx CSI driver
+StorageClass is 2.10, which is incompatible with the Lustre 2.15.6 client
+bundled in the p5e AMI. Mount attempts fail with kernel log
+`Server MGS version (2.10.5.0) refused connection from this client with an
+incompatible version (2.15.6)`.
+
+**Fix**: `storage.yaml-template` explicitly sets `fileSystemTypeVersion: "2.15"`.
+If you see this error, confirm the StorageClass applied cleanly:
+
+```bash
+kubectl get storageclass fsx-sc-215-$NAMESPACE -o yaml | grep fileSystemTypeVersion
+```
+
+### Mount fails with EINVAL (exit status 22) on p5e
+
+Symptom: pod event `mount.lustre: ... failed: Invalid argument`.
+
+**Root cause**: LNet kernel module not loaded. The HyperPod p5e AMI has the
+Lustre client installed but doesn't auto-load the modules at boot.
+
+**Fix**: ensure the node's lifecycle script loads Lustre modules:
+
+```bash
+modprobe lnet
+modprobe lustre
+lctl network up
+```
+
+For HyperPod, add this to `on_create_main.sh` before the cluster is created.
+If you need to fix running nodes, run a privileged pod that execs
+`nsenter --target 1 -- modprobe lnet && modprobe lustre` on each GPU host.
+
+## Tokenizer
+
+### Training crashes at iteration 1 with "NullTokenizer" error
+
+Symptom:
+
+```
+NotImplementedError: This method is not supported for null-text tokenizers.
+  at megatron/core/tokenizers/text/text_tokenizer.py:181  space_sensitive
+```
+
+**Root cause**: the Qwen3.5-VL recipe defaults to `NullTokenizer`, a stub used
+for image-token pipelines. The text SFT dataset builder calls
+`tokenizer.space_sensitive` which `NullTokenizer` doesn't implement.
+
+**Fix**: already handled in `src/xlam_runner.py`:
+
+```python
+cfg.tokenizer.tokenizer_type = "HuggingFaceTokenizer"
+cfg.tokenizer.tokenizer_model = "/fsx/hf_cache/models--Qwen--Qwen3.6-35B-A3B"
+```
+
+If you override the HF model path in `env.sh`, update the `tokenizer_model`
+path too or expose it as another env var.
+
+### Training fails with "Tokenizer path must be specified"
+
+Symptom:
+
+```
+AssertionError: Tokenizer path must be specified.
+  at megatron_tokenizer.py:85  from_pretrained
+```
+
+**Root cause**: `cfg.tokenizer.tokenizer_type = "HuggingFaceTokenizer"` was
+set but `cfg.tokenizer.tokenizer_model` was not. Setting
+`hf_tokenizer_kwargs` (as one might guess from HF convention) is NOT what
+Bridge wants.
+
+**Fix**: use `cfg.tokenizer.tokenizer_model = <path-or-hf-id>`.
+
+## Checkpoint
+
+### Training crashes with "Invalid pretrained checkpoint directory"
+
+Symptom:
+
+```
+ValueError: Invalid pretrained checkpoint directory found: /fsx/hf_cache/...
+```
+
+**Root cause**: `cfg.checkpoint.pretrained_checkpoint` points at raw HF
+safetensors. Bridge expects its own distributed-checkpoint format
+(`metadata.json` + sharded `.distcp` files).
+
+**Fix**: run `./scripts/3.convert-to-bridge.sh` first, which runs
+`convert_checkpoints_multi_gpu.py import`. The resulting `/fsx/qwen36-bridge/`
+is what `PRETRAINED_CHECKPOINT` should point at.
+
+### Export fails with "cuda rng state model-parallel-rng is not added"
+
+Symptom (during `./scripts/5.export-adapter.sh`):
+
+```
+Exception: cuda rng state model-parallel-rng is not added
+  at megatron/core/tensor_parallel/random.py:303  fork
+```
+
+**Root cause**: Megatron's TP-aware RNG was not seeded before the first
+transformer layer was built.
+
+**Fix**: already handled in `src/export_lora_adapter.py` by calling
+`provider.initialize_model_parallel(seed=0)`, which internally calls
+`model_parallel_cuda_manual_seed`. Verify if you customized the export script.
+
+### Export fails with "Different dict keys encountered in apply_factory_merges"
+
+Symptom (during `./scripts/5.export-adapter.sh`):
+
+```
+ValueError: Different dict keys encountered in apply_factory_merges
+  (checkpoint has: vision_model.*, optimizer.*, scheduler.*, content_metadata, ...)
+```
+
+**Root cause**: raw `dist_checkpointing.load(sharded_state_dict)` can't
+reconcile the training checkpoint's extra keys (VL-recipe vision adapters +
+optimizer state + scheduler + metadata) against a filtered state dict that
+expects language-model adapter keys only.
+
+**Fix**: `src/export_lora_adapter.py` uses
+`_generate_model_state_dict` + `apply_peft_adapter_filter_to_state_dict` to
+produce an adapter-only filtered state dict before loading (the pattern
+from `examples/peft/merge_lora.py` in the Megatron-Bridge repo). Verify the
+filter is applied if you modify the script.
+
+## Inference
+
+### vLLM pod OOM at model load
+
+Symptom: `CUDA out of memory ... GPU 0 has a total capacity of 22.03 GiB`.
+
+**Root cause**: pod scheduled on a 24 GB L4 or A10G node instead of a p5e/p5
+H100/H200 node. Qwen3.6-35B bf16 is ~28 GB of weights — can't fit on a single
+24 GB GPU, needs at least 2× 80 GB (H100) or 2× 141 GB (H200) via
+`--tensor-parallel-size`.
+
+**Fix**: the inference manifest pins `nodeSelector:
+node.kubernetes.io/instance-type: ${NODE_INSTANCE_TYPE}` where
+`NODE_INSTANCE_TYPE=ml.p5e.48xlarge` in `env.sh`. Don't override to a smaller
+type for inference; the base model needs its HBM.
+
+
+### HF lockfile read-only filesystem error at vLLM startup
+
+Symptom:
+
+```
+OSError: [Errno 30] Read-only file system:
+'/fsx/hf_cache/hub/.locks/...'
+```
+
+**Root cause**: vLLM writes HuggingFace cache lockfiles into the PVC mount. If
+mounted read-only, every config lookup fails.
+
+**Fix**: the inference manifest mounts Lustre read-write. The base model
+weights are append-only by construction (no vLLM code writes to them); only
+`.locks/` bookkeeping gets written. Don't set `readOnly: true` on the PVC
+mount for vLLM.
+
+### Both models emit reasoning prose but no tool call
+
+Symptom: `content` contains `Thinking Process: ... 1. Analyze input ...` but
+no `<tool_call>` tags.
+
+**Root cause**: Qwen3.6 defaults to "thinking mode" — generates a `<think>`
+CoT preamble before any action. The token budget runs out before the tool
+call is emitted.
+
+**Fix**: every request must include
+`"chat_template_kwargs": {"enable_thinking": False}`. The
+`src/eval_function_calling.py` helper does this automatically.
+

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/0.precache-weights.yaml-template
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/0.precache-weights.yaml-template
@@ -1,0 +1,62 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# One-shot pod: pre-cache base model weights to FSx Lustre so the 70 GB download
+# happens once, not on every training pod start.
+#
+# Required env vars: NAMESPACE, IMAGE, HF_MODEL_ID, NODE_INSTANCE_TYPE
+# Optional:          HF_TOKEN_SECRET  (Secret name with `token` key, for gated models)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: qwen-precache-weights
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    node.kubernetes.io/instance-type: ${NODE_INSTANCE_TYPE}
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: precache
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          set -ex
+          pip install --quiet "huggingface_hub>=0.24,<1.0"
+          mkdir -p /fsx/hf_cache
+          python - <<'PY'
+          import os
+          from huggingface_hub import snapshot_download
+          snapshot_download(
+              repo_id=os.environ["HF_MODEL_ID"],
+              local_dir=f"/fsx/hf_cache/models--{os.environ['HF_MODEL_ID'].replace('/','--')}",
+              max_workers=8,
+          )
+          PY
+          echo "Pre-cache complete:"
+          du -sh /fsx/hf_cache/*
+      env:
+        - name: HF_MODEL_ID
+          value: "${HF_MODEL_ID}"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${HF_TOKEN_SECRET}
+              key: token
+              optional: true
+      resources:
+        limits:
+          cpu: "8"
+          memory: 64Gi
+        requests:
+          cpu: "4"
+          memory: 32Gi
+      volumeMounts:
+        - { name: lustre, mountPath: /fsx }
+  volumes:
+    - name: lustre
+      persistentVolumeClaim:
+        claimName: qwen-moe-lustre

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/1.prep-dataset.yaml-template
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/1.prep-dataset.yaml-template
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# One-shot pod: convert the xLAM-60k parquet dataset to Megatron-Bridge JSONL.
+# Writes /fsx/datasets/training.jsonl + /fsx/datasets/validation.jsonl.
+#
+# Required env vars: NAMESPACE, IMAGE, NODE_INSTANCE_TYPE, CONFIG_MAP
+#   CONFIG_MAP must contain prep_xlam_dataset.py (created by 1.prep-dataset.sh).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: qwen-prep-xlam
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    node.kubernetes.io/instance-type: ${NODE_INSTANCE_TYPE}
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: prep
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          set -ex
+          pip install --quiet "datasets>=2.14,<3.0"
+          mkdir -p /fsx/datasets
+          python /config/prep_xlam_dataset.py --output-dir /fsx/datasets
+          echo "Dataset prep complete:"
+          wc -l /fsx/datasets/training.jsonl /fsx/datasets/validation.jsonl
+      resources:
+        limits:
+          cpu: "8"
+          memory: 32Gi
+        requests:
+          cpu: "4"
+          memory: 16Gi
+      volumeMounts:
+        - { name: lustre, mountPath: /fsx }
+        - { name: config, mountPath: /config }
+  volumes:
+    - name: lustre
+      persistentVolumeClaim:
+        claimName: qwen-moe-lustre
+    - name: config
+      configMap:
+        name: ${CONFIG_MAP}

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/2.convert-to-bridge.yaml-template
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/2.convert-to-bridge.yaml-template
@@ -1,0 +1,87 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# One-shot pod: convert HuggingFace safetensors to Megatron-Bridge distributed
+# checkpoint format. Runs on a single GPU node via torchrun with the same
+# TP/PP/EP sharding the training job will use, so the output shard layout
+# matches exactly.
+#
+# This is a one-time cost per (model, parallelism-config) pair — subsequent
+# training runs reuse the output.
+#
+# Required env vars: NAMESPACE, IMAGE, NODE_INSTANCE_TYPE, GPU_PER_NODE,
+#                    EFA_PER_NODE, HF_MODEL_ID, TP, PP, EP
+apiVersion: v1
+kind: Pod
+metadata:
+  name: qwen-convert-to-bridge
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    node.kubernetes.io/instance-type: ${NODE_INSTANCE_TYPE}
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: convert
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          set -ex
+          HF_LOCAL="/fsx/hf_cache/models--$(echo ${HF_MODEL_ID} | tr '/' '-' | sed 's/-/--/')"
+          test -d "${HF_LOCAL}" || HF_LOCAL="${HF_MODEL_ID}"
+          mkdir -p /fsx/qwen36-bridge
+
+          if [ -f /fsx/qwen36-bridge/.done ]; then
+            echo "Bridge checkpoint already present; skipping conversion."
+            exit 0
+          fi
+          rm -rf /fsx/qwen36-bridge/*
+
+          cd /opt/Megatron-Bridge
+          torchrun --nproc_per_node=${GPU_PER_NODE} \
+            examples/conversion/convert_checkpoints_multi_gpu.py import \
+              --hf-model "${HF_LOCAL}" \
+              --megatron-path /fsx/qwen36-bridge \
+              --tp ${TP} --pp ${PP} --ep ${EP} \
+              --torch-dtype bfloat16 \
+              2>&1 | tee /fsx/qwen36-bridge/convert.log
+
+          touch /fsx/qwen36-bridge/.done
+          echo "Conversion complete:"
+          du -sh /fsx/qwen36-bridge
+      env:
+        - { name: HF_MODEL_ID,           value: "${HF_MODEL_ID}" }
+        - { name: NCCL_DEBUG,            value: WARN }
+        - { name: NCCL_SOCKET_IFNAME,    value: "^lo" }
+        - { name: FI_PROVIDER,           value: efa }
+        - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+        - { name: FI_EFA_FORK_SAFE,      value: "1" }
+        - { name: PYTHONUNBUFFERED,      value: "1" }
+      resources:
+        limits:
+          nvidia.com/gpu: "${GPU_PER_NODE}"
+          vpc.amazonaws.com/efa: "${EFA_PER_NODE}"
+          cpu: "90"
+          memory: 1500Gi
+        requests:
+          nvidia.com/gpu: "${GPU_PER_NODE}"
+          vpc.amazonaws.com/efa: "${EFA_PER_NODE}"
+          cpu: "90"
+          memory: 1500Gi
+      volumeMounts:
+        - { name: lustre, mountPath: /fsx }
+        - { name: shm,    mountPath: /dev/shm }
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK"]
+  volumes:
+    - name: lustre
+      persistentVolumeClaim:
+        claimName: qwen-moe-lustre
+    - name: shm
+      emptyDir:
+        medium: Memory
+        sizeLimit: 128Gi

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/3.pytorchjob-train.yaml-template
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/3.pytorchjob-train.yaml-template
@@ -1,0 +1,110 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# PyTorchJob for Qwen3.6-35B-A3B xLAM function-calling LoRA.
+#
+# Parallelism (set via env vars, matching the base checkpoint sharding from
+# 2.convert-to-bridge.yaml-template):
+#   TP=2, PP=1, EP=4, DP=NUM_NODES*GPU_PER_NODE/(TP*PP*EP)
+#
+# Required env vars: NAMESPACE, IMAGE, NODE_INSTANCE_TYPE, NUM_NODES,
+#                    GPU_PER_NODE, EFA_PER_NODE, CONFIG_MAP, HF_MODEL_ID, TP,
+#                    PP, EP, TRAIN_ITERS, GLOBAL_BS, MICRO_BS
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: qwen36-xlam-train
+  namespace: ${NAMESPACE}
+spec:
+  nprocPerNode: "${GPU_PER_NODE}"
+  elasticPolicy:
+    rdzvBackend: c10d
+    minReplicas: ${NUM_NODES}
+    maxReplicas: ${NUM_NODES}
+    maxRestarts: 0
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: ${NUM_NODES}
+      restartPolicy: OnFailure
+      template:
+        spec:
+          hostIPC: true
+          nodeSelector:
+            node.kubernetes.io/instance-type: ${NODE_INSTANCE_TYPE}
+          tolerations:
+            - operator: Exists
+          containers:
+            - name: pytorch
+              image: ${IMAGE}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/bash", "-lc"]
+              args:
+                - |
+                  set -ex
+                  python -c 'from megatron.core import __version__ as v; assert v >= "0.13", f"megatron-core >= 0.13 required, got {v}"'
+                  test -f /fsx/datasets/training.jsonl
+                  test -f /fsx/datasets/validation.jsonl
+                  test -f /fsx/qwen36-bridge/.done
+                  mkdir -p /fsx/qwen36-xlam-runs/checkpoints
+
+                  cd /opt/Megatron-Bridge
+                  torchrun \
+                    --nproc_per_node=${GPU_PER_NODE} \
+                    --nnodes=${PET_NNODES} \
+                    --node_rank=${PET_NODE_RANK} \
+                    --master_addr=${MASTER_ADDR} \
+                    --master_port=${MASTER_PORT} \
+                    /config/xlam_runner.py \
+                    2>&1 | tee -a /fsx/qwen36-xlam-runs/train.log
+              env:
+                # Training hyperparams (consumed by xlam_runner.py)
+                - { name: HF_MODEL_ID,          value: "${HF_MODEL_ID}" }
+                - { name: TOKENIZER_PATH,       value: "/fsx/hf_cache/models--Qwen--Qwen3.6-35B-A3B" }
+                - { name: DATASET_ROOT,         value: "/fsx/datasets" }
+                - { name: PRETRAINED_CHECKPOINT, value: "/fsx/qwen36-bridge" }
+                - { name: CHECKPOINT_SAVE_DIR,  value: "/fsx/qwen36-xlam-runs/checkpoints" }
+                - { name: TRAIN_ITERS,          value: "${TRAIN_ITERS}" }
+                - { name: GLOBAL_BS,            value: "${GLOBAL_BS}" }
+                - { name: MICRO_BS,             value: "${MICRO_BS}" }
+                # NCCL / EFA
+                - { name: NCCL_DEBUG,            value: WARN }
+                - { name: NCCL_SOCKET_IFNAME,    value: "^lo" }
+                - { name: FI_PROVIDER,           value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE,      value: "1" }
+                - { name: NCCL_BUFFSIZE,         value: "8388608" }
+                - { name: NCCL_NET_GDR_LEVEL,    value: PHB }
+                # HF cache on shared Lustre
+                - { name: HF_HOME,               value: /fsx/hf_cache }
+                - { name: TRANSFORMERS_CACHE,    value: /fsx/hf_cache }
+                - { name: PYTORCH_CUDA_ALLOC_CONF, value: "expandable_segments:True,max_split_size_mb:512" }
+                - { name: PYTHONUNBUFFERED,      value: "1" }
+              resources:
+                limits:
+                  nvidia.com/gpu: "${GPU_PER_NODE}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_NODE}"
+                  cpu: "90"
+                  memory: 1500Gi
+                requests:
+                  nvidia.com/gpu: "${GPU_PER_NODE}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_NODE}"
+                  cpu: "90"
+                  memory: 1500Gi
+              volumeMounts:
+                - { name: lustre, mountPath: /fsx }
+                - { name: shm,    mountPath: /dev/shm }
+                - { name: config, mountPath: /config }
+              securityContext:
+                capabilities:
+                  add: ["IPC_LOCK"]
+          volumes:
+            - name: lustre
+              persistentVolumeClaim:
+                claimName: qwen-moe-lustre
+            - name: shm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 128Gi
+            - name: config
+              configMap:
+                name: ${CONFIG_MAP}

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/4.export-adapter.yaml-template
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/4.export-adapter.yaml-template
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# One-shot pod: convert the distributed LoRA checkpoint produced by training
+# to HuggingFace PEFT format (adapter_config.json + adapter_model.safetensors).
+#
+# Output at /fsx/qwen36-xlam-runs/adapter_hf is directly loadable by
+# `peft.PeftModel.from_pretrained(...)` and by vLLM via --lora-modules.
+#
+# Required env vars: NAMESPACE, IMAGE, NODE_INSTANCE_TYPE, GPU_PER_NODE,
+#                    EFA_PER_NODE, CONFIG_MAP, HF_MODEL_ID, ITER, TP, PP, EP
+apiVersion: v1
+kind: Pod
+metadata:
+  name: qwen-export-adapter
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    node.kubernetes.io/instance-type: ${NODE_INSTANCE_TYPE}
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: export
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          set -ex
+          CKPT=$(ls -d /fsx/qwen36-xlam-runs/checkpoints/iter_${ITER} 2>/dev/null \
+                 || ls -d /fsx/qwen36-xlam-runs/checkpoints/iter_* | sort | tail -1)
+          echo "LoRA checkpoint: $CKPT"
+          mkdir -p /fsx/qwen36-xlam-runs/adapter_hf
+
+          cd /opt/Megatron-Bridge
+          torchrun --nproc_per_node=${GPU_PER_NODE} /config/export_lora_adapter.py \
+            --lora-checkpoint  "$CKPT" \
+            --hf-model         ${HF_MODEL_ID} \
+            --output           /fsx/qwen36-xlam-runs/adapter_hf \
+            --base-checkpoint  /fsx/qwen36-bridge \
+            --tp ${TP} --pp ${PP} --ep ${EP} \
+            2>&1 | tee /fsx/qwen36-xlam-runs/export.log
+
+          echo "Adapter written:"
+          ls -la /fsx/qwen36-xlam-runs/adapter_hf
+      env:
+        - { name: HF_MODEL_ID,           value: "${HF_MODEL_ID}" }
+        - { name: ITER,                  value: "${ITER}" }
+        - { name: NCCL_DEBUG,            value: WARN }
+        - { name: NCCL_SOCKET_IFNAME,    value: "^lo" }
+        - { name: FI_PROVIDER,           value: efa }
+        - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+        - { name: HF_HOME,               value: /fsx/hf_cache }
+        - { name: TRANSFORMERS_CACHE,    value: /fsx/hf_cache }
+        - { name: PYTHONUNBUFFERED,      value: "1" }
+      resources:
+        limits:
+          nvidia.com/gpu: "${GPU_PER_NODE}"
+          vpc.amazonaws.com/efa: "${EFA_PER_NODE}"
+          cpu: "90"
+          memory: 1500Gi
+        requests:
+          nvidia.com/gpu: "${GPU_PER_NODE}"
+          vpc.amazonaws.com/efa: "${EFA_PER_NODE}"
+          cpu: "90"
+          memory: 1500Gi
+      volumeMounts:
+        - { name: lustre, mountPath: /fsx }
+        - { name: shm,    mountPath: /dev/shm }
+        - { name: config, mountPath: /config }
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK"]
+  volumes:
+    - name: lustre
+      persistentVolumeClaim:
+        claimName: qwen-moe-lustre
+    - name: shm
+      emptyDir:
+        medium: Memory
+        sizeLimit: 128Gi
+    - name: config
+      configMap:
+        name: ${CONFIG_MAP}

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/5.inference-vllm.yaml-template
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/5.inference-vllm.yaml-template
@@ -1,0 +1,109 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# vLLM inference Deployment serving the base model with the fine-tuned adapter
+# hot-loaded under the alias "tools". Exposes an OpenAI-compatible
+# /v1/chat/completions API. Fronted by a ClusterIP Service for in-cluster
+# evaluation.
+#
+# The LoRA adapter can come from either:
+#   1. The local Lustre export at /fsx/qwen36-xlam-runs/adapter_hf, or
+#   2. A published HuggingFace repo (set LORA_SOURCE=hf, LORA_REPO=...)
+#
+# Required env vars: NAMESPACE, NODE_INSTANCE_TYPE, VLLM_IMAGE, HF_MODEL_ID,
+#                    LORA_SOURCE (=local|hf), LORA_REPO, TP
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen-inference
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qwen-inference
+  template:
+    metadata:
+      labels:
+        app: qwen-inference
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: ${NODE_INSTANCE_TYPE}
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: vllm
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -ex
+              if [ "${LORA_SOURCE}" = "local" ]; then
+                LORA_PATH=/fsx/qwen36-xlam-runs/adapter_hf
+                test -d "$LORA_PATH" || { echo "Adapter missing at $LORA_PATH"; exit 1; }
+              else
+                LORA_PATH=${LORA_REPO}
+              fi
+              echo "Serving adapter: $LORA_PATH"
+              exec vllm serve ${HF_MODEL_ID} \
+                --enable-lora \
+                --lora-modules tools=$LORA_PATH \
+                --max-loras 1 --max-lora-rank 64 \
+                --tensor-parallel-size ${TP} \
+                --gpu-memory-utilization 0.90 \
+                --max-model-len 4096 \
+                --enable-auto-tool-choice \
+                --tool-call-parser hermes \
+                --port 8000
+          env:
+            - { name: HF_MODEL_ID,                value: "${HF_MODEL_ID}" }
+            - { name: LORA_SOURCE,                value: "${LORA_SOURCE}" }
+            - { name: LORA_REPO,                  value: "${LORA_REPO}" }
+            - { name: HF_HOME,                    value: /fsx/hf_cache }
+            - { name: TRANSFORMERS_CACHE,         value: /fsx/hf_cache }
+            - { name: VLLM_WORKER_MULTIPROC_METHOD, value: spawn }
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            initialDelaySeconds: 300
+            periodSeconds: 15
+            failureThreshold: 40
+          resources:
+            limits:
+              nvidia.com/gpu: "${TP}"
+              cpu: "16"
+              memory: 128Gi
+            requests:
+              nvidia.com/gpu: "${TP}"
+              cpu: "16"
+              memory: 128Gi
+          volumeMounts:
+            - { name: lustre, mountPath: /fsx }
+            - { name: shm,    mountPath: /dev/shm }
+      volumes:
+        - name: lustre
+          persistentVolumeClaim:
+            claimName: qwen-moe-lustre
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen-inference
+  namespace: ${NAMESPACE}
+spec:
+  type: ClusterIP
+  selector:
+    app: qwen-inference
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/6.eval-job.yaml-template
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/6.eval-job.yaml-template
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Evaluation Job: runs Gate 1 (10 hand-crafted prompts) and optionally Gate 2
+# (50 xLAM validation prompts judged by Claude Opus 4.7 via Bedrock). Writes a
+# summary to stdout; captured via `kubectl logs`.
+#
+# Gate 2 requires AWS credentials resolvable by boto3. On HyperPod EKS, the
+# preferred path is IRSA (annotate this Job's ServiceAccount with the IAM role
+# that has bedrock:InvokeModel on the Claude Opus 4.7 profile). On a laptop,
+# use AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars on this Job.
+#
+# Required env vars: NAMESPACE, IMAGE, NODE_INSTANCE_TYPE, CONFIG_MAP,
+#                    HF_MODEL_ID, GATE, N_SAMPLES, BEDROCK_REGION, JUDGE_MODEL
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: qwen-eval
+  namespace: ${NAMESPACE}
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        node.kubernetes.io/instance-type: ${NODE_INSTANCE_TYPE}
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: eval
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -ex
+              pip install --quiet "boto3>=1.35,<2.0" "requests>=2.31,<3.0"
+              python /config/eval_function_calling.py \
+                --endpoint http://qwen-inference.${NAMESPACE}.svc.cluster.local:8000 \
+                --base-model ${HF_MODEL_ID} \
+                --lora-alias tools \
+                --gate ${GATE} \
+                --val-file /fsx/datasets/validation.jsonl \
+                --n ${N_SAMPLES} \
+                --bedrock-region ${BEDROCK_REGION} \
+                --judge-model ${JUDGE_MODEL}
+          env:
+            - { name: NAMESPACE,       value: "${NAMESPACE}" }
+            - { name: HF_MODEL_ID,     value: "${HF_MODEL_ID}" }
+            - { name: GATE,            value: "${GATE}" }
+            - { name: N_SAMPLES,       value: "${N_SAMPLES}" }
+            - { name: BEDROCK_REGION,  value: "${BEDROCK_REGION}" }
+            - { name: JUDGE_MODEL,     value: "${JUDGE_MODEL}" }
+            - { name: PYTHONUNBUFFERED, value: "1" }
+          resources:
+            limits:
+              cpu: "2"
+              memory: 8Gi
+            requests:
+              cpu: "1"
+              memory: 4Gi
+          volumeMounts:
+            - { name: lustre, mountPath: /fsx }
+            - { name: config, mountPath: /config }
+      volumes:
+        - name: lustre
+          persistentVolumeClaim:
+            claimName: qwen-moe-lustre
+        - name: config
+          configMap:
+            name: ${CONFIG_MAP}

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/storage.yaml-template
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/manifests/storage.yaml-template
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# FSx for Lustre 2.15 PVC for model weights, dataset, checkpoints, and adapter.
+#
+# Why explicit 2.15: The FSx CSI driver defaults to filesystem version 2.10,
+# which is incompatible with the Lustre 2.15.6 client bundled in the p5e AMI.
+# Mounting a 2.10 server with a 2.15 client fails with
+#   "Server MGS version (2.10.5.0) refused connection from this client
+#    with an incompatible version (2.15.6)"
+# surfaced only in kernel dmesg; the mount exits with a generic EINVAL.
+#
+# Required env vars:
+#   NAMESPACE           Kubernetes namespace (this file's target)
+#   FSX_SUBNET_ID       Subnet in the same AZ as your HyperPod GPU nodes
+#   FSX_SECURITY_GROUP  SG with Lustre ports (988 + 1021-1023 TCP) open to itself
+#   FSX_SIZE_GB         Filesystem size (minimum 1200)
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fsx-sc-215-${NAMESPACE}
+parameters:
+  deploymentType: SCRATCH_2
+  fileSystemTypeVersion: "2.15"
+  securityGroupIds: ${FSX_SECURITY_GROUP}
+  storageType: SSD
+  subnetId: ${FSX_SUBNET_ID}
+provisioner: fsx.csi.aws.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen-moe-lustre
+  namespace: ${NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fsx-sc-215-${NAMESPACE}
+  resources:
+    requests:
+      storage: ${FSX_SIZE_GB}Gi

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/0.setup-storage.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/0.setup-storage.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Creates the FSx for Lustre StorageClass (version 2.15) and the shared PVC used
+# by every subsequent step. Also creates a ConfigMap holding our Python scripts
+# so training / eval pods can mount them.
+#
+# Prerequisite: env.sh sourced.
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+: "${FSX_SUBNET_ID:?}"
+: "${FSX_SECURITY_GROUP:?}"
+: "${FSX_SIZE_GB:?}"
+: "${CONFIG_MAP:?}"
+
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+envsubst '$NAMESPACE $FSX_SUBNET_ID $FSX_SECURITY_GROUP $FSX_SIZE_GB' \
+  < "$HERE/kubernetes/manifests/storage.yaml-template" | kubectl apply -f -
+
+kubectl -n "$NAMESPACE" create configmap "$CONFIG_MAP" \
+  --from-file="$HERE/src/xlam_runner.py" \
+  --from-file="$HERE/src/export_lora_adapter.py" \
+  --from-file="$HERE/src/prep_xlam_dataset.py" \
+  --from-file="$HERE/src/eval_function_calling.py" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Waiting for PVC qwen-moe-lustre to be Bound (this takes 10-15 min for FSx)..."
+kubectl -n "$NAMESPACE" wait --for=jsonpath='{.status.phase}'=Bound \
+  pvc/qwen-moe-lustre --timeout=20m
+echo "Storage ready."

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/1.precache-weights.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/1.precache-weights.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+: "${IMAGE:?}"
+: "${HF_MODEL_ID:?}"
+: "${NODE_INSTANCE_TYPE:?}"
+: "${HF_TOKEN_SECRET:=hf-token}"
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+
+envsubst '$NAMESPACE $IMAGE $HF_MODEL_ID $NODE_INSTANCE_TYPE $HF_TOKEN_SECRET' \
+  < "$HERE/kubernetes/manifests/0.precache-weights.yaml-template" | kubectl apply -f -
+
+echo "Precache submitted. Watch:"
+echo "  kubectl -n $NAMESPACE logs -f qwen-precache-weights"

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/2.prep-dataset.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/2.prep-dataset.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+: "${IMAGE:?}"
+: "${NODE_INSTANCE_TYPE:?}"
+: "${CONFIG_MAP:?}"
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+
+envsubst '$NAMESPACE $IMAGE $NODE_INSTANCE_TYPE $CONFIG_MAP' \
+  < "$HERE/kubernetes/manifests/1.prep-dataset.yaml-template" | kubectl apply -f -
+
+echo "Dataset prep submitted. Watch:"
+echo "  kubectl -n $NAMESPACE logs -f qwen-prep-xlam"

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/3.convert-to-bridge.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/3.convert-to-bridge.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+: "${IMAGE:?}"
+: "${NODE_INSTANCE_TYPE:?}"
+: "${GPU_PER_NODE:?}"
+: "${EFA_PER_NODE:?}"
+: "${HF_MODEL_ID:?}"
+: "${TP:?}"; : "${PP:?}"; : "${EP:?}"
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+
+envsubst '$NAMESPACE $IMAGE $NODE_INSTANCE_TYPE $GPU_PER_NODE $EFA_PER_NODE $HF_MODEL_ID $TP $PP $EP' \
+  < "$HERE/kubernetes/manifests/2.convert-to-bridge.yaml-template" | kubectl apply -f -
+
+echo "Conversion submitted. Watch:"
+echo "  kubectl -n $NAMESPACE logs -f qwen-convert-to-bridge"

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/4.train.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/4.train.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+: "${IMAGE:?}"
+: "${NODE_INSTANCE_TYPE:?}"
+: "${NUM_NODES:?}"; : "${GPU_PER_NODE:?}"; : "${EFA_PER_NODE:?}"
+: "${CONFIG_MAP:?}"
+: "${HF_MODEL_ID:?}"
+: "${TP:?}"; : "${PP:?}"; : "${EP:?}"
+: "${TRAIN_ITERS:?}"; : "${GLOBAL_BS:?}"; : "${MICRO_BS:?}"
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+
+# Re-create the ConfigMap to pick up any local edits to src/ since setup.
+kubectl -n "$NAMESPACE" create configmap "$CONFIG_MAP" \
+  --from-file="$HERE/src/xlam_runner.py" \
+  --from-file="$HERE/src/export_lora_adapter.py" \
+  --from-file="$HERE/src/prep_xlam_dataset.py" \
+  --from-file="$HERE/src/eval_function_calling.py" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+envsubst '$NAMESPACE $IMAGE $NODE_INSTANCE_TYPE $NUM_NODES $GPU_PER_NODE $EFA_PER_NODE $CONFIG_MAP $HF_MODEL_ID $TP $PP $EP $TRAIN_ITERS $GLOBAL_BS $MICRO_BS' \
+  < "$HERE/kubernetes/manifests/3.pytorchjob-train.yaml-template" | kubectl apply -f -
+
+echo "Training submitted. Watch:"
+echo "  kubectl -n $NAMESPACE get pytorchjob"
+echo "  kubectl -n $NAMESPACE logs -f qwen36-xlam-train-worker-0"

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/5.export-adapter.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/5.export-adapter.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+: "${IMAGE:?}"
+: "${NODE_INSTANCE_TYPE:?}"
+: "${GPU_PER_NODE:?}"; : "${EFA_PER_NODE:?}"
+: "${CONFIG_MAP:?}"
+: "${HF_MODEL_ID:?}"
+: "${ITER:?}"
+: "${TP:?}"; : "${PP:?}"; : "${EP:?}"
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+
+envsubst '$NAMESPACE $IMAGE $NODE_INSTANCE_TYPE $GPU_PER_NODE $EFA_PER_NODE $CONFIG_MAP $HF_MODEL_ID $ITER $TP $PP $EP' \
+  < "$HERE/kubernetes/manifests/4.export-adapter.yaml-template" | kubectl apply -f -
+
+echo "Adapter export submitted. Watch:"
+echo "  kubectl -n $NAMESPACE logs -f qwen-export-adapter"

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/6.deploy-inference.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/6.deploy-inference.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+: "${VLLM_IMAGE:?}"
+: "${NODE_INSTANCE_TYPE:?}"
+: "${HF_MODEL_ID:?}"
+: "${LORA_SOURCE:?}"
+: "${LORA_REPO:?}"
+: "${TP:?}"
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+
+envsubst '$NAMESPACE $VLLM_IMAGE $NODE_INSTANCE_TYPE $HF_MODEL_ID $LORA_SOURCE $LORA_REPO $TP' \
+  < "$HERE/kubernetes/manifests/5.inference-vllm.yaml-template" | kubectl apply -f -
+
+echo "vLLM deployment submitted. Wait for Ready:"
+echo "  kubectl -n $NAMESPACE rollout status deployment/qwen-inference --timeout=15m"
+echo "Then the endpoint is:"
+echo "  http://qwen-inference.$NAMESPACE.svc.cluster.local:8000"

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/7.run-eval.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/7.run-eval.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+: "${IMAGE:?}"
+: "${NODE_INSTANCE_TYPE:?}"
+: "${CONFIG_MAP:?}"
+: "${HF_MODEL_ID:?}"
+: "${GATE:?}"
+: "${N_SAMPLES:?}"
+: "${BEDROCK_REGION:?}"
+: "${JUDGE_MODEL:?}"
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+
+# Delete any prior Job with the same name (Jobs are immutable on spec).
+kubectl -n "$NAMESPACE" delete job qwen-eval --ignore-not-found --wait=true >/dev/null
+
+envsubst '$NAMESPACE $IMAGE $NODE_INSTANCE_TYPE $CONFIG_MAP $HF_MODEL_ID $GATE $N_SAMPLES $BEDROCK_REGION $JUDGE_MODEL' \
+  < "$HERE/kubernetes/manifests/6.eval-job.yaml-template" | kubectl apply -f -
+
+echo "Eval Job submitted. Watch:"
+echo "  kubectl -n $NAMESPACE logs -f job/qwen-eval"

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/cleanup.sh
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/cleanup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Tears down every Kubernetes resource created by this test case. Preserves the
+# FSx Lustre PVC so the weights + dataset + adapter persist (delete manually if
+# you want the underlying filesystem to be deleted too).
+set -euo pipefail
+: "${NAMESPACE:?source scripts/env.sh first}"
+
+kubectl -n "$NAMESPACE" delete deployment,service qwen-inference --ignore-not-found --wait=false
+kubectl -n "$NAMESPACE" delete pytorchjob qwen36-xlam-train --ignore-not-found
+kubectl -n "$NAMESPACE" delete job qwen-eval --ignore-not-found
+kubectl -n "$NAMESPACE" delete pod \
+  qwen-precache-weights \
+  qwen-prep-xlam \
+  qwen-convert-to-bridge \
+  qwen-export-adapter \
+  --ignore-not-found
+
+echo "Stateless resources removed. PVC qwen-moe-lustre retained."
+echo "To also delete persistent data:"
+echo "  kubectl -n $NAMESPACE delete pvc qwen-moe-lustre"

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/env.example
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/kubernetes/scripts/env.example
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Copy to env.sh, fill in values, and `source env.sh` before running numbered
+# scripts. env.sh is .gitignore'd so credentials don't get committed.
+
+# Kubernetes namespace for this test case. Create it first:
+#   kubectl create namespace qwen36-moe-lora
+export NAMESPACE=qwen36-moe-lora
+
+# FSx Lustre (only needed for 0.setup-storage.sh)
+export FSX_SUBNET_ID=subnet-EXAMPLEabc12345       # must be in same AZ as GPU nodes
+export FSX_SECURITY_GROUP=sg-EXAMPLEabc12345      # must allow Lustre 988 + 1021-1023 TCP
+export FSX_SIZE_GB=1200                           # minimum; bump for larger datasets/checkpoints
+
+# Compute
+export NODE_INSTANCE_TYPE=ml.p5e.48xlarge         # or ml.p5.48xlarge, ml.p4de.24xlarge
+export NUM_NODES=2
+export GPU_PER_NODE=8
+export EFA_PER_NODE=32                            # 32 on p5e; 4 on p5; check `kubectl describe node`
+
+# Parallelism (must match across convert, train, and export steps)
+export TP=2
+export PP=1
+export EP=4
+
+# Model + training
+export HF_MODEL_ID="Qwen/Qwen3.6-35B-A3B"
+export TRAIN_ITERS=4200
+export GLOBAL_BS=48
+export MICRO_BS=3
+
+# Container images — PIN explicit tags, never :latest
+export IMAGE=nvcr.io/nvidia/nemo:26.04            # ships Megatron-Bridge 0.4.0rc0
+export VLLM_IMAGE=vllm/vllm-openai:v0.10.2        # last verified with Qwen3.6 tool-calling; newer versions may work
+
+# Inference
+export LORA_SOURCE=local                          # 'local' (Lustre) or 'hf' (HuggingFace Hub)
+export LORA_REPO=ying2022/qwen3-6-35b-xlam-tools-lora  # used when LORA_SOURCE=hf
+
+# Export-adapter iteration to materialize (default: last)
+export ITER=0004200
+
+# Eval
+export GATE=1                                     # 1 | 2 | all
+export N_SAMPLES=50                               # only used by Gate 2
+export BEDROCK_REGION=us-west-2
+export JUDGE_MODEL=us.anthropic.claude-opus-4-7
+
+# Optional: HuggingFace token Secret for gated models (create beforehand:
+#   kubectl -n $NAMESPACE create secret generic hf-token --from-literal=token=hf_...)
+export HF_TOKEN_SECRET=hf-token
+
+# Derived — do not edit
+export CONFIG_MAP=qwen36-moe-lora-config

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/__init__.py
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/eval_function_calling.py
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/eval_function_calling.py
@@ -1,0 +1,374 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Two-gate evaluation of a deployed Qwen3.6-35B xLAM LoRA vs its base.
+
+Gate 1  — 10 hand-crafted prompts covering function-calling edge cases (single
+          tool, nested objects, enums, multi-tool, array args, typed args,
+          ambiguous "no tool"). Passes if predicted tool name matches expected
+          AND the call is parseable.
+
+Gate 2  — 50 held-out xLAM validation prompts scored by Claude Opus 4.7 as an
+          LLM-as-judge. Position-randomized A/B presentation to remove bias.
+
+Usage:
+    python eval_function_calling.py \\
+        --endpoint http://qwen-inference.qwen-moe-lora.svc.cluster.local:8000 \\
+        --base-model Qwen/Qwen3.6-35B-A3B \\
+        --lora-alias tools \\
+        --val-file /fsx/datasets/validation.jsonl \\
+        --gate 1
+    python eval_function_calling.py --gate 2 --val-file ... --n 50
+    python eval_function_calling.py --gate all ...
+
+Gate 2 requires AWS credentials resolvable via boto3's default chain (IRSA on the
+pod's ServiceAccount, or AWS_* env vars), and bedrock:InvokeModel on the Claude
+Opus 4.7 inference profile in the chosen region.
+"""
+import argparse
+import json
+import random
+import re
+from typing import Any
+
+import requests
+
+
+# ---------------------------------------------------------------------------
+# Tool-call output parser — Qwen3+ family emits Qwen-Agent XML form:
+#   <tool_call><function=name><parameter=key>value</parameter>...</function></tool_call>
+# vLLM's built-in --tool-call-parser hermes expects JSON-in-XML instead, so we
+# parse the XML ourselves rather than relying on msg.tool_calls being populated.
+# ---------------------------------------------------------------------------
+_TOOL_CALL_RE = re.compile(r"<function=(\w+)>(.*?)</function>", re.S)
+_PARAM_RE = re.compile(r"<parameter=(\w+)>\s*(.*?)\s*</parameter>", re.S)
+
+
+def parse_qwen_tool_call(content: str) -> dict | None:
+    if not content or "<tool_call>" not in content:
+        return None
+    m = _TOOL_CALL_RE.search(content)
+    if not m:
+        return None
+    name = m.group(1)
+    args: dict[str, Any] = {}
+    for pm in _PARAM_RE.finditer(m.group(2)):
+        k, v = pm.group(1), pm.group(2).strip()
+        # best-effort type coercion
+        try:
+            args[k] = int(v)
+            continue
+        except ValueError:
+            pass
+        try:
+            args[k] = float(v)
+            continue
+        except ValueError:
+            pass
+        if v.lower() == "true":
+            args[k] = True
+        elif v.lower() == "false":
+            args[k] = False
+        else:
+            args[k] = v
+    return {"name": name, "arguments": args}
+
+
+def chat_tools(endpoint: str, model: str, messages: list, tools: list | None = None,
+               max_tokens: int = 512, timeout: int = 180) -> dict:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.1,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    if tools is not None:
+        payload["tools"] = tools
+        payload["tool_choice"] = "auto"
+    r = requests.post(
+        f"{endpoint}/v1/chat/completions",
+        json=payload,
+        timeout=timeout,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def score_response(resp: dict, expected_tool: str | None) -> dict:
+    msg = resp["choices"][0]["message"]
+    calls = msg.get("tool_calls") or []
+    name = None
+    args: dict = {}
+    if calls:
+        name = calls[0].get("function", {}).get("name")
+        try:
+            args = json.loads(calls[0].get("function", {}).get("arguments", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            args = {}
+    else:
+        parsed = parse_qwen_tool_call(msg.get("content", "") or "")
+        if parsed:
+            name = parsed["name"]
+            args = parsed["arguments"]
+
+    if name is None:
+        return {"valid": True,
+                "right_name": expected_tool is None,
+                "has_args": expected_tool is None}
+    return {"valid": True,
+            "right_name": name == expected_tool,
+            "has_args": bool(args)}
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — hand-crafted edge-case prompts
+# ---------------------------------------------------------------------------
+GATE1_PROMPTS = [
+    ("Simple single tool",
+     [{"type": "function", "function": {"name": "search_flights", "description": "Search flights",
+        "parameters": {"type": "object",
+            "properties": {"origin": {"type": "string"}, "destination": {"type": "string"},
+                           "departure_date": {"type": "string"}, "passengers": {"type": "integer"}},
+            "required": ["origin", "destination", "departure_date"]}}}],
+     "Find flights from JFK to SFO on 2026-05-10 for 2 passengers.",
+     "search_flights"),
+    ("camelCase schema",
+     [{"type": "function", "function": {"name": "getUserProfile", "description": "Fetch user profile",
+        "parameters": {"type": "object",
+            "properties": {"userId": {"type": "integer"}, "includeOrders": {"type": "boolean"}},
+            "required": ["userId"]}}}],
+     "Get the profile for user 42 and include their orders.",
+     "getUserProfile"),
+    ("Nested object",
+     [{"type": "function", "function": {"name": "create_event", "description": "Create calendar event",
+        "parameters": {"type": "object",
+            "properties": {"title": {"type": "string"},
+                           "time": {"type": "object",
+                                    "properties": {"start": {"type": "string"},
+                                                   "end": {"type": "string"}},
+                                    "required": ["start", "end"]}},
+            "required": ["title", "time"]}}}],
+     'Schedule a meeting "Team sync" from 2026-05-12T10:00 to 11:00.',
+     "create_event"),
+    ("Enum argument",
+     [{"type": "function", "function": {"name": "get_weather", "description": "Get weather",
+        "parameters": {"type": "object",
+            "properties": {"location": {"type": "string"},
+                           "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}},
+            "required": ["location"]}}}],
+     "What is the weather in Seattle in fahrenheit?",
+     "get_weather"),
+    ("Multi-tool required",
+     [{"type": "function", "function": {"name": "search_flights",
+        "parameters": {"type": "object",
+            "properties": {"origin": {"type": "string"}, "destination": {"type": "string"},
+                           "departure_date": {"type": "string"}},
+            "required": ["origin", "destination", "departure_date"]}}},
+      {"type": "function", "function": {"name": "book_hotel",
+        "parameters": {"type": "object",
+            "properties": {"city": {"type": "string"}, "nights": {"type": "integer"}},
+            "required": ["city", "nights"]}}}],
+     "Book me a flight from JFK to SFO on 2026-05-10 and a 3-night hotel in San Francisco.",
+     "search_flights"),
+    ("Array argument",
+     [{"type": "function", "function": {"name": "send_emails",
+        "parameters": {"type": "object",
+            "properties": {"recipients": {"type": "array", "items": {"type": "string"}},
+                           "subject": {"type": "string"}, "body": {"type": "string"}},
+            "required": ["recipients", "subject", "body"]}}}],
+     'Email alice@x.com and bob@y.com with subject "Meeting" and body "Tomorrow 10am".',
+     "send_emails"),
+    ("Integer type",
+     [{"type": "function", "function": {"name": "cart_add",
+        "parameters": {"type": "object",
+            "properties": {"sku": {"type": "string"},
+                           "quantity": {"type": "integer", "minimum": 1}},
+            "required": ["sku", "quantity"]}}}],
+     "Add 3 of item ABC-123 to the cart.",
+     "cart_add"),
+    ("Boolean flag",
+     [{"type": "function", "function": {"name": "subscribe",
+        "parameters": {"type": "object",
+            "properties": {"email": {"type": "string"},
+                           "marketing_consent": {"type": "boolean"}},
+            "required": ["email"]}}}],
+     "Subscribe user@example.com, they have consented to marketing.",
+     "subscribe"),
+    ("Ambiguous - no tool",
+     [{"type": "function", "function": {"name": "play_music",
+        "parameters": {"type": "object",
+            "properties": {"song": {"type": "string"}},
+            "required": ["song"]}}}],
+     "What is the capital of France?",
+     None),
+    ("Decimal + currency",
+     [{"type": "function", "function": {"name": "transfer",
+        "parameters": {"type": "object",
+            "properties": {"from": {"type": "string"}, "to": {"type": "string"},
+                           "amount": {"type": "number"}, "currency": {"type": "string"}},
+            "required": ["from", "to", "amount", "currency"]}}}],
+     "Transfer $1,234.56 from acct-A to acct-B.",
+     "transfer"),
+]
+
+
+def run_gate_1(endpoint: str, model: str) -> tuple[int, list]:
+    results = []
+    passed = 0
+    for i, (desc, tools, user, expected) in enumerate(GATE1_PROMPTS, 1):
+        try:
+            resp = chat_tools(endpoint, model, [{"role": "user", "content": user}], tools=tools)
+            s = score_response(resp, expected)
+            ok = s["valid"] and s["right_name"]
+            err = ""
+        except Exception as e:
+            s = {"valid": False, "right_name": False, "has_args": False}
+            ok = False
+            err = f"  ERR: {type(e).__name__}: {str(e)[:80]}"
+        if ok:
+            passed += 1
+        results.append({"idx": i, "desc": desc, "passed": ok, **s})
+        print(f"  [{model[:24]:<24}] {i:2d} {desc[:30]:<30}  pass={ok}  right_name={s['right_name']}{err}")
+    return passed, results
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — LLM-as-judge via Bedrock
+# ---------------------------------------------------------------------------
+JUDGE_PROMPT_TEMPLATE = (
+    "You are an impartial judge of function-calling quality. The user prompt "
+    "includes tool schemas and a user request. Compare two model outputs on: "
+    "(1) valid JSON / valid tool-call format, (2) correct tool name and args, "
+    "(3) no extraneous prose. Respond with EXACTLY one token: A, B, or TIE. "
+    "No explanation.\n\n"
+    "USER PROMPT:\n{user}\n\n"
+    "OUTPUT A:\n{a}\n\n"
+    "OUTPUT B:\n{b}\n\n"
+    "Which is better? Answer A, B, or TIE only."
+)
+
+
+def run_gate_2(endpoint: str, base_model: str, lora_alias: str,
+               val_file: str, n: int, bedrock_region: str,
+               judge_model: str) -> tuple[int, int, int, int]:
+    import boto3
+    bedrock = boto3.client("bedrock-runtime", region_name=bedrock_region)
+
+    def judge(user_prompt, out_a, out_b):
+        body = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 8,
+            "messages": [{"role": "user",
+                          "content": JUDGE_PROMPT_TEMPLATE.format(
+                              user=user_prompt, a=out_a, b=out_b)}],
+        }
+        # NOTE: Claude Opus 4.7+ deprecated the `temperature` parameter — do not
+        # pass it. Older judges (Sonnet 4.6 etc.) still accept it.
+        resp = bedrock.invoke_model(
+            modelId=judge_model,
+            body=json.dumps(body),
+            contentType="application/json",
+            accept="application/json",
+        )
+        text = json.loads(resp["body"].read())["content"][0]["text"].strip().upper()
+        for tok in ("TIE", "A", "B"):
+            if text.startswith(tok):
+                return tok
+        return "TIE"
+
+    # Load validation rows.
+    rows = []
+    with open(val_file) as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+            if len(rows) >= n:
+                break
+    if not rows:
+        raise SystemExit(f"No rows loaded from {val_file}")
+
+    random.seed(42)
+    wins, ties, losses, errors = 0, 0, 0, 0
+    for i, row in enumerate(rows, 1):
+        user = row["input"]
+        try:
+            base_resp = chat_tools(endpoint, base_model,
+                                   [{"role": "user", "content": user}], max_tokens=400)
+            lora_resp = chat_tools(endpoint, lora_alias,
+                                   [{"role": "user", "content": user}], max_tokens=400)
+            base_msg = base_resp["choices"][0]["message"]
+            lora_msg = lora_resp["choices"][0]["message"]
+            base_out = base_msg.get("content") or str(base_msg.get("tool_calls"))
+            lora_out = lora_msg.get("content") or str(lora_msg.get("tool_calls"))
+
+            swap = random.random() < 0.5
+            if swap:
+                raw = judge(user, lora_out, base_out)
+                verdict = {"A": "LORA", "B": "BASE", "TIE": "TIE"}[raw]
+            else:
+                raw = judge(user, base_out, lora_out)
+                verdict = {"A": "BASE", "B": "LORA", "TIE": "TIE"}[raw]
+
+            if verdict == "LORA":
+                wins += 1
+            elif verdict == "BASE":
+                losses += 1
+            else:
+                ties += 1
+            print(f"  [{i:2d}/{n}] {verdict:<4}  {user[:60]}...")
+        except Exception as e:
+            errors += 1
+            print(f"  [{i:2d}/{n}] ERR: {type(e).__name__}: {str(e)[:80]}")
+
+    return wins, losses, ties, errors
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--endpoint", required=True,
+                   help="Base URL of the vLLM OpenAI-compatible endpoint")
+    p.add_argument("--base-model", default="Qwen/Qwen3.6-35B-A3B")
+    p.add_argument("--lora-alias", default="tools",
+                   help="Name used in vLLM's --lora-modules <name>=<path>")
+    p.add_argument("--gate", choices=["1", "2", "all"], default="all")
+    p.add_argument("--val-file", default="/fsx/datasets/validation.jsonl",
+                   help="Gate 2 validation JSONL path")
+    p.add_argument("--n", type=int, default=50, help="Gate 2 sample count")
+    p.add_argument("--bedrock-region", default="us-west-2")
+    p.add_argument("--judge-model", default="us.anthropic.claude-opus-4-7",
+                   help="Bedrock inference profile ID")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    gates = ("1", "2") if args.gate == "all" else (args.gate,)
+
+    summary: dict = {}
+    if "1" in gates:
+        print("=== Gate 1 - Base model ===")
+        base_pass, _ = run_gate_1(args.endpoint, args.base_model)
+        print("\n=== Gate 1 - LoRA ===")
+        lora_pass, _ = run_gate_1(args.endpoint, args.lora_alias)
+        summary["gate1_base"] = f"{base_pass}/10"
+        summary["gate1_lora"] = f"{lora_pass}/10"
+
+    if "2" in gates:
+        print(f"\n=== Gate 2 - Judge ({args.judge_model}), {args.n} samples ===")
+        wins, losses, ties, errs = run_gate_2(
+            args.endpoint, args.base_model, args.lora_alias,
+            args.val_file, args.n, args.bedrock_region, args.judge_model,
+        )
+        total = wins + losses + ties
+        win_rate = wins / total if total else 0.0
+        summary["gate2_lora_wins"] = f"{wins}/{total}"
+        summary["gate2_win_rate"] = f"{win_rate:.0%}"
+        summary["gate2_errors"] = errs
+
+    print("\n=== Summary ===")
+    for k, v in summary.items():
+        print(f"  {k:<22} {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/export_lora_adapter.py
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/export_lora_adapter.py
@@ -1,0 +1,176 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Export a Megatron-Bridge distributed LoRA checkpoint to HuggingFace PEFT format.
+
+Reads the distcp shard directory written by the training job and emits:
+    <output>/adapter_config.json
+    <output>/adapter_model.safetensors
+
+The output is directly loadable by `peft.PeftModel.from_pretrained(...)` and by
+vLLM via `--lora-modules <name>=<output-dir>`.
+
+Must run under torchrun with matching parallelism (TP=2, PP=1, EP=4 for this test
+case). The conversion is done by:
+  1. Re-instantiating the base model architecture via AutoBridge
+  2. Loading dense base weights (needed for shape reference)
+  3. Attaching LoRA wrappers that match training config
+  4. Loading the adapter shards via dist_checkpointing with a filtered state dict
+  5. Calling bridge.save_hf_adapter(...) which writes the HF PEFT files
+
+Invocation:
+    torchrun --nproc_per_node=8 export_lora_adapter.py \\
+        --lora-checkpoint /fsx/qwen36-xlam-runs/checkpoints/iter_0004200 \\
+        --hf-model         Qwen/Qwen3.6-35B-A3B \\
+        --base-checkpoint  /fsx/qwen36-bridge \\
+        --output           /fsx/qwen36-xlam-runs/adapter_hf \\
+        --tp 2 --pp 1 --ep 4
+"""
+import argparse
+import logging
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from megatron.core import dist_checkpointing
+from megatron.core.dist_checkpointing.validation import StrictHandling
+
+from megatron.bridge.models.conversion.auto_bridge import AutoBridge
+from megatron.bridge.peft.lora import LoRA, VLMLoRA
+from megatron.bridge.training.checkpointing import (
+    _generate_model_state_dict,
+    apply_peft_adapter_filter_to_state_dict,
+)
+from megatron.bridge.training.utils.checkpoint_utils import read_run_config
+from megatron.bridge.utils.common_utils import print_rank_0
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--lora-checkpoint", required=True,
+                   help="Path to iter_NNNNNNN directory containing the trained LoRA adapter")
+    p.add_argument("--hf-model", required=True,
+                   help="HF model id for the base (e.g. Qwen/Qwen3.6-35B-A3B)")
+    p.add_argument("--output", required=True,
+                   help="Where to write adapter_config.json + adapter_model.safetensors")
+    p.add_argument("--base-checkpoint", default=None,
+                   help="Bridge distcp directory for the base dense model. If omitted, "
+                        "read from run_config.yaml inside the LoRA checkpoint.")
+    p.add_argument("--tp", type=int, default=2)
+    p.add_argument("--pp", type=int, default=1)
+    p.add_argument("--ep", type=int, default=4)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # 1. Build the HF bridge config (no weights yet).
+    print_rank_0(f"[export] Building AutoBridge from {args.hf_model}")
+    bridge = AutoBridge.from_hf_pretrained(args.hf_model, trust_remote_code=True)
+
+    provider = bridge.to_megatron_provider(load_weights=False)
+    provider.tensor_model_parallel_size = args.tp
+    provider.pipeline_model_parallel_size = args.pp
+    provider.expert_model_parallel_size = args.ep
+    provider.expert_tensor_parallel_size = 1
+    provider.pipeline_dtype = torch.bfloat16
+
+    # initialize_model_parallel() also seeds Megatron's TP-aware RNG, which is
+    # required before any transformer layer can be materialized (otherwise
+    # TransformerEngine's `random.fork('model-parallel-rng')` raises).
+    provider.initialize_model_parallel(seed=0)
+
+    mp_overrides = {
+        "tensor_model_parallel_size": args.tp,
+        "pipeline_model_parallel_size": args.pp,
+        "expert_model_parallel_size": args.ep,
+    }
+
+    # 2. Locate the base dense checkpoint (needed by load_megatron_model).
+    lora_dir = Path(args.lora_checkpoint)
+    base_dir = args.base_checkpoint
+    if base_dir is None:
+        cfg_file = lora_dir / "run_config.yaml"
+        if not cfg_file.exists():
+            cfg_file = lora_dir.parent.parent / "run_config.yaml"
+        if cfg_file.exists():
+            run_cfg = read_run_config(str(cfg_file))
+            base_dir = run_cfg.get("checkpoint", {}).get("pretrained_checkpoint")
+    if base_dir is None:
+        raise SystemExit("Could not determine base checkpoint path; pass --base-checkpoint")
+    print_rank_0(f"[export] Base dense checkpoint: {base_dir}")
+
+    # 3. Load the base dense weights.
+    print_rank_0("[export] Loading base dense model")
+    model = bridge.load_megatron_model(str(base_dir), mp_overrides=mp_overrides)
+
+    # 4. Read peft hyperparameters from the LoRA checkpoint's run_config.yaml.
+    cfg_file = lora_dir / "run_config.yaml"
+    if not cfg_file.exists():
+        cfg_file = lora_dir.parent.parent / "run_config.yaml"
+
+    peft_cfg = {}
+    peft_class = LoRA
+    if cfg_file.exists():
+        run_cfg_dict = read_run_config(str(cfg_file))
+        peft_cfg = run_cfg_dict.get("peft", {}) or {}
+        target = peft_cfg.get("_target_", "")
+        if "VLMLoRA" in target:
+            peft_class = VLMLoRA
+        allowed = {"target_modules", "dim", "alpha", "dropout",
+                   "dropout_position",
+                   "freeze_language_model", "freeze_vision_model",
+                   "freeze_vision_projection"}
+        peft_cfg = {k: v for k, v in peft_cfg.items() if k in allowed}
+    print_rank_0(f"[export] PEFT class {peft_class.__name__} with cfg: {peft_cfg}")
+    lora_peft = peft_class(**peft_cfg)
+
+    # 5. Attach LoRA wrappers (no weights yet — those come next).
+    model = lora_peft(model, training=False)
+
+    # 6. Load adapter weights. Use a filtered state dict so dist_checkpointing
+    #    only tries to match adapter tensors, not the base weights + optimizer
+    #    state + scheduler + content_metadata that live alongside them in the
+    #    training checkpoint.
+    print_rank_0(f"[export] Loading adapter weights from {lora_dir}")
+    sharded_state_dict = _generate_model_state_dict(model, {})
+    sharded_state_dict = apply_peft_adapter_filter_to_state_dict(
+        sharded_state_dict, lora_peft
+    )
+
+    loaded_sd = dist_checkpointing.load(
+        sharded_state_dict, str(lora_dir),
+        strict=StrictHandling.LOG_UNEXPECTED,
+    )
+    model_section_key = (
+        "model" if "model" in loaded_sd
+        else next(k for k in loaded_sd if k.startswith("model"))
+    )
+    adapter_sd = loaded_sd[model_section_key]
+    model[0].load_state_dict(adapter_sd, strict=False)
+
+    # 7. Write HF PEFT format.
+    print_rank_0(f"[export] Writing HF PEFT adapter to {args.output}")
+    bridge.save_hf_adapter(
+        model,
+        path=args.output,
+        peft_config=lora_peft,
+        base_model_name_or_path=args.hf_model,
+        show_progress=(dist.get_rank() == 0),
+    )
+
+    dist.barrier()
+    if dist.get_rank() == 0:
+        out = Path(args.output)
+        print("[export] Output contents:")
+        for f in sorted(out.iterdir()):
+            print(f"  {f.name:40s} {f.stat().st_size/1e6:.2f} MB")
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/prep_xlam_dataset.py
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/prep_xlam_dataset.py
@@ -1,0 +1,115 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Convert xLAM-60k function-calling dataset to Megatron-Bridge SFT JSONL.
+
+Reads the parsed parquet files from HF hub and emits two JSONL files:
+  <output-dir>/training.jsonl
+  <output-dir>/validation.jsonl
+
+Each line is:  {"input": "<tools JSON>\\n\\n<user message>", "output": "<tool call JSON>"}
+
+These file names are what Megatron-Bridge's FinetuningDatasetBuilder expects when
+the recipe's dataset_type is set to 'llm-finetune-preloaded'.
+
+Usage:
+    python prep_xlam_dataset.py --output-dir /fsx/datasets
+"""
+import argparse
+import json
+import os
+import random
+from pathlib import Path
+
+from datasets import load_dataset
+
+
+HF_DATASET_ID = "minpeter/xlam-function-calling-60k-parsed"
+DEFAULT_VAL_RATIO = 0.02   # 98/2 train/val split
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--output-dir", required=True, help="Directory to write training.jsonl and validation.jsonl")
+    p.add_argument("--dataset-id", default=HF_DATASET_ID,
+                   help=f"HF dataset ID (default: {HF_DATASET_ID})")
+    p.add_argument("--val-ratio", type=float, default=DEFAULT_VAL_RATIO,
+                   help=f"Validation split ratio (default: {DEFAULT_VAL_RATIO})")
+    p.add_argument("--seed", type=int, default=42, help="Shuffle seed")
+    p.add_argument("--max-samples", type=int, default=None,
+                   help="Optional cap on total samples (for smoke tests)")
+    return p.parse_args()
+
+
+def build_row(row):
+    """Convert one xLAM row to {input, output} SFT format.
+
+    xLAM schema:
+      row["messages"] = [
+          {"role": "system", "content": "..."},   # optional
+          {"role": "user", "content": "..."},
+          {"role": "assistant", "content": null, "tool_calls": [{...}, ...]},
+      ]
+      row["tools"] = [{"type":"function","function":{"name":"...","parameters":{...}}}, ...]
+    """
+    tools = row.get("tools") or []
+    messages = row.get("messages") or []
+
+    user_msg = next((m for m in messages if m.get("role") == "user"), None)
+    asst_msg = next((m for m in messages if m.get("role") == "assistant"), None)
+    if user_msg is None or asst_msg is None:
+        return None
+
+    # The assistant message carries tool_calls (content is usually null).
+    tool_calls = asst_msg.get("tool_calls") or []
+    if not tool_calls:
+        return None
+
+    input_text = (
+        f"You have access to the following tools:\n"
+        f"{json.dumps(tools, separators=(',', ':'))}\n\n"
+        f"User: {user_msg['content']}"
+    )
+    output_text = json.dumps(tool_calls, separators=(',', ':'))
+    return {"input": input_text, "output": output_text}
+
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    print(f"Loading {args.dataset_id}...")
+    ds = load_dataset(args.dataset_id, split="train")
+    print(f"  Loaded {len(ds)} raw rows")
+
+    rows = []
+    for row in ds:
+        converted = build_row(row)
+        if converted is not None:
+            rows.append(converted)
+    print(f"  Converted {len(rows)} rows (dropped {len(ds) - len(rows)} with missing/empty assistants)")
+
+    if args.max_samples is not None and args.max_samples < len(rows):
+        rows = rows[: args.max_samples]
+
+    random.seed(args.seed)
+    random.shuffle(rows)
+
+    n_val = max(1, int(len(rows) * args.val_ratio))
+    val_rows = rows[:n_val]
+    train_rows = rows[n_val:]
+
+    train_path = Path(args.output_dir) / "training.jsonl"
+    val_path = Path(args.output_dir) / "validation.jsonl"
+    with open(train_path, "w") as f:
+        for r in train_rows:
+            f.write(json.dumps(r) + "\n")
+    with open(val_path, "w") as f:
+        for r in val_rows:
+            f.write(json.dumps(r) + "\n")
+
+    print(f"Wrote {len(train_rows)} training rows -> {train_path}")
+    print(f"Wrote {len(val_rows)} validation rows -> {val_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/xlam_runner.py
+++ b/3.test_cases/megatron/megatron-lm/qwen36-moe-lora/src/xlam_runner.py
@@ -1,0 +1,136 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Qwen3.6-35B-A3B xLAM function-calling LoRA training driver.
+
+Builds a Megatron-Bridge ConfigContainer from the Qwen3.5-VL MoE LoRA recipe
+(which loads its architecture dynamically from HF via AutoBridge, so passing
+hf_path="Qwen/Qwen3.6-35B-A3B" correctly targets Qwen 3.6), applies task-specific
+overrides (tokenizer, dataset, PEFT, training schedule), and calls finetune().
+
+Invocation (via torchrun inside the training PyTorchJob):
+    torchrun --nproc_per_node=$NPROC_PER_NODE --nnodes=$PET_NNODES \\
+             --node_rank=$PET_NODE_RANK --master_addr=$MASTER_ADDR \\
+             --master_port=$MASTER_PORT xlam_runner.py
+
+Environment variables consumed (all have defaults; override in the PyTorchJob):
+    HF_MODEL_ID              HuggingFace model id for the base
+    TOKENIZER_PATH           Local path to the HF tokenizer assets
+    DATASET_ROOT             Directory containing training.jsonl + validation.jsonl
+    PRETRAINED_CHECKPOINT    Bridge distcp dir produced by the conversion pod
+    CHECKPOINT_SAVE_DIR      Where to write training checkpoints
+    SEQ_LENGTH, MICRO_BS, GLOBAL_BS, TRAIN_ITERS, LR, MIN_LR,
+    LORA_DIM, LORA_ALPHA, LORA_TARGET_MODULES
+"""
+import os
+
+from megatron.bridge.recipes.qwen_vl.qwen35_vl import qwen35_vl_35b_a3b_peft_config
+from megatron.bridge.recipes.utils.dataset_utils import apply_dataset_override
+from megatron.bridge.training.finetune import finetune
+from megatron.bridge.training.gpt_step import forward_step as gpt_forward_step
+
+
+def _getenv_int(name, default):
+    return int(os.environ.get(name, default))
+
+
+def _getenv_float(name, default):
+    return float(os.environ.get(name, default))
+
+
+def _getenv_list(name, default):
+    raw = os.environ.get(name)
+    if not raw:
+        return list(default)
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def main():
+    hf_model_id = os.environ.get("HF_MODEL_ID", "Qwen/Qwen3.6-35B-A3B")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "/fsx/hf_cache/models--Qwen--Qwen3.6-35B-A3B")
+    dataset_root = os.environ.get("DATASET_ROOT", "/fsx/datasets")
+    pretrained_ckpt = os.environ.get("PRETRAINED_CHECKPOINT", "/fsx/qwen36-bridge")
+    save_dir = os.environ.get("CHECKPOINT_SAVE_DIR", "/fsx/qwen36-xlam-runs/checkpoints")
+
+    seq_length = _getenv_int("SEQ_LENGTH", 2048)
+    micro_bs = _getenv_int("MICRO_BS", 3)
+    global_bs = _getenv_int("GLOBAL_BS", 48)
+    train_iters = _getenv_int("TRAIN_ITERS", 4200)
+    lr = _getenv_float("LR", 1.5e-4)
+    min_lr = _getenv_float("MIN_LR", 1.5e-5)
+    warmup_iters = _getenv_int("WARMUP_ITERS", 100)
+    eval_interval = _getenv_int("EVAL_INTERVAL", 500)
+    save_interval = _getenv_int("SAVE_INTERVAL", 500)
+    log_interval = _getenv_int("LOG_INTERVAL", 10)
+
+    lora_dim = _getenv_int("LORA_DIM", 64)
+    lora_alpha = _getenv_int("LORA_ALPHA", 128)
+    lora_target_modules = _getenv_list(
+        "LORA_TARGET_MODULES", ["linear_qkv", "linear_proj"]
+    )
+
+    # 1. Load the recipe. AutoBridge dynamically loads the model config via
+    #    hf_path, so passing Qwen3.6 here correctly configures num_moe_experts=256,
+    #    moe_router_topk=8, etc., even though the recipe function name says "qwen35".
+    cfg = qwen35_vl_35b_a3b_peft_config(
+        peft_scheme="lora",
+        hf_path=hf_model_id,
+    )
+
+    # 2. Text-only SFT dataset (xLAM JSONL).
+    cfg = apply_dataset_override(cfg, dataset_type="llm-finetune-preloaded",
+                                 seq_length=seq_length)
+    cfg.dataset.dataset_root = dataset_root
+    cfg.dataset.seq_length = seq_length
+
+    # 3. Model-level overrides: freeze the VL encoder (we do text-only SFT).
+    cfg.model.seq_length = seq_length
+    cfg.model.freeze_vision_model = True
+    cfg.model.freeze_vision_projection = True
+
+    # 4. Force the HF text tokenizer. The VL recipe defaults to NullTokenizer,
+    #    which crashes FinetuningDatasetBuilder at `tokenizer.space_sensitive`.
+    cfg.tokenizer.tokenizer_type = "HuggingFaceTokenizer"
+    cfg.tokenizer.tokenizer_model = tokenizer_path
+
+    # 5. PEFT overrides (can't be set via Hydra CLI — peft is attached to the
+    #    ConfigContainer dynamically, not a schema field).
+    cfg.peft.dim = lora_dim
+    cfg.peft.alpha = lora_alpha
+    cfg.peft.target_modules = lora_target_modules
+    # NOTE: excluding linear_fc1/linear_fc2 is critical for MoE models. Those
+    # target each expert's MLP — applying LoRA there would bloat the adapter
+    # ~256x (one per expert) and break EP sharding.
+
+    # 6. Checkpoints.
+    cfg.checkpoint.pretrained_checkpoint = pretrained_ckpt
+    cfg.checkpoint.save = save_dir
+
+    # 7. Training schedule.
+    cfg.train.train_iters = train_iters
+    cfg.train.global_batch_size = global_bs
+    cfg.train.micro_batch_size = micro_bs
+    cfg.train.eval_iters = 20
+    cfg.train.eval_interval = eval_interval
+    cfg.train.log_interval = log_interval
+    cfg.train.save_interval = save_interval
+
+    cfg.optimizer.lr = lr
+    cfg.optimizer.min_lr = min_lr
+
+    cfg.scheduler.lr_warmup_iters = warmup_iters
+    cfg.scheduler.lr_decay_iters = train_iters
+    cfg.scheduler.lr_decay_style = "cosine"
+
+    # 8. Logger. Put TensorBoard on the shared FSx mount so monitoring pods can
+    #    read it without the training pod being modified.
+    cfg.logger.log_interval = log_interval
+    cfg.logger.log_throughput = True
+    cfg.logger.log_params_norm = True
+    cfg.logger.log_l2_norm_grad_to_tensorboard = True
+    cfg.logger.tensorboard_dir = os.path.join(os.path.dirname(save_dir), "tb_logs")
+
+    finetune(cfg, gpt_forward_step)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

Add a self-contained Kubernetes test case for parameter-efficient fine-tuning of a Mixture-of-Experts model. This is the first MoE PEFT recipe under `3.test_cases/megatron/megatron-lm/` and the first to exercise Megatron-Bridge 0.4's `expert_model_parallel_size` dimension end-to-end (training, adapter export to HuggingFace PEFT format, and vLLM serving).

## Changes

- New test case at `3.test_cases/megatron/megatron-lm/qwen36-moe-lora/` (28 files) following the canonical `<framework>/<library>/<model>/{kubernetes,...}` layout
- Training driver (`src/xlam_runner.py`) wraps Megatron-Bridge's `qwen35_vl_35b_a3b_peft_config` recipe with overrides for text-only SFT (vision encoder frozen, HuggingFace tokenizer, xLAM dataset)
- Adapter exporter (`src/export_lora_adapter.py`) converts the distributed Megatron-Bridge LoRA checkpoint to standard HuggingFace PEFT format using `AutoBridge.save_hf_adapter` with adapter-only state-dict filtering
- Eight numbered Kubernetes manifests covering: storage (FSx Lustre 2.15), weight pre-cache, dataset prep, HF→Bridge conversion, training (Kubeflow `PyTorchJob`), adapter export, vLLM inference (Deployment + Service), and evaluation (Job)
- Nine numbered shell scripts that drive the manifests via `envsubst` with explicit variable whitelists
- Two-gate evaluation harness (`src/eval_function_calling.py`): 10 hand-crafted function-calling prompts, plus 50 held-out xLAM validation prompts judged by Claude Opus 4.7 via Amazon Bedrock
- Documentation: top-level README, `docs/PERFORMANCE.md` (observed step time, MFU, parallelism topology), `docs/EVALUATION.md` (methodology + reference results), `docs/TROUBLESHOOTING.md` (failure modes encountered during bring-up)

## Test Plan

**Environment:**
- AWS Service: Amazon SageMaker HyperPod (EKS mode)
- Instance type: ml.p5e.48xlarge (8x NVIDIA H200 141 GB, 32 EFA NICs per node)
- Number of nodes: 2 (16 H200 total)

Storage: FSx for Lustre 2.15 (Scratch_2, 1.2 TiB)
Container: `nvcr.io/nvidia/nemo:26.04` (Megatron-Bridge 0.4.0rc0, Megatron-Core 0.17.0rc0)
Parallelism: TP=2, PP=1, EP=4, DP=2

**Test commands:**

```bash
cd 3.test_cases/megatron/megatron-lm/qwen36-moe-lora
cp kubernetes/scripts/env.example kubernetes/scripts/env.sh
# fill in FSX_SUBNET_ID, FSX_SECURITY_GROUP, etc.
source kubernetes/scripts/env.sh

./kubernetes/scripts/0.setup-storage.sh        # FSx Lustre PVC + ConfigMap
./kubernetes/scripts/1.precache-weights.sh     # ~30 min, 70 GB
./kubernetes/scripts/2.prep-dataset.sh         # ~2 min
./kubernetes/scripts/3.convert-to-bridge.sh    # ~25 min, one-time
./kubernetes/scripts/4.train.sh                # ~2 h 12 min
./kubernetes/scripts/5.export-adapter.sh       # ~10 min
./kubernetes/scripts/6.deploy-inference.sh     # ~8 min cold start
GATE=all ./kubernetes/scripts/7.run-eval.sh    # ~6 min
```

To skip training and serve the published reference adapter directly:

```bash
export LORA_SOURCE=hf
export LORA_REPO=ying2022/qwen3-6-35b-xlam-tools-lora
./kubernetes/scripts/6.deploy-inference.sh
```

## Test Results

End-to-end run executed on 2x ml.p5e.48xlarge.

**Training:**

| Metric | Value |
|---|---|
| Wall-clock, 4,200 iterations | 2 h 12 min |
| Step time (mean) | 1.73 s |
| Per-GPU throughput | ~77 MODEL TFLOP/s |
| Aggregate throughput | ~1.2 PFLOPS |
| Total tokens trained | 413 M (3.43 epochs over 58.8k samples) |
| Memory per GPU | 56-68 GB / 141 GB (40-48% utilization) |
| LoRA adapter output | 108 MB (rank 64, alpha 128, target `linear_qkv` + `linear_proj`) |

**Evaluation:**

| Gate | Metric | Result |
|---|---|---|
| Gate 1 (10 hand-crafted prompts) | Pass rate | base 6/10 -> LoRA 9/10 (+30 pp) |
| Gate 2 (50 xLAM val prompts, Claude Opus 4.7 judge) | LoRA win rate | 47/50 (94%) |

**Reference adapter** (publicly available; use to skip training and reproduce only the eval): https://huggingface.co/ying2022/qwen3-6-35b-xlam-tools-lora

## Directory Structure

```
3.test_cases/
└── megatron/
    └── megatron-lm/
        └── qwen36-moe-lora/
            ├── README.md
            ├── .gitignore
            ├── src/                       # platform-agnostic Python (training, eval, export)
            │   ├── __init__.py
            │   ├── prep_xlam_dataset.py
            │   ├── xlam_runner.py
            │   ├── export_lora_adapter.py
            │   └── eval_function_calling.py
            ├── docs/                      # platform-agnostic docs
            │   ├── PERFORMANCE.md
            │   ├── EVALUATION.md
            │   └── TROUBLESHOOTING.md
            └── kubernetes/
                ├── manifests/             # 8 envsubst-driven YAML templates
                └── scripts/               # env.example + 9 numbered shell scripts
```

Layout follows the canonical `<framework>/<library>/<model>/{kubernetes,...}` structure documented in `.github/PULL_REQUEST_TEMPLATE.md`. Platform-agnostic Python and docs sit above `kubernetes/` so a future Slurm or HyperPod-Slurm path can be added without relocating any code.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [x] New test cases follow the [expected directory structure](#directory-structure).
