### PR TITLE
Add two-post series: Multi-Tenant Slurm on AWS ParallelCluster (Parts 1 & 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Hugo build artifacts
+public/
+.hugo_build.lock
+resources/_gen/

--- a/content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
+++ b/content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
@@ -105,7 +105,7 @@ flowchart LR
             GPU["Compute fleet<br/>2× g6.48xlarge<br/>(EFA, 8× L4 each)"]
             DB[("Aurora Serverless v2<br/>MySQL 8.0<br/>TLS required")]
             FSXL["FSx Lustre /fsx<br/>1.2 TB, P2 125 MB/s/TiB"]
-            FSXZ["FSx OpenZFS /home<br/>256 GB, HA-2 160 MB/s"]
+            FSXZ["FSx OpenZFS /home<br/>256 GB, Multi-AZ 160 MB/s"]
         end
     end
     SM["Secrets Manager<br/>(DB password)"]
@@ -137,23 +137,23 @@ A few details worth flagging up front:
 - **The cluster fleet only ever talks to `slurmctld`** on the head node, via
   Slurm's own RPC. The DB is never on the compute path.
 
-There's one wrinkle the source template doesn't currently document: Aurora's
-`DBSubnetGroup` requires subnets in **at least two different availability
-zones**, but the repo's
-[`parallelcluster-prerequisites.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
-creates exactly one private subnet, in a single AZ specified by the
-`PrimarySubnetAZ` parameter. We'll work around that with one extra
-`aws ec2 create-subnet` call below.
+The prereqs template provisions **two private subnets** in different
+AZs (specified by `PrimarySubnetAZ` and `SecondarySubnetAZ`), which the
+accounting-DB template will consume directly for the Aurora
+`DBSubnetGroup`. The same two subnets also back the Multi-AZ FSx OpenZFS
+file system that serves `/home`, with the HA pair split across them for
+cross-AZ failover.
 
 ## Provision the foundation
 
-We're going to build this in three CloudFormation layers plus one S3 bucket:
+We'll build this in two CloudFormation layers plus one S3 bucket:
 
-1. **Prereqs**: VPC, NAT, security groups, FSx Lustre, FSx OpenZFS
-2. **Manual fix**: a second private subnet in a different AZ (for Aurora)
-3. **Accounting DB**: Aurora Serverless v2 + secret + client/server SGs
-4. **S3 bucket**: home for the `create-users.sh` post-install script
-5. **ParallelCluster**: head node + a single GPU queue, wired to the DB
+1. **Prereqs**: VPC with two private subnets in different AZs, NAT, security
+   groups, FSx Lustre (`/fsx`), FSx OpenZFS Multi-AZ (`/home`)
+2. **Accounting DB**: Aurora Serverless v2 + secret + client/server SGs,
+   consuming both subnets from the prereqs stack
+3. **S3 bucket**: home for the `create-users.sh` post-install script
+4. **ParallelCluster**: head node + a single GPU queue, wired to the DB
 
 ### Pin the AWS environment
 
@@ -170,76 +170,47 @@ We'll use `us-east-1` throughout because `g6.48xlarge` is broadly available
 there, and the region has six AZs to pick from when capacity is tight in
 your preferred AZ.
 
-> **AZ caveat for FSx OpenZFS** — when this walkthrough was first run, the
-> prereqs template used `DeploymentType: SINGLE_AZ_HA_1` for `/home`, which
-> [is not offered in many regions](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/available-aws-regions.html)
-> — including `us-east-1`, `us-east-2`, `us-west-2`, `eu-central-1`,
-> `eu-west-1`, `ap-northeast-1`, `ap-southeast-1`/`2`, `ap-south-1`, and
-> `ca-central-1`. In `us-east-1` we saw the create fail with:
->
-> ```
-> The file system creation request failed because OpenZFS file systems with
-> the provided deployment type and storage type are not available in the
-> requested Availability Zones
-> ```
->
-> [`PR #1100`](https://github.com/awslabs/awsome-distributed-ai/pull/1100)
-> ([issue #1097](https://github.com/awslabs/awsome-distributed-ai/issues/1097))
-> flips the default to `SINGLE_AZ_HA_2`, which uses gen-2 hardware and is
-> available in every region where HA_1 was failing. If you're running this
-> post before that PR has merged, fork the template with a one-line patch:
->
-> ```bash
-> sed 's/DeploymentType: SINGLE_AZ_HA_1/DeploymentType: SINGLE_AZ_HA_2/' \
->   1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml \
->   > parallelcluster-prerequisites-ha2.yaml
-> ```
->
-> HA_2's throughput minimum is 160 MB/s (vs HA_1's 64 MB/s), and HA_2's
-> valid set is discrete: `160, 320, 640, 1280, 2560, 3840, 5120, 7680,
-> 10240`. Pick a value from that set when overriding `HomeThroughput`. The
-> per-MB/s price is also different; see the
-> [FSx OpenZFS pricing page](https://aws.amazon.com/fsx/openzfs/pricing/).
-
 ### Step 1 — Prereqs stack
 
 The repo's
 [`parallelcluster-prerequisites.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
-emits everything we need: a VPC with `10.0.0.0/16` (public) and `10.1.0.0/16`
-(private) CIDR ranges, an Internet Gateway, a NAT Gateway, an S3 VPC
-endpoint, an EFA-friendly all-to-all security group, plus FSx Lustre (for
-`/fsx`) and FSx OpenZFS (for `/home`).
+emits everything we need: a VPC with `10.0.0.0/16` (public) and
+`10.1.0.0/16` (private) CIDR ranges, **two private subnets in different
+AZs** (`10.1.0.0/17` and `10.1.128.0/17`), an Internet Gateway, a NAT
+Gateway, an S3 VPC endpoint, an EFA-friendly all-to-all security group,
+plus FSx Lustre (for `/fsx`) and **Multi-AZ FSx OpenZFS** (for `/home`).
+The Multi-AZ default means the template works in every region per the
+[FSx OpenZFS availability table](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/available-aws-regions.html),
+including the regions where `SINGLE_AZ_HA_1` / `HA_2` aren't offered.
 
-Two parameter notes:
+One parameter note worth calling out:
 
-- `PerUnitStorageThroughput` defaults to **250 MB/s/TiB**, which is fine for
-  real training but doubles the per-GB-month cost over the **125 MB/s/TiB**
-  minimum tier. For a QoS-walkthrough cluster we don't need the throughput,
-  so we knock it down.
-- `HomeThroughput` (the FSx OpenZFS provisioned throughput) defaults to
-  **512 MB/s**. That's badly oversized for shared home directories on a
-  3-user demo cluster, and FSx OpenZFS prices throughput aggressively. Drop
-  it to **160 MB/s** — the minimum value for the `SINGLE_AZ_HA_2`
-  deployment type we use below. (Watch for this gotcha: the
-  `HomeThroughput` parameter has no `AllowedValues` constraint in the
-  template, and FSx accepts only a discrete set of values that *differs by
-  deployment type*. Pass a value not in the set — e.g. `512` against HA_2
-  — and FSx rejects with a `BadRequest` from the API rather than from
-  CloudFormation itself, sending the stack straight to `ROLLBACK_COMPLETE`.)
+- `PerUnitStorageThroughput` (FSx Lustre) defaults to **250 MB/s/TiB**,
+  which is fine for real training but doubles the per-GB-month cost over
+  the **125 MB/s/TiB** minimum tier. For a QoS-walkthrough cluster we
+  don't need the throughput, so we knock it down.
 
-These two knobs cut storage cost from ~$1.70/hr to ~$0.55/hr.
+The template's `HomeThroughput` default is already **160 MB/s** (the
+minimum valid throughput for Multi-AZ FSx OpenZFS) and has an
+`AllowedValues` constraint, so misconfigurations fail at CFN parameter-
+validation time instead of mid-stack inside the FSx API. The
+`SecondarySubnetAZ` parameter also defaults sensibly: empty means
+"auto-pick the second AZ in this region," and you can override with an
+explicit AZ name if you need fine-grained control.
+
+These knobs cut storage cost from the un-tuned default to ~$0.55/hr.
 
 ```bash
 aws cloudformation create-stack \
   --stack-name slurm-qos-demo-prereqs \
-  --template-body file://parallelcluster-prerequisites-ha2.yaml \
+  --template-body file://1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml \
   --parameters \
     ParameterKey=VPCName,ParameterValue=slurm-qos-demo \
     ParameterKey=PrimarySubnetAZ,ParameterValue=us-east-1b \
+    ParameterKey=SecondarySubnetAZ,ParameterValue=us-east-1c \
     ParameterKey=Capacity,ParameterValue=1200 \
     ParameterKey=PerUnitStorageThroughput,ParameterValue=125 \
     ParameterKey=HomeCapacity,ParameterValue=256 \
-    ParameterKey=HomeThroughput,ParameterValue=160 \
   --capabilities CAPABILITY_IAM
 ```
 
@@ -258,76 +229,31 @@ PREREQS_OUTPUTS=$(aws cloudformation describe-stacks \
 
 VPC_ID=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="VPC") | .OutputValue')
 PRIMARY_SUBNET=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="PrimaryPrivateSubnet") | .OutputValue')
+SECONDARY_SUBNET=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="SecondaryPrivateSubnet") | .OutputValue')
 PUBLIC_SUBNET=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="PublicSubnet") | .OutputValue')
 EFA_SG=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="SecurityGroup") | .OutputValue')
 FSXL_ID=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="FSxLustreFilesystemId") | .OutputValue')
 FSXZ_VOL_ID=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="FSxORootVolumeId") | .OutputValue')
 ```
 
-### Step 2 — Add a second private subnet
+The `SecondaryPrivateSubnet` output is what makes the next step clean —
+the Aurora DBSubnetGroup needs subnets in ≥2 AZs, and we now have them
+without a manual `aws ec2 create-subnet` workaround.
 
-This is the part the prereqs template doesn't do for you. The Aurora
-DBSubnetGroup demands AZ-redundancy, so we carve a second `/19` out of the
-private CIDR block in a *different* AZ:
+### Step 2 — Provision the accounting DB
 
-```bash
-# Pick a second AZ that has capacity for whatever else you might want to run there.
-# (Must be different from PrimarySubnetAZ, so we use 1c here since the prereqs landed in 1b.)
-SECONDARY_AZ=us-east-1c
-
-SECONDARY_SUBNET=$(aws ec2 create-subnet \
-  --vpc-id "$VPC_ID" \
-  --cidr-block 10.1.128.0/19 \
-  --availability-zone "$SECONDARY_AZ" \
-  --tag-specifications "ResourceType=subnet,Tags=[{Key=Name,Value=slurm-qos-demo Private Subnet - $SECONDARY_AZ}]" \
-  --query 'Subnet.SubnetId' --output text)
-
-echo "Secondary private subnet: $SECONDARY_SUBNET"
-
-# Associate it with the existing private route table (NAT-routed).
-PRIVATE_RT=$(aws ec2 describe-route-tables \
-  --filters "Name=vpc-id,Values=$VPC_ID" "Name=route.nat-gateway-id,Values=*" \
-  --query 'RouteTables[0].RouteTableId' --output text)
-aws ec2 associate-route-table --subnet-id "$SECONDARY_SUBNET" --route-table-id "$PRIVATE_RT"
-```
-
-The DB doesn't actually receive cross-AZ traffic in our setup (the head node
-is in the public subnet, which routes through the primary AZ's NAT gateway),
-but RDS requires the *subnet group* to span ≥2 AZs whether or not Aurora
-deploys an instance into both. The serverless v2 cluster we deploy below
-runs one writer instance in the primary AZ; the secondary subnet's only job
-is to satisfy the API.
-
-### Step 3 — Provision the accounting DB
-
-Now the database itself, with the prereqs subnets wired in.
-
-When this walkthrough was first run, the template hard-coded
-`EngineVersion: "8.0.mysql_aurora.3.07.1"` — a version
-[AWS rotates out of service on a rolling basis](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.Versions.html).
-CloudFormation failed with `Cannot find version 8.0.mysql_aurora.3.07.1 for
-aurora-mysql`.
-[`PR #1101`](https://github.com/awslabs/awsome-distributed-ai/pull/1101)
-([issue #1096](https://github.com/awslabs/awsome-distributed-ai/issues/1096))
-exposes `EngineVersion` as a CloudFormation parameter so the template can
-absorb future Aurora rotations without code edits. If you're running this
-before that PR has merged, sed the template to a currently-available
-version (`aws rds describe-db-engine-versions --engine aurora-mysql --query
-'DBEngineVersions[?Status==\`available\`].EngineVersion'` lists what's
-live — `8.0.mysql_aurora.3.12.0` was the latest at the time of writing):
-
-```bash
-sed 's|EngineVersion: "8.0.mysql_aurora.3.07.1"|EngineVersion: "8.0.mysql_aurora.3.12.0"|' \
-  1.architectures/8.accounting-database/cf_database-accounting.yaml \
-  > cf_database-accounting-patched.yaml
-```
-
-Then deploy:
+Now the database itself. The
+[`cf_database-accounting.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/8.accounting-database/cf_database-accounting.yaml)
+template exposes `EngineVersion` as a parameter, defaulting to the latest
+Aurora MySQL 8.0 version available at the time of the template's last
+update. Override if needed (`aws rds describe-db-engine-versions --engine
+aurora-mysql --query 'DBEngineVersions[?Status==\`available\`].EngineVersion'`
+lists what's live in your region).
 
 ```bash
 aws cloudformation create-stack \
   --stack-name slurm-qos-demo-accounting \
-  --template-body file://cf_database-accounting-patched.yaml \
+  --template-body file://1.architectures/8.accounting-database/cf_database-accounting.yaml \
   --parameters \
     ParameterKey=ClusterName,ParameterValue=slurm-qos-demo-accounting \
     ParameterKey=MinCapacity,ParameterValue=1 \
@@ -358,7 +284,7 @@ permission is to reach the Aurora cluster on TCP 3306. Anything you attach
 that SG to becomes a permitted DB client. The head node gets it; nothing
 else needs to.
 
-### Step 4 — S3 bucket for the post-install script
+### Step 3 — S3 bucket for the post-install script
 
 ParallelCluster runs `CustomActions.OnNodeConfigured` on every compute node
 after it boots, fetching the script from S3. We need a bucket for that:
@@ -399,7 +325,7 @@ We'll talk about *why* this script exists (and the LDAP alternative) in the
 multi-user section below. For now it's just sitting in the bucket waiting
 for the compute fleet to fetch it.
 
-### Step 5 — ParallelCluster itself
+### Step 4 — ParallelCluster itself
 
 ParallelCluster 3.3+ supports Slurm accounting natively via the
 [`SlurmSettings.Database`](https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-yaml-Database-section-v3.html)
@@ -792,16 +718,17 @@ in production:
 | Aurora ACU floor charges 24/7 | Even an idle cluster bills ~$0.12/hr from Aurora | Acceptable; if you tear the cluster down nightly, also delete the DB stack. |
 | `require_secure_transport: ON` rejects plaintext clients | Manual `mysql` clients connecting directly fail with `SSL connection error` | Use `mysql --ssl-mode=REQUIRED --ssl-ca=/path/to/global-bundle.pem`, or connect via `slurmdbd` only. |
 
-Drafting this post surfaced four upstream issues in
+Drafting this post surfaced five upstream changes in
 [`awslabs/awsome-distributed-ai`](https://github.com/awslabs/awsome-distributed-ai)
-that were filed and have fixes in flight:
+— three already merged, two still in flight at the time of writing:
 
-| Issue | PR | What it fixes |
-|---|---|---|
-| [#1094](https://github.com/awslabs/awsome-distributed-ai/issues/1094) | [#1098](https://github.com/awslabs/awsome-distributed-ai/pull/1098) | Three typos and a leftover LDAP copy/paste line in the accounting-DB README (`custeradmin` → `clusteradmin`, `slurmdctld` → `slurmctld`, "LDAP User Interface" → "database"). |
-| [#1095](https://github.com/awslabs/awsome-distributed-ai/issues/1095) | [#1099](https://github.com/awslabs/awsome-distributed-ai/pull/1099) | The HyperPod `slurmdbd.conf` snippet doesn't configure TLS even though the Aurora cluster parameter group sets `require_secure_transport: ON`. Adds the RDS CA bundle download and `StorageParameters=SSL_CA=...`. ParallelCluster is unaffected — PC plumbs SSL automatically. |
-| [#1096](https://github.com/awslabs/awsome-distributed-ai/issues/1096) | [#1101](https://github.com/awslabs/awsome-distributed-ai/pull/1101) | Accounting-DB template pinned the retired Aurora MySQL `8.0.mysql_aurora.3.07.1`. The PR exposes `EngineVersion` as a parameter (default `8.0.mysql_aurora.3.12.0`, the current latest Serverless-v2-compatible version) so future Aurora rotations don't break the template. |
-| [#1097](https://github.com/awslabs/awsome-distributed-ai/issues/1097) | [#1100](https://github.com/awslabs/awsome-distributed-ai/pull/1100) | Prereqs template hard-coded `SINGLE_AZ_HA_1` for FSx OpenZFS, which isn't offered in many major regions (us-east-1, us-east-2, us-west-2, eu-central-1, eu-west-1, ap-northeast-1, …). Flips the default to `SINGLE_AZ_HA_2`. |
+| Issue | PR | Status | What it fixes |
+|---|---|---|---|
+| [#1094](https://github.com/awslabs/awsome-distributed-ai/issues/1094) | [#1098](https://github.com/awslabs/awsome-distributed-ai/pull/1098) | merged | Three typos and a leftover LDAP copy/paste line in the accounting-DB README (`custeradmin` → `clusteradmin`, `slurmdctld` → `slurmctld`, "LDAP User Interface" → "database"). |
+| [#1095](https://github.com/awslabs/awsome-distributed-ai/issues/1095) | [#1099](https://github.com/awslabs/awsome-distributed-ai/pull/1099) | in flight | The HyperPod `slurmdbd.conf` snippet doesn't configure TLS even though the Aurora cluster parameter group sets `require_secure_transport: ON`. Adds the RDS CA bundle download and `StorageParameters=SSL_CA=...`. ParallelCluster is unaffected — PC plumbs SSL automatically. |
+| [#1096](https://github.com/awslabs/awsome-distributed-ai/issues/1096) | [#1101](https://github.com/awslabs/awsome-distributed-ai/pull/1101) | merged | Accounting-DB template pinned the retired Aurora MySQL `8.0.mysql_aurora.3.07.1`. Exposes `EngineVersion` as a parameter (default `8.0.mysql_aurora.3.12.0`) so future Aurora rotations don't break the template. |
+| [#1097](https://github.com/awslabs/awsome-distributed-ai/issues/1097) | [#1100](https://github.com/awslabs/awsome-distributed-ai/pull/1100) | merged | Tactical fix for the prereqs template hard-coding `SINGLE_AZ_HA_1` for FSx OpenZFS (unavailable in us-east-1 and other major regions). Flipped the default to `SINGLE_AZ_HA_2`. |
+| — | [#1102](https://github.com/awslabs/awsome-distributed-ai/pull/1102) | in flight | Follow-up to #1100 that also addresses the manual-second-subnet workaround. Adds a `SecondarySubnetAZ` parameter and a second private subnet, then switches FSx OpenZFS from `SINGLE_AZ_HA_2` to `MULTI_AZ_1` — the only deployment type with universal regional coverage. This walkthrough assumes #1102 has merged; readers running it before then will see the template still on `SINGLE_AZ_HA_2` and need to add a second subnet by hand. |
 
 ## Wrap-up — and what's next
 
@@ -820,7 +747,7 @@ The building blocks:
   needed for `slurmdbd`.
 - The
   [`1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
-  prereqs template handles VPC + FSx (with the HA_2 patch we describe).
+  prereqs template handles VPC + two private subnets + FSx Lustre + Multi-AZ FSx OpenZFS.
 - ParallelCluster ≥3.3's
   [`SlurmSettings.Database`](https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-yaml-Database-section-v3.html)
   field wires `slurmdbd` in automatically (and plumbs the RDS CA so TLS

--- a/content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
+++ b/content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
@@ -369,6 +369,7 @@ Scheduling:
       PasswordSecretArn: ${DB_SECRET}
     CustomSlurmSettings:
       - AccountingStorageTRES: gres/gpu
+      - AccountingStorageEnforce: qos,limits   # otherwise QoS limits are silently inactive — see note below
       - PriorityType: priority/multifactor
       - PriorityDecayHalfLife: 7-0      # 7 days for fairshare decay
       - PriorityWeightAge: 1000
@@ -448,6 +449,18 @@ A few choices worth explaining:
 - **`AccountingStorageTRES: gres/gpu`** is what tells `slurmdbd` to record
   GPU usage as a TRES (Trackable RESource) on every job; without it,
   `sreport` will only show CPU consumption.
+- **`AccountingStorageEnforce: qos,limits`** is the line that makes QoS
+  *actually enforce*. By default
+  ([`slurm.conf` docs](https://slurm.schedmd.com/slurm.conf.html)) this
+  setting is unset and Slurm runs "based upon policies configured in
+  Slurm on each cluster" — i.e. QoS rows in `slurmdbd` are stored and
+  visible but *silently inactive*. `sacctmgr` accepts QoS definitions,
+  `show qos` displays them, jobs record the right QoS attribution in
+  `sacct` — but every limit (`GrpTRES`, `MaxWall`, `MaxJobsPerUser`,
+  `DenyOnLimit`, etc.) is ignored. Setting this to `qos,limits` is the
+  minimum needed to enforce the QoS deep dive in Part 2; `limits` covers
+  `GrpTRES` / `MaxWall` and `qos` covers QoS identity + flags. Both
+  imply `associations`.
 - The head node lands in the *public* subnet so we can `pcluster ssh` to
   it directly. The compute fleet stays in the *primary private* subnet.
 - We deliberately attach **two security groups** to the head node: the EFA
@@ -717,6 +730,7 @@ in production:
 | `OnNodeConfigured` script fails on first boot → compute self-terminates → `HeadNodeWaitCondition timed out` | Cluster CREATE never finishes; failed-bootstrap counter on `clustermgtd.events` keeps incrementing | Author every `OnNodeConfigured` script to be **idempotent and tolerant of missing inputs**. In our walkthrough the script reads `/home/shared/userlistfile`, which doesn't exist on the very first boot (the head node hasn't gotten there yet). An unconditional `< /home/shared/userlistfile` bash redirect on a non-existent file exits non-zero, and PC interprets that as bootstrap failure. The fixed script checks `[ -f $USERLIST ] || exit 0` before reading. |
 | Aurora ACU floor charges 24/7 | Even an idle cluster bills ~$0.12/hr from Aurora | Acceptable; if you tear the cluster down nightly, also delete the DB stack. |
 | `require_secure_transport: ON` rejects plaintext clients | Manual `mysql` clients connecting directly fail with `SSL connection error` | Use `mysql --ssl-mode=REQUIRED --ssl-ca=/path/to/global-bundle.pem`, or connect via `slurmdbd` only. |
+| `sbatch` from a non-shared cwd → job dies with `ExitCode 0:53`, looks like a QoS denial | `slurmd.log` shows `_init_task_stdio_fds: Could not open stdout file '...' No such file` followed by `_fork_all_tasks: IO setup failed: Slurmd could not connect IO`; `sacct` reports `FAILED 0:53` with no useful Reason — indistinguishable from a `DenyOnLimit` denial | `sbatch`'s default `--output` is `slurm-%j.out` in the *invocation* cwd (per the [sbatch docs](https://slurm.schedmd.com/sbatch.html)). When `sbatch` is invoked from automation — `aws ssm send-command` (cwd is `/var/snap/amazon-ssm-agent/<pid>/`), a `cron` job, a `systemd` unit — that path doesn't exist on the compute node, slurmd can't create it, and the job dies with signal 53 before the prolog runs. Pass `--chdir=/home/$USER` *or* `--output=/fsx/slurm-%j.out` to anchor the output path explicitly. |
 
 Drafting this post surfaced five upstream changes in
 [`awslabs/awsome-distributed-ai`](https://github.com/awslabs/awsome-distributed-ai)

--- a/content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
+++ b/content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
@@ -1,10 +1,10 @@
 ---
-title: "Multi-Tenant Slurm on AWS ParallelCluster: Accounting and QoS Deep Dive"
+title: "Multi-Tenant Slurm on AWS ParallelCluster, Part 1: Accounting Database + Multi-User Setup"
 date: 2026-05-16
 draft: true
 author: ["Keita Watanabe"]
-description: "Stand up a Slurm accounting database, wire it into AWS ParallelCluster, onboard multiple users without LDAP, and use Slurm QoS to govern shared GPU capacity across teams."
-tags: ["slurm", "qos", "accounting", "parallelcluster", "aurora", "rds", "multi-tenant", "scheduling", "fairshare", "preemption", "aws"]
+description: "Stand up a Slurm accounting database on Aurora Serverless v2, wire it into AWS ParallelCluster, and onboard multiple users without LDAP. Part 1 of a two-post series; Part 2 adds QoS on top."
+tags: ["slurm", "accounting", "parallelcluster", "aurora", "rds", "multi-tenant", "aws", "multi-user"]
 ShowToc: true
 TocOpen: false
 ---
@@ -19,34 +19,47 @@ shuffled to the back because nothing prevents the latest submissions from
 front-running it. The scheduler is doing exactly what it was configured to do:
 nothing about it.
 
-[Slurm](https://slurm.schedmd.com/) ships the machinery to fix this — but it
-requires two pieces of infrastructure that, on AWS, you have to assemble
-yourself. First, a *job accounting database* — typically MySQL — that records
-every job, its resource usage, and the account it billed against. Second, a
-*Quality of Service (QoS)* layer that uses that account information to enforce
-per-team capacity reservations, per-user limits, and preemption rules. Without
-the database, QoS has no associations to gate against; without QoS, the
-database is a passive log of how badly your cluster got over-subscribed.
+Two pieces of infrastructure stand between you and that pain. First, every
+user needs their *own* Linux identity on the cluster — both on the head node
+where they submit work and on every compute node where their jobs actually
+run — so that you can say "Alice's job" and have the scheduler agree. Second,
+[Slurm](https://slurm.schedmd.com/) needs a *job accounting database* —
+typically MySQL — that records every job, its resource usage, and the account
+it billed against. Without per-user identity, every job is `root` and audit
+is impossible; without the accounting database, you can't build the per-team
+capacity reservations, per-user limits, and preemption rules that the
+*Quality of Service (QoS)* layer needs to actually enforce policy.
 
-This post is a deep dive on both, for **AWS ParallelCluster** administrators
-operating multi-tenant GPU clusters. We'll provision the accounting database
-using the CloudFormation template at
-[`1.architectures/8.accounting-database/`](https://github.com/awslabs/awsome-distributed-ai/tree/main/1.architectures/8.accounting-database)
-in the [awslabs/awsome-distributed-ai](https://github.com/awslabs/awsome-distributed-ai)
-repo, wire it into ParallelCluster, onboard a handful of users with a
-lightweight (no-LDAP) approach, and then drive a complete QoS configuration
-realizing a concrete multi-tenant policy:
+This post is the first of a two-part series for **AWS ParallelCluster**
+administrators operating multi-tenant GPU clusters. We'll cover the
+foundation here:
 
-> *"A research team gets a 50% capacity reservation. Interactive jobs are
-> capped at 1 hour and 4 GPUs per user. Low-priority batch jobs are
-> preemptible by both."*
+1. Provisioning the accounting database using the CloudFormation template at
+   [`1.architectures/8.accounting-database/`](https://github.com/awslabs/awsome-distributed-ai/tree/main/1.architectures/8.accounting-database)
+   in the [awslabs/awsome-distributed-ai](https://github.com/awslabs/awsome-distributed-ai)
+   repo.
+2. Wiring that database into ParallelCluster via `SlurmSettings.Database`.
+3. Onboarding a handful of users (alice, bob, charlie) with a **lightweight,
+   no-LDAP approach**: `useradd` on the head node, plus a post-install script
+   that propagates matching UIDs to every compute node via a shared FSx-OpenZFS
+   file.
+4. Verifying that `slurmdbd` is recording every job with the right user,
+   account, and GPU TRES.
 
-By the end you'll have a cluster where `sacctmgr`, `sshare`, and `sprio` all
-have something to say, and you'll understand what each of them is saying.
+[**Part 2**](../slurm-qos-on-parallelcluster/) takes the cluster we build
+here and adds QoS on top — associations, limits (`GrpTRES`, `MaxWall`),
+multifactor priority and fairshare, preemption, partition QoS — realizing
+a concrete shared-GPU policy: *"A research team gets a 50% capacity
+reservation. Interactive jobs are capped at 1 hour and 4 GPUs per user.
+Low-priority batch jobs are preemptible by both."*
+
+By the end of this post you'll have a working ParallelCluster with three
+users, an Aurora-backed accounting database, and every job ending up in
+`sacct` with correct attribution. Part 2 picks up exactly there.
 
 > **Audience**: cluster administrators. We assume comfort with `sbatch`,
 > `squeue`, basic VPC and IAM, and CloudFormation. We do *not* assume any
-> prior Slurm-accounting or QoS experience.
+> prior Slurm-accounting experience.
 
 ## Why an external accounting database?
 
@@ -92,7 +105,7 @@ flowchart LR
             GPU["Compute fleet<br/>2× g6.48xlarge<br/>(EFA, 8× L4 each)"]
             DB[("Aurora Serverless v2<br/>MySQL 8.0<br/>TLS required")]
             FSXL["FSx Lustre /fsx<br/>1.2 TB, P2 125 MB/s/TiB"]
-            FSXZ["FSx OpenZFS /home<br/>64 GB, HA-1 64 MB/s"]
+            FSXZ["FSx OpenZFS /home<br/>256 GB, HA-2 160 MB/s"]
         end
     end
     SM["Secrets Manager<br/>(DB password)"]
@@ -764,385 +777,6 @@ Note three things:
    so far. After the QoS scenario below, those numbers shift toward
    `Allocate`.)
 
-## QoS deep dive
-
-QoS is the part of Slurm that turns a passive accounting record into a
-policy enforcer. There are five primitives, in roughly the order you build
-them up:
-
-1. **Associations** — the *(cluster, account, user, partition)* tuples that
-   bind a submitting user to a billing identity
-2. **QoS limits** — knobs like `MaxWall`, `GrpTRES`, `MaxJobsPerUser` that
-   cap what a job (or a user, or an account) can ask for
-3. **Multifactor priority** — the formula that combines age, fairshare,
-   QoS priority, and TRES-weights into a number used to order pending jobs
-4. **Preemption** — declarative rules saying "QoS A can preempt QoS B"
-5. **Partition QoS** — a QoS attached to a *partition* rather than a user
-
-Each of these is independently useful; combining all five is how you get
-the canonical "research team owns 50% of the cluster, interactive jobs
-capped at 1 hour, low-priority batch is preemptible" setup we're building.
-
-```mermaid
-flowchart TD
-    A["Job submitted<br/>sbatch --qos=X --gres=gpu:N --time=..."] --> B{Association lookup}
-    B -- "user/account not found" --> X1["Reject: Invalid account"]
-    B -- "association exists" --> C{QoS limits gate}
-    C -- "GrpTRES exceeded" --> X2["Pending: AssocGrpGRES"]
-    C -- "MaxJobsPerUser exceeded" --> X3["Pending: QOSMaxJobsPerUserLimit"]
-    C -- "time > MaxWall" --> X4["Reject: Time limit exceeds QOS"]
-    C -- "all passes" --> D["Compute priority<br/>(multifactor)"]
-    D --> E["P = w_age * Age<br/>+ w_fs * Fairshare<br/>+ w_qos * QoSPriority<br/>+ w_tres * TRESFactor"]
-    E --> F{Partition QoS gate}
-    F -- "partition limit fails" --> X5["Pending: partition limit"]
-    F -- "all clear" --> G{Scheduler}
-    G -- "resources free" --> H["Running"]
-    G -- "blocked by lower-prio job" --> I{Preempt rule matches?}
-    I -- "yes" --> J["Lower-prio job REQUEUE'd"]
-    J --> H
-    I -- "no" --> K["Pending: waiting in queue"]
-```
-
-This is the decision tree every job traverses on submission and on every
-scheduler tick afterwards. The rest of this section walks each gate in
-order, with the commands to configure it.
-
-### Associations
-
-Slurm requires every job to bill against an *association*. By default — as
-we saw with Alice's smoke-test job — that association is the
-`(slurm-qos-demo, root, alice, *)` tuple created on the fly. That's fine
-for accounting but useless for QoS: limits live on accounts, not on the
-`root` catch-all.
-
-Build a two-account tree — `research` and `batch` — and bind our three
-users:
-
-```bash
-sudo sacctmgr -i add account research Description="Research team" Organization=acme
-sudo sacctmgr -i add account batch    Description="Batch jobs"    Organization=acme
-
-sudo sacctmgr -i add user alice   DefaultAccount=research
-sudo sacctmgr -i add user bob     DefaultAccount=research
-sudo sacctmgr -i add user charlie DefaultAccount=batch
-```
-
-`DefaultAccount` is what gets stamped on a job when the user doesn't pass
-`--account=…`. You can list the associations to confirm:
-
-```bash
-$ sacctmgr show associations format=Cluster,Account,User,Partition,Share -P
-Cluster|Account|User|Partition|Share
-slurm-qos-demo|root|||1
-slurm-qos-demo|root|root||1
-slurm-qos-demo|batch|||100
-slurm-qos-demo|batch|charlie||1
-slurm-qos-demo|pcdefault|||1
-slurm-qos-demo|pcdefault|slurm||1
-slurm-qos-demo|pcdefault|ubuntu||1
-slurm-qos-demo|research|||500
-slurm-qos-demo|research|alice||1
-slurm-qos-demo|research|bob||1
-```
-
-(`pcdefault` is ParallelCluster's own service account; ignore it.
-`Share=500` on `research` and `Share=100` on `batch` reflect the fairshare
-values we'll set in the next-to-next section.)
-
-### QoS limits
-
-Now the actual QoS objects. We need three:
-
-| QoS | Purpose | Limits |
-|---|---|---|
-| `research` | High-priority team jobs | `MaxWall=72h`, can preempt `batch-lowprio` |
-| `interactive` | Debugging / notebooks | `MaxWall=1h`, `GrpTRES=gres/gpu=4`, `MaxJobsPU=2` |
-| `batch-lowprio` | Best-effort overnight | `MaxWall=24h`, `MaxJobsPU=10`, preemptible |
-
-```bash
-sudo sacctmgr -i add qos research      Priority=10000 Flags=DenyOnLimit
-sudo sacctmgr -i add qos interactive   Priority=5000  Flags=DenyOnLimit
-sudo sacctmgr -i add qos batch-lowprio Priority=100   Flags=DenyOnLimit
-
-sudo sacctmgr -i modify qos interactive    set \
-    MaxWall=01:00:00 GrpTRES=gres/gpu=4 MaxJobsPerUser=2
-sudo sacctmgr -i modify qos batch-lowprio  set \
-    MaxWall=24:00:00 MaxJobsPerUser=10
-sudo sacctmgr -i modify qos research       set MaxWall=72:00:00
-
-# Allow each account to use the QoSes their users are entitled to
-sudo sacctmgr -i modify account research set qos+=research,interactive
-sudo sacctmgr -i modify account batch    set qos+=batch-lowprio,interactive
-```
-
-The limit knobs are the single most confusing part of QoS configuration.
-Here's a cheat sheet:
-
-| Knob | Scope of the cap | Trigger when exceeded |
-|---|---|---|
-| `MaxTRESPerJob` | A *single job*'s asks | Reject at submission |
-| `MaxTRESPerUser` | All *running* jobs of one user | New jobs pend with `QOSMaxTRESPerUser` |
-| `GrpTRES` | All *running* jobs in this QoS, *across all users* | New jobs pend with `AssocGrpGRES` (despite the name, this triggers on the QoS's group limit too) |
-| `MaxJobsPerUser` | Concurrent running jobs per user | New jobs pend with `QOSMaxJobsPerUser` |
-| `MaxSubmitJobsPerUser` | Submitted-but-not-completed jobs per user | New jobs *rejected* at submission |
-| `MaxWall` | Wall time *requested* (the `--time=`) | Reject at submission if `--time` > MaxWall |
-
-`Flags=DenyOnLimit` makes Slurm reject submissions that would violate any
-of the above *at submission time*, rather than letting them queue forever.
-Use it everywhere — submissions that pend on QoS limits with no chance of
-clearing are a real-world tar pit.
-
-Inspect the resulting QoS configuration:
-
-```bash
-$ sacctmgr show qos format=Name,Priority,GrpTRES,MaxWall,MaxJobsPU,Preempt%30 -P
-Name|Priority|GrpTRES|MaxWall|MaxJobsPU|Preempt
-normal|0||||
-research|10000||3-00:00:00||
-interactive|5000|gres/gpu=4|01:00:00|2|
-batch-lowprio|100||1-00:00:00|10|
-```
-
-(We haven't wired preemption yet — the `Preempt` column will populate
-after the next step.)
-
-### Multifactor priority and fairshare
-
-Two pending jobs from different users in the same QoS — who runs first?
-That's what the [multifactor priority plugin](https://slurm.schedmd.com/priority_multifactor.html)
-decides. The formula is:
-
-> *Priority = w<sub>age</sub>·Age + w<sub>fs</sub>·Fairshare + w<sub>qos</sub>·QoSPriority + w<sub>tres</sub>·TRESFactor*
-
-Where:
-
-- **Age** — how long the job has been pending in the queue (normalized 0-1)
-- **Fairshare** — how *under*-used this association is relative to its
-  share allocation (also 0-1; higher = more entitled to run next)
-- **QoSPriority** — the `Priority` field on the QoS object, normalized
-- **TRESFactor** — a weighted combination of the job's resource request,
-  used to bias toward (or against) GPU-heavy jobs
-
-The weights live in the cluster's `slurm.conf`; in our PC YAML we set:
-
-```yaml
-- PriorityWeightAge: 1000
-- PriorityWeightFairshare: 100000
-- PriorityWeightQOS: 10000
-- PriorityWeightTRES: CPU=1000,Mem=2000,GRES/gpu=4000
-- PriorityDecayHalfLife: 7-0
-```
-
-These values make fairshare dominate (100× the QoS weight), QoS dominate
-within an account, and TRES the tiebreaker between jobs. The
-`PriorityDecayHalfLife=7-0` (7 days) means past usage stops mattering
-for fairshare after about two weeks.
-
-The shares themselves live on the *association*, not the QoS. Give the
-research team 5× the batch team's share:
-
-```bash
-sudo sacctmgr -i modify account research set FairShare=500
-sudo sacctmgr -i modify account batch    set FairShare=100
-```
-
-Then inspect:
-
-```bash
-$ sshare -alP
-Account|User|RawShares|NormShares|RawUsage|NormUsage|EffectvUsage|FairShare|LevelFS|...
-root|||0.000000|0||1.000000||
- root|root|1|0.001661|0|0.000000|0.000000|1.000000|inf
- batch||100|0.166113|0|0.000000|0.000000||inf
-  batch|charlie|1|1.000000|0|0.000000|0.000000|0.000000|inf
- research||500|0.830565|0|0.000000|0.000000||inf
-  research|alice|1|0.500000|0|0.000000|0.000000|0.000000|inf
-  research|bob|1|0.500000|0|0.000000|0.000000|0.000000|inf
-```
-
-`NormShares` is the share-of-cluster you get: `research` has 0.83 (= 500
-÷ (500 + 100 + small root pool)), `batch` has 0.17. After they actually
-run jobs, `NormUsage` accumulates and `LevelFS` (= NormShares ÷
-NormUsage) becomes the fairshare priority factor, decaying with the
-half-life we set. While idle, `LevelFS` is `inf` (no usage to weigh
-against), and after `bob` consumed some cycles in our test the value
-drops:
-
-```bash
-# Post-scenario sshare (after research/alice consumed cluster time):
- research||500|0.830565|47|1.000000|1.000000||0.830565
-  research|alice|1|0.500000|0|0.000000|0.000000|0.333333|inf
-  research|bob|1|0.500000|47|1.000000|1.000000|0.166667|0.500000
-```
-
-(Bob's `LevelFS` dropped to 0.5 — he ate his share, so his next job will
-have lower fairshare priority than alice's until `PriorityDecayHalfLife`
-decays the usage.)
-
-When you're trying to explain "why is my job pended?" the right tool is
-`sprio -l`, which breaks the priority back down into its components so
-you can see exactly which gate is pinning a job's position.
-
-### Preemption
-
-Now we can let `research` and `interactive` *push out* `batch-lowprio`
-jobs when the cluster is full. Two pieces:
-
-1. **Cluster-level**: turned on in our PC YAML via
-   `PreemptType: preempt/qos` and `PreemptMode: REQUEUE` (preempted jobs
-   re-queue rather than die)
-2. **Per-QoS**: each preempting QoS declares which lower QoS it can boot
-
-```bash
-sudo sacctmgr -i modify qos research    set preempt=batch-lowprio
-sudo sacctmgr -i modify qos interactive set preempt=batch-lowprio
-```
-
-With this in place, the scheduler logic becomes:
-
-1. Job `J` in QoS `research` arrives, requesting 8 GPUs
-2. All 16 GPUs are busy running `batch-lowprio` jobs
-3. Slurm picks lower-priority `batch-lowprio` jobs to evict until 8 GPUs
-   are free
-4. Evicted jobs are requeued (kept in `slurmdbd`, re-runnable from the start)
-5. `J` runs
-
-`PreemptMode` has variants — `CANCEL` kills the lower job outright (use
-when restarts are cheap), `SUSPEND` pauses (rarely useful with GPU
-workloads because the GPUs stay allocated), `REQUEUE` is the safe default
-for everything else.
-
-### Partition QoS
-
-Everything we've done so far attaches QoS to *accounts*. There's a second
-hook point — attaching a QoS to a *partition* — which gates anyone using
-that partition, regardless of their account or user QoS. The typical use:
-
-```bash
-# Create a debug QoS with hard 30-min cap
-sudo sacctmgr -i add qos debug-partition Priority=15000 MaxWall=00:30:00 Flags=DenyOnLimit,PartitionMaxNodes
-sudo sacctmgr -i modify partition gpu set QOS=debug-partition
-```
-
-Reading: *any* job submitted to the `gpu` partition is gated by
-`debug-partition`'s limits *in addition to* its own QoS. We're not
-configuring this in our scenario (one partition, one set of users), but
-it's the lever you'd reach for if you wanted, e.g., a separate `debug`
-partition with a hard 30-minute cap regardless of which team submitted.
-
-### Job arrays
-
-Job arrays interact with QoS in two non-obvious ways:
-
-- **`MaxSubmitJobsPerUser`** counts every array task — a `sbatch
-  --array=0-99` against a QoS with `MaxSubmitJobsPerUser=10` is rejected.
-- **`MaxJobsPerUser`** counts only the *running* tasks. The same array
-  works fine, but only `MaxJobsPerUser` tasks run concurrently.
-
-For the QoS in our scenario, we deliberately set
-`MaxSubmitJobsPerUser` lax (no limit) and `MaxJobsPerUser` tight, so
-researchers can submit a 100-element sweep and the cluster trickles them
-through under fairshare and preemption pressure.
-
-## Putting it together — the shared-GPU scenario
-
-The fully assembled policy:
-
-| Account | Users | Default QoS | Allowed QoSes | Fairshare |
-|---|---|---|---|---|
-| `research` | alice, bob | (none — explicit) | `research`, `interactive` | 500 (~83%) |
-| `batch` | charlie | (none — explicit) | `batch-lowprio`, `interactive` | 100 (~17%) |
-
-| QoS | Priority | Limits | Preempts |
-|---|---|---|---|
-| `research` | 10000 | `MaxWall=72h` | `batch-lowprio` |
-| `interactive` | 5000 | `MaxWall=1h`, `GrpTRES=gres/gpu=4`, `MaxJobsPU=2` | `batch-lowprio` |
-| `batch-lowprio` | 100 | `MaxWall=24h`, `MaxJobsPU=10` | — (preemptible) |
-
-Watch the policy in action with three concurrent submissions:
-
-```bash
-# 1. Charlie's batch hogs both nodes
-sudo -u charlie sbatch --partition=gpu --qos=batch-lowprio --gres=gpu:8 \
-                       --nodes=2 --time=04:00:00 --wrap='sleep 14400'
-```
-
-```bash
-$ squeue -o "%.10i %.8u %.10a %.14q %.10j %.8T %.5D %.20R"
-     JOBID     USER    ACCOUNT            QOS       NAME    STATE NODES     NODELIST(REASON)
-         2  charlie      batch  batch-lowprio batch-char  RUNNING     2 gpu-st-g6-48xl-[1-2]
-```
-
-```bash
-# 2. Alice (research) submits — claims the same 16 GPUs
-sudo -u alice sbatch --partition=gpu --qos=research --gres=gpu:8 \
-                     --nodes=2 --time=02:00:00 --wrap='sleep 7200'
-```
-
-Almost immediately, charlie's job goes `PENDING (BeginTime)` (it was
-requeued) and alice's takes over:
-
-```bash
-$ squeue -o "%.10i %.8u %.10a %.14q %.10j %.8T %.5D %.20R"
-     JOBID     USER    ACCOUNT            QOS       NAME    STATE NODES     NODELIST(REASON)
-         2  charlie      batch  batch-lowprio batch-char  PENDING     2          (BeginTime)
-         3    alice   research       research research-a  RUNNING     2 gpu-st-g6-48xl-[1-2]
-```
-
-In `sacct`, the preempted job lands with state `PREEMPTED` (and gets
-re-queued under the same JobID if you check later):
-
-```bash
-$ sacct -a -X --starttime now-1hours --format=JobID,User,Account,QOS%14,AllocTRES%30,State
-JobID             User    Account            QOS                      AllocTRES      State
------------- --------- ---------- -------------- ------------------------------ ----------
-2              charlie      batch  batch-lowprio billing=2,cpu=2,gres/gpu=16,n+  PREEMPTED
-3                alice   research       research billing=2,cpu=2,gres/gpu=16,n+    RUNNING
-```
-
-And when Bob — also research — tries to grab 5 GPUs for an *interactive*
-session, the `interactive` QoS's `GrpTRES=gres/gpu=4` cap rejects the
-launch:
-
-```bash
-$ sudo -u bob sbatch --partition=gpu --qos=interactive --gres=gpu:5 \
-                     --nodes=1 --time=00:10:00 --wrap='sleep 60'
-Submitted batch job 9
-
-$ sacct -j 9 --format=JobID,User,QOS%14,AllocTRES%30,State,ExitCode,Reason
-JobID             User            QOS                      AllocTRES      State ExitCode  Reason
------------- --------- -------------- ------------------------------ ---------- -------- -------
-9                  bob    interactive billing=1,cpu=1,gres/gpu=5,no+     FAILED     0:53    None
-9.batch                                cpu=1,gres/gpu=5,mem=0,node=1  CANCELLED     0:53
-```
-
-Note the subtle behavior: `sbatch` *accepted* the submission (returned a
-job ID), but the job was immediately marked `FAILED` with **ExitCode
-`0:53`** — Slurm's "job exceeded a QoS or association limit"
-termination. The job never ran a single command; it was killed before
-the prolog. This is `Flags=DenyOnLimit` in action: the request would
-exceed `GrpTRES=gres/gpu=4`, so it gets aborted at allocation time
-rather than queuing forever.
-
-The same Bob with `--gres=gpu:4` (within the cap) succeeds:
-
-```bash
-$ sudo -u bob sbatch --partition=gpu --qos=interactive --gres=gpu:4 \
-                     --nodes=1 --time=00:10:00 --wrap='sleep 60'
-Submitted batch job 10
-
-$ squeue -o "%.10i %.8u %.14q %.8T %.30R"
-     JOBID     USER            QOS    STATE               NODELIST(REASON)
-        10      bob    interactive  RUNNING               gpu-st-g6-48xl-1
-```
-
-(Caveat we hit during testing: `salloc --gres=gpu:5` does *not* always
-honor `GrpTRES` the same way `sbatch` does — `salloc` granted the
-allocation past the cap. If you need a hard cap that applies to both
-batch and interactive paths, set `MaxTRESPerJob=gres/gpu=4` *in addition
-to* `GrpTRES` — that constrains the per-job request directly, which
-both `sbatch` and `salloc` honor at submission.)
-
 ## Operational guidance
 
 The walkthrough above is the happy path. Here are the gotchas that bite
@@ -1169,27 +803,61 @@ that were filed and have fixes in flight:
 | [#1096](https://github.com/awslabs/awsome-distributed-ai/issues/1096) | [#1101](https://github.com/awslabs/awsome-distributed-ai/pull/1101) | Accounting-DB template pinned the retired Aurora MySQL `8.0.mysql_aurora.3.07.1`. The PR exposes `EngineVersion` as a parameter (default `8.0.mysql_aurora.3.12.0`, the current latest Serverless-v2-compatible version) so future Aurora rotations don't break the template. |
 | [#1097](https://github.com/awslabs/awsome-distributed-ai/issues/1097) | [#1100](https://github.com/awslabs/awsome-distributed-ai/pull/1100) | Prereqs template hard-coded `SINGLE_AZ_HA_1` for FSx OpenZFS, which isn't offered in many major regions (us-east-1, us-east-2, us-west-2, eu-central-1, eu-west-1, ap-northeast-1, …). Flips the default to `SINGLE_AZ_HA_2`. |
 
-## Wrap-up
+## Wrap-up — and what's next
 
-We've turned a stock ParallelCluster deployment into a multi-tenant GPU
-cluster with three classes of jobs, real per-account limits, working
-fairshare, and preemption — all on top of an Aurora-backed accounting
-database that gives us a permanent audit log of GPU consumption.
+We've taken a stock ParallelCluster deployment and added two things every
+multi-tenant cluster needs: an **Aurora-backed Slurm accounting database**
+where every job lands in `slurmdbd` with full attribution, and a
+**lightweight multi-user identity layer** where `alice`, `bob`, and
+`charlie` share consistent UIDs across the head node and every compute
+node — no LDAP, no IDP, just a CSV file on FSx OpenZFS and a small
+post-install script.
 
-The pieces:
+The building blocks:
 
 - The [`1.architectures/8.accounting-database/`](https://github.com/awslabs/awsome-distributed-ai/tree/main/1.architectures/8.accounting-database)
   CloudFormation template gives you the Aurora cluster + secret + SGs
   needed for `slurmdbd`.
 - The
   [`1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
-  prereqs template handles VPC + FSx, with the HA_2 patch we describe.
+  prereqs template handles VPC + FSx (with the HA_2 patch we describe).
 - ParallelCluster ≥3.3's
   [`SlurmSettings.Database`](https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-yaml-Database-section-v3.html)
-  field wires `slurmdbd` in automatically.
-- Slurm's [QoS docs](https://slurm.schedmd.com/qos.html) and
-  [multifactor priority plugin docs](https://slurm.schedmd.com/priority_multifactor.html)
-  are the canonical references for the knobs we drove above.
+  field wires `slurmdbd` in automatically (and plumbs the RDS CA so TLS
+  "just works").
+- A two-step user pattern — `useradd` on the head node, plus a shared
+  `userlistfile` on FSx OpenZFS that a post-install script reads on every
+  compute node — gives consistent UIDs without an external identity store.
+
+Right now every job correctly attributes to a user, but nothing actually
+*enforces* fair sharing. Alice can still grab all 16 GPUs for 72 hours and
+starve everyone else. The `normal` QoS that every job billed against in
+the smoke test is a placeholder — no priority differentiation, no per-team
+caps, no preemption.
+
+### Up next — Part 2
+
+[**Part 2 — Slurm QoS Deep Dive**](../slurm-qos-on-parallelcluster/) takes
+the cluster you've built here and adds the policy layer:
+
+- **Associations** — bind users to billing accounts so QoS limits have a
+  target to gate against.
+- **QoS limits** — `MaxWall`, `GrpTRES`, `MaxJobsPerUser` and how each
+  knob actually rejects (or pends) a job.
+- **Multifactor priority and fairshare** — the formula behind every
+  pending-job ordering, and how `sshare`/`sprio` let you debug it.
+- **Preemption** — declarative "QoS A can preempt QoS B" rules, demonstrated
+  with a `research` job requeuing a `batch-lowprio` one.
+- **Partition QoS, job arrays, and the assembled multi-tenant scenario.**
+
+By the end you'll have realized the policy:
+
+> *"A research team gets a 50% capacity reservation. Interactive jobs are
+> capped at 1 hour and 4 GPUs per user. Low-priority batch jobs are
+> preemptible by both."*
+
+— with `sacctmgr`, `sshare`, `sprio`, `squeue`, and `sacct` all telling
+the same story, on the cluster you just provisioned.
 
 ### Further reading
 
@@ -1197,7 +865,7 @@ The pieces:
   upstream reference
 - [Managing AWS ParallelCluster SSH Users with OpenLDAP](https://aws.amazon.com/blogs/opensource/managing-aws-parallelcluster-ssh-users-with-openldap/)
   — the production-grade alternative to the lightweight method shown above
-- [SchedMD QoS limit tutorial](https://slurm.schedmd.com/resource_limits.html)
-  — exhaustive reference for the limit knobs
-- [Anatomy of an `sprio` output](https://slurm.schedmd.com/sprio.html) —
-  what the columns actually mean
+- [ParallelCluster `SlurmSettings.Database`](https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-yaml-Database-section-v3.html)
+  — the canonical reference for the wiring done in Step 5
+- [Aurora Serverless v2 docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html)
+  — sizing and operational guidance for the DB

--- a/content/posts/slurm-accounting-qos-on-aws-parallelcluster/index.md
+++ b/content/posts/slurm-accounting-qos-on-aws-parallelcluster/index.md
@@ -459,7 +459,7 @@ Scheduling:
           Efa:
             Enabled: true                # single-AZ → EFA OK
           CapacityReservationTarget:
-            CapacityReservationId: cr-0d11c4b5795ff089d  # 4× g6.48xlarge in us-east-1a
+            CapacityReservationId: <your-odcr-id>  # e.g. cr-0123abcd... — must be in the same AZ as Networking.SubnetIds
       CustomActions:
         OnNodeConfigured:
           Script: s3://${S3_BUCKET}/create-users.sh

--- a/content/posts/slurm-accounting-qos-on-aws-parallelcluster/index.md
+++ b/content/posts/slurm-accounting-qos-on-aws-parallelcluster/index.md
@@ -157,12 +157,12 @@ We'll use `us-east-1` throughout because `g6.48xlarge` is broadly available
 there, and the region has six AZs to pick from when capacity is tight in
 your preferred AZ.
 
-> **AZ caveat for FSx OpenZFS** — at the time of writing, the prereqs
-> template uses `DeploymentType: SINGLE_AZ_HA_1` for `/home`. HA_1 depends
-> on first-generation FSx hardware that has been rolling off in favor of
-> [`SINGLE_AZ_HA_2`](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/deployment-options.html)
-> (Graviton-based, broader AZ coverage). In our test deployments, `HA_1`
-> failed in both `us-east-1a` and `us-east-1b` with:
+> **AZ caveat for FSx OpenZFS** — when this walkthrough was first run, the
+> prereqs template used `DeploymentType: SINGLE_AZ_HA_1` for `/home`, which
+> [is not offered in many regions](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/available-aws-regions.html)
+> — including `us-east-1`, `us-east-2`, `us-west-2`, `eu-central-1`,
+> `eu-west-1`, `ap-northeast-1`, `ap-southeast-1`/`2`, `ap-south-1`, and
+> `ca-central-1`. In `us-east-1` we saw the create fail with:
 >
 > ```
 > The file system creation request failed because OpenZFS file systems with
@@ -170,8 +170,11 @@ your preferred AZ.
 > requested Availability Zones
 > ```
 >
-> For the rest of this post we use a **forked template** with HA_1 changed
-> to HA_2 — a single-line patch:
+> [`PR #1100`](https://github.com/awslabs/awsome-distributed-ai/pull/1100)
+> ([issue #1097](https://github.com/awslabs/awsome-distributed-ai/issues/1097))
+> flips the default to `SINGLE_AZ_HA_2`, which uses gen-2 hardware and is
+> available in every region where HA_1 was failing. If you're running this
+> post before that PR has merged, fork the template with a one-line patch:
 >
 > ```bash
 > sed 's/DeploymentType: SINGLE_AZ_HA_1/DeploymentType: SINGLE_AZ_HA_2/' \
@@ -179,10 +182,11 @@ your preferred AZ.
 >   > parallelcluster-prerequisites-ha2.yaml
 > ```
 >
-> HA_2 has different parameter minimums: **storage ≥256 GiB** and
-> **throughput ≥160 MB/s** (HA_1 allowed 64/128). Reflect this in the
-> create-stack parameters below. The pricing per MB/s is also different;
-> see the [FSx OpenZFS pricing page](https://aws.amazon.com/fsx/openzfs/pricing/).
+> HA_2's throughput minimum is 160 MB/s (vs HA_1's 64 MB/s), and HA_2's
+> valid set is discrete: `160, 320, 640, 1280, 2560, 3840, 5120, 7680,
+> 10240`. Pick a value from that set when overriding `HomeThroughput`. The
+> per-MB/s price is also different; see the
+> [FSx OpenZFS pricing page](https://aws.amazon.com/fsx/openzfs/pricing/).
 
 ### Step 1 — Prereqs stack
 
@@ -202,11 +206,13 @@ Two parameter notes:
 - `HomeThroughput` (the FSx OpenZFS provisioned throughput) defaults to
   **512 MB/s**. That's badly oversized for shared home directories on a
   3-user demo cluster, and FSx OpenZFS prices throughput aggressively. Drop
-  it to the **128 MB/s** minimum allowed for `SINGLE_AZ_HA_1` deployments.
-  (Watch for this gotcha: the `HomeThroughput` parameter has no
-  `AllowedValues` constraint in the template, but FSx rejects values below
-  128 with a `BadRequest` from the API rather than from CloudFormation
-  itself — a failed CREATE that takes you straight to `ROLLBACK_COMPLETE`.)
+  it to **160 MB/s** — the minimum value for the `SINGLE_AZ_HA_2`
+  deployment type we use below. (Watch for this gotcha: the
+  `HomeThroughput` parameter has no `AllowedValues` constraint in the
+  template, and FSx accepts only a discrete set of values that *differs by
+  deployment type*. Pass a value not in the set — e.g. `512` against HA_2
+  — and FSx rejects with a `BadRequest` from the API rather than from
+  CloudFormation itself, sending the stack straight to `ROLLBACK_COMPLETE`.)
 
 These two knobs cut storage cost from ~$1.70/hr to ~$0.55/hr.
 
@@ -281,17 +287,24 @@ is to satisfy the API.
 
 ### Step 3 — Provision the accounting DB
 
-Now the database itself, with the prereqs subnets wired in. One patch
-first: the template hard-codes an Aurora MySQL engine version
-(`8.0.mysql_aurora.3.07.1` at the time of this writing) that
+Now the database itself, with the prereqs subnets wired in.
+
+When this walkthrough was first run, the template hard-coded
+`EngineVersion: "8.0.mysql_aurora.3.07.1"` — a version
 [AWS rotates out of service on a rolling basis](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.Versions.html).
-If the version named in the template is no longer offered in your region,
-CloudFormation fails with `Cannot find version 8.0.mysql_aurora.3.07.1 for
-aurora-mysql`. Patch to a current version (`aws rds
-describe-db-engine-versions --engine aurora-mysql` lists what's live):
+CloudFormation failed with `Cannot find version 8.0.mysql_aurora.3.07.1 for
+aurora-mysql`.
+[`PR #1101`](https://github.com/awslabs/awsome-distributed-ai/pull/1101)
+([issue #1096](https://github.com/awslabs/awsome-distributed-ai/issues/1096))
+exposes `EngineVersion` as a CloudFormation parameter so the template can
+absorb future Aurora rotations without code edits. If you're running this
+before that PR has merged, sed the template to a currently-available
+version (`aws rds describe-db-engine-versions --engine aurora-mysql --query
+'DBEngineVersions[?Status==\`available\`].EngineVersion'` lists what's
+live — `8.0.mysql_aurora.3.12.0` was the latest at the time of writing):
 
 ```bash
-sed 's|EngineVersion: "8.0.mysql_aurora.3.07.1"|EngineVersion: "8.0.mysql_aurora.3.09.0"|' \
+sed 's|EngineVersion: "8.0.mysql_aurora.3.07.1"|EngineVersion: "8.0.mysql_aurora.3.12.0"|' \
   1.architectures/8.accounting-database/cf_database-accounting.yaml \
   > cf_database-accounting-patched.yaml
 ```
@@ -1145,28 +1158,16 @@ in production:
 | Aurora ACU floor charges 24/7 | Even an idle cluster bills ~$0.12/hr from Aurora | Acceptable; if you tear the cluster down nightly, also delete the DB stack. |
 | `require_secure_transport: ON` rejects plaintext clients | Manual `mysql` clients connecting directly fail with `SSL connection error` | Use `mysql --ssl-mode=REQUIRED --ssl-ca=/path/to/global-bundle.pem`, or connect via `slurmdbd` only. |
 
-Two issues we noticed in passing in the source repository
-([`awslabs/awsome-distributed-ai`](https://github.com/awslabs/awsome-distributed-ai))
-that are worth filing as follow-up PRs:
+Drafting this post surfaced four upstream issues in
+[`awslabs/awsome-distributed-ai`](https://github.com/awslabs/awsome-distributed-ai)
+that were filed and have fixes in flight:
 
-- The accounting DB
-  [README's slurmdbd snippet](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/8.accounting-database/README.md#configure-slurm-accounting)
-  has three typos (`custeradmin` for `clusteradmin`, `slurmdctld` for
-  `slurmctld`, and a copy-paste reference to "LDAP User Interface") and
-  doesn't mention the `StorageParameters=SSL_CA=...` needed for the
-  TLS-required cluster. Fine for someone working on autopilot, painful for
-  someone copy-pasting.
-- The
-  [prereqs CloudFormation template](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
-  hard-codes `SINGLE_AZ_HA_1` for the OpenZFS deployment type — which is
-  not available in many AZs. Exposing this as a parameter (with `HA_2` as
-  a recommended default) would save people the surprise rollback.
-- The
-  [accounting DB template](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/8.accounting-database/cf_database-accounting.yaml)
-  hard-codes Aurora MySQL `8.0.mysql_aurora.3.07.1` — a version AWS has
-  since retired. Pinning by minor version makes the template stop working
-  on a rolling cadence; either pin to the family (e.g. `8.0.mysql_aurora.3`)
-  and let RDS pick latest, or expose as a parameter.
+| Issue | PR | What it fixes |
+|---|---|---|
+| [#1094](https://github.com/awslabs/awsome-distributed-ai/issues/1094) | [#1098](https://github.com/awslabs/awsome-distributed-ai/pull/1098) | Three typos and a leftover LDAP copy/paste line in the accounting-DB README (`custeradmin` → `clusteradmin`, `slurmdctld` → `slurmctld`, "LDAP User Interface" → "database"). |
+| [#1095](https://github.com/awslabs/awsome-distributed-ai/issues/1095) | [#1099](https://github.com/awslabs/awsome-distributed-ai/pull/1099) | The HyperPod `slurmdbd.conf` snippet doesn't configure TLS even though the Aurora cluster parameter group sets `require_secure_transport: ON`. Adds the RDS CA bundle download and `StorageParameters=SSL_CA=...`. ParallelCluster is unaffected — PC plumbs SSL automatically. |
+| [#1096](https://github.com/awslabs/awsome-distributed-ai/issues/1096) | [#1101](https://github.com/awslabs/awsome-distributed-ai/pull/1101) | Accounting-DB template pinned the retired Aurora MySQL `8.0.mysql_aurora.3.07.1`. The PR exposes `EngineVersion` as a parameter (default `8.0.mysql_aurora.3.12.0`, the current latest Serverless-v2-compatible version) so future Aurora rotations don't break the template. |
+| [#1097](https://github.com/awslabs/awsome-distributed-ai/issues/1097) | [#1100](https://github.com/awslabs/awsome-distributed-ai/pull/1100) | Prereqs template hard-coded `SINGLE_AZ_HA_1` for FSx OpenZFS, which isn't offered in many major regions (us-east-1, us-east-2, us-west-2, eu-central-1, eu-west-1, ap-northeast-1, …). Flips the default to `SINGLE_AZ_HA_2`. |
 
 ## Wrap-up
 

--- a/content/posts/slurm-accounting-qos-on-aws-parallelcluster/index.md
+++ b/content/posts/slurm-accounting-qos-on-aws-parallelcluster/index.md
@@ -1,0 +1,1207 @@
+---
+title: "Multi-Tenant Slurm on AWS ParallelCluster: Accounting and QoS Deep Dive"
+date: 2026-05-16
+draft: true
+author: ["Keita Watanabe"]
+description: "Stand up a Slurm accounting database, wire it into AWS ParallelCluster, onboard multiple users without LDAP, and use Slurm QoS to govern shared GPU capacity across teams."
+tags: ["slurm", "qos", "accounting", "parallelcluster", "aurora", "rds", "multi-tenant", "scheduling", "fairshare", "preemption", "aws"]
+ShowToc: true
+TocOpen: false
+---
+
+
+A shared GPU cluster without enforcement is a queue with a [tragedy of the
+commons](https://en.wikipedia.org/wiki/Tragedy_of_the_commons) baked in. One
+researcher launches a 64-GPU sweep at 9pm; the on-call engineer can't get a
+1-GPU interactive session for debugging the next morning; a third user's
+batch job — submitted a week ago and patiently waiting — keeps getting
+shuffled to the back because nothing prevents the latest submissions from
+front-running it. The scheduler is doing exactly what it was configured to do:
+nothing about it.
+
+[Slurm](https://slurm.schedmd.com/) ships the machinery to fix this — but it
+requires two pieces of infrastructure that, on AWS, you have to assemble
+yourself. First, a *job accounting database* — typically MySQL — that records
+every job, its resource usage, and the account it billed against. Second, a
+*Quality of Service (QoS)* layer that uses that account information to enforce
+per-team capacity reservations, per-user limits, and preemption rules. Without
+the database, QoS has no associations to gate against; without QoS, the
+database is a passive log of how badly your cluster got over-subscribed.
+
+This post is a deep dive on both, for **AWS ParallelCluster** administrators
+operating multi-tenant GPU clusters. We'll provision the accounting database
+using the CloudFormation template at
+[`1.architectures/8.accounting-database/`](https://github.com/awslabs/awsome-distributed-ai/tree/main/1.architectures/8.accounting-database)
+in the [awslabs/awsome-distributed-ai](https://github.com/awslabs/awsome-distributed-ai)
+repo, wire it into ParallelCluster, onboard a handful of users with a
+lightweight (no-LDAP) approach, and then drive a complete QoS configuration
+realizing a concrete multi-tenant policy:
+
+> *"A research team gets a 50% capacity reservation. Interactive jobs are
+> capped at 1 hour and 4 GPUs per user. Low-priority batch jobs are
+> preemptible by both."*
+
+By the end you'll have a cluster where `sacctmgr`, `sshare`, and `sprio` all
+have something to say, and you'll understand what each of them is saying.
+
+> **Audience**: cluster administrators. We assume comfort with `sbatch`,
+> `squeue`, basic VPC and IAM, and CloudFormation. We do *not* assume any
+> prior Slurm-accounting or QoS experience.
+
+## Why an external accounting database?
+
+Slurm without `slurmdbd` will happily run jobs, scheduling them with the
+[multifactor priority plugin](https://slurm.schedmd.com/priority_multifactor.html)
+or any plugin you point it at. What it *won't* do is enforce per-account or
+per-user limits in any persistent way, because those limits live in
+associations — *(cluster, account, user, partition)* tuples — that are kept
+in the accounting database. From [the Slurm docs](https://slurm.schedmd.com/accounting.html):
+
+> Slurm Workload Manager can be configured to collect accounting information
+> for every job and job step executed […]. Accounting records can be written
+> to a simple text file or a database […]. Storing information directly into
+> a database can offer many benefits, including a much faster turnaround
+> time for analyzing complex queries from administrators.
+
+The "store to a flat file" mode (`jobcomp/filetxt`, used as a default in
+several AWS sample configurations including
+[`cluster-vanilla.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/cluster-templates/cluster-vanilla.yaml#L42))
+is fine for "what jobs ran when" forensics, but it cannot back QoS — QoS
+requires the relational schema that `slurmdbd` lays out on top of MySQL or
+MariaDB. So the *first* thing we need is a managed MySQL.
+
+On AWS, the natural place to land that is **Aurora Serverless v2 (MySQL
+8.0)** — it scales down to fractional ACU when idle (`slurmdbd` is bursty),
+encrypts at rest, requires TLS, and is fully managed. The repo provides a
+[CloudFormation template](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/8.accounting-database/cf_database-accounting.yaml)
+that deploys exactly this, with the security-group plumbing already worked
+out.
+
+## Architecture
+
+The full picture has four data planes:
+
+```mermaid
+flowchart LR
+    subgraph VPC["VPC (10.0.0.0/16)"]
+        subgraph Pub["Public subnet"]
+            HN["Head node<br/>slurmctld + slurmdbd<br/>(c5.xlarge)"]
+            NAT["NAT Gateway"]
+        end
+        subgraph Priv["Private subnet(s)"]
+            GPU["Compute fleet<br/>2× g5.48xlarge<br/>(EFA, 8× A10G each)"]
+            DB[("Aurora Serverless v2<br/>MySQL 8.0<br/>TLS required")]
+            FSXL["FSx Lustre /fsx<br/>1.2 TB, P2 125 MB/s/TiB"]
+            FSXZ["FSx OpenZFS /home<br/>64 GB, HA-1 64 MB/s"]
+        end
+    end
+    SM["Secrets Manager<br/>(DB password)"]
+    S3["S3<br/>create-users.sh<br/>post-install script"]
+
+    HN -- "slurmd RPC" --> GPU
+    HN -- "TCP 3306 (TLS)" --> DB
+    HN -- "GetSecretValue" --> SM
+    GPU -- "NFS /home" --> FSXZ
+    GPU -- "Lustre /fsx" --> FSXL
+    GPU -. "fetch script<br/>on first boot" .-> S3
+```
+
+A few details worth flagging up front:
+
+- **`slurmctld` and `slurmdbd` both live on the head node.** This is the
+  ParallelCluster default; for very large clusters you can split `slurmdbd`
+  onto its own host, but that's out of scope here.
+- **Aurora sits in private subnets only.** The CloudFormation template
+  enforces `PubliclyAccessible: false` and `StorageEncrypted: true`, and the
+  cluster parameter group sets `require_secure_transport: ON` — so any
+  client connection must be over TLS. ParallelCluster handles this for you;
+  hand-rolled `slurmdbd.conf` would need `StorageParameters=SSL_CA=...`.
+- **Two security groups, not one.** The template emits a *server* SG
+  (attached to Aurora, accepts inbound only from the *client* SG) and a
+  *client* SG (which you attach to the head node). This means the head node
+  can reach the DB, and nothing else in the VPC can — including the compute
+  fleet, which has no business talking to `slurmdbd` directly.
+- **The cluster fleet only ever talks to `slurmctld`** on the head node, via
+  Slurm's own RPC. The DB is never on the compute path.
+
+There's one wrinkle the source template doesn't currently document: Aurora's
+`DBSubnetGroup` requires subnets in **at least two different availability
+zones**, but the repo's
+[`parallelcluster-prerequisites.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
+creates exactly one private subnet, in a single AZ specified by the
+`PrimarySubnetAZ` parameter. We'll work around that with one extra
+`aws ec2 create-subnet` call below.
+
+## Provision the foundation
+
+We're going to build this in three CloudFormation layers plus one S3 bucket:
+
+1. **Prereqs**: VPC, NAT, security groups, FSx Lustre, FSx OpenZFS
+2. **Manual fix**: a second private subnet in a different AZ (for Aurora)
+3. **Accounting DB**: Aurora Serverless v2 + secret + client/server SGs
+4. **S3 bucket**: home for the `create-users.sh` post-install script
+5. **ParallelCluster**: head node + a single GPU queue, wired to the DB
+
+### Pin the AWS environment
+
+Every command in this post assumes you've pinned the profile and region for
+the duration of the session. Pick once, verify, never `unset` mid-run:
+
+```bash
+export AWS_PROFILE=<your-profile>
+export AWS_REGION=us-east-1
+aws sts get-caller-identity   # confirm account before any deploy
+```
+
+We'll use `us-east-1` throughout because `g5.48xlarge` is available in five
+of its AZs (`1a`, `1b`, `1c`, `1d`, `1f`), which gives us plenty of room to
+land the cluster and pick a second AZ for the DB.
+
+> **AZ caveat for FSx OpenZFS** — at the time of writing, the prereqs
+> template uses `DeploymentType: SINGLE_AZ_HA_1` for `/home`. HA_1 depends
+> on first-generation FSx hardware that has been rolling off in favor of
+> [`SINGLE_AZ_HA_2`](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/deployment-options.html)
+> (Graviton-based, broader AZ coverage). In our test deployments, `HA_1`
+> failed in both `us-east-1a` and `us-east-1b` with:
+>
+> ```
+> The file system creation request failed because OpenZFS file systems with
+> the provided deployment type and storage type are not available in the
+> requested Availability Zones
+> ```
+>
+> For the rest of this post we use a **forked template** with HA_1 changed
+> to HA_2 — a single-line patch:
+>
+> ```bash
+> sed 's/DeploymentType: SINGLE_AZ_HA_1/DeploymentType: SINGLE_AZ_HA_2/' \
+>   1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml \
+>   > parallelcluster-prerequisites-ha2.yaml
+> ```
+>
+> HA_2 has different parameter minimums: **storage ≥256 GiB** and
+> **throughput ≥160 MB/s** (HA_1 allowed 64/128). Reflect this in the
+> create-stack parameters below. The pricing per MB/s is also different;
+> see the [FSx OpenZFS pricing page](https://aws.amazon.com/fsx/openzfs/pricing/).
+
+### Step 1 — Prereqs stack
+
+The repo's
+[`parallelcluster-prerequisites.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
+emits everything we need: a VPC with `10.0.0.0/16` (public) and `10.1.0.0/16`
+(private) CIDR ranges, an Internet Gateway, a NAT Gateway, an S3 VPC
+endpoint, an EFA-friendly all-to-all security group, plus FSx Lustre (for
+`/fsx`) and FSx OpenZFS (for `/home`).
+
+Two parameter notes:
+
+- `PerUnitStorageThroughput` defaults to **250 MB/s/TiB**, which is fine for
+  real training but doubles the per-GB-month cost over the **125 MB/s/TiB**
+  minimum tier. For a QoS-walkthrough cluster we don't need the throughput,
+  so we knock it down.
+- `HomeThroughput` (the FSx OpenZFS provisioned throughput) defaults to
+  **512 MB/s**. That's badly oversized for shared home directories on a
+  3-user demo cluster, and FSx OpenZFS prices throughput aggressively. Drop
+  it to the **128 MB/s** minimum allowed for `SINGLE_AZ_HA_1` deployments.
+  (Watch for this gotcha: the `HomeThroughput` parameter has no
+  `AllowedValues` constraint in the template, but FSx rejects values below
+  128 with a `BadRequest` from the API rather than from CloudFormation
+  itself — a failed CREATE that takes you straight to `ROLLBACK_COMPLETE`.)
+
+These two knobs cut storage cost from ~$1.70/hr to ~$0.55/hr.
+
+```bash
+aws cloudformation create-stack \
+  --stack-name slurm-qos-demo-prereqs \
+  --template-body file://parallelcluster-prerequisites-ha2.yaml \
+  --parameters \
+    ParameterKey=VPCName,ParameterValue=slurm-qos-demo \
+    ParameterKey=PrimarySubnetAZ,ParameterValue=us-east-1b \
+    ParameterKey=Capacity,ParameterValue=1200 \
+    ParameterKey=PerUnitStorageThroughput,ParameterValue=125 \
+    ParameterKey=HomeCapacity,ParameterValue=256 \
+    ParameterKey=HomeThroughput,ParameterValue=160 \
+  --capabilities CAPABILITY_IAM
+```
+
+Wait for `CREATE_COMPLETE` (~15-20 minutes; FSx Lustre is the slow part):
+
+```bash
+aws cloudformation wait stack-create-complete --stack-name slurm-qos-demo-prereqs
+```
+
+And export the outputs we'll need downstream:
+
+```bash
+PREREQS_OUTPUTS=$(aws cloudformation describe-stacks \
+  --stack-name slurm-qos-demo-prereqs \
+  --query 'Stacks[0].Outputs' --output json)
+
+VPC_ID=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="VPC") | .OutputValue')
+PRIMARY_SUBNET=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="PrimaryPrivateSubnet") | .OutputValue')
+PUBLIC_SUBNET=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="PublicSubnet") | .OutputValue')
+EFA_SG=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="SecurityGroup") | .OutputValue')
+FSXL_ID=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="FSxLustreFilesystemId") | .OutputValue')
+FSXZ_VOL_ID=$(echo "$PREREQS_OUTPUTS" | jq -r '.[] | select(.OutputKey=="FSxORootVolumeId") | .OutputValue')
+```
+
+### Step 2 — Add a second private subnet
+
+This is the part the prereqs template doesn't do for you. The Aurora
+DBSubnetGroup demands AZ-redundancy, so we carve a second `/19` out of the
+private CIDR block in a *different* AZ:
+
+```bash
+# Pick a second AZ that has capacity for whatever else you might want to run there.
+# (Must be different from PrimarySubnetAZ, so we use 1c here since the prereqs landed in 1b.)
+SECONDARY_AZ=us-east-1c
+
+SECONDARY_SUBNET=$(aws ec2 create-subnet \
+  --vpc-id "$VPC_ID" \
+  --cidr-block 10.1.128.0/19 \
+  --availability-zone "$SECONDARY_AZ" \
+  --tag-specifications "ResourceType=subnet,Tags=[{Key=Name,Value=slurm-qos-demo Private Subnet - $SECONDARY_AZ}]" \
+  --query 'Subnet.SubnetId' --output text)
+
+echo "Secondary private subnet: $SECONDARY_SUBNET"
+
+# Associate it with the existing private route table (NAT-routed).
+PRIVATE_RT=$(aws ec2 describe-route-tables \
+  --filters "Name=vpc-id,Values=$VPC_ID" "Name=route.nat-gateway-id,Values=*" \
+  --query 'RouteTables[0].RouteTableId' --output text)
+aws ec2 associate-route-table --subnet-id "$SECONDARY_SUBNET" --route-table-id "$PRIVATE_RT"
+```
+
+The DB doesn't actually receive cross-AZ traffic in our setup (the head node
+is in the public subnet, which routes through the primary AZ's NAT gateway),
+but RDS requires the *subnet group* to span ≥2 AZs whether or not Aurora
+deploys an instance into both. The serverless v2 cluster we deploy below
+runs one writer instance in the primary AZ; the secondary subnet's only job
+is to satisfy the API.
+
+### Step 3 — Provision the accounting DB
+
+Now the database itself, with the prereqs subnets wired in. One patch
+first: the template hard-codes an Aurora MySQL engine version
+(`8.0.mysql_aurora.3.07.1` at the time of this writing) that
+[AWS rotates out of service on a rolling basis](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.Versions.html).
+If the version named in the template is no longer offered in your region,
+CloudFormation fails with `Cannot find version 8.0.mysql_aurora.3.07.1 for
+aurora-mysql`. Patch to a current version (`aws rds
+describe-db-engine-versions --engine aurora-mysql` lists what's live):
+
+```bash
+sed 's|EngineVersion: "8.0.mysql_aurora.3.07.1"|EngineVersion: "8.0.mysql_aurora.3.09.0"|' \
+  1.architectures/8.accounting-database/cf_database-accounting.yaml \
+  > cf_database-accounting-patched.yaml
+```
+
+Then deploy:
+
+```bash
+aws cloudformation create-stack \
+  --stack-name slurm-qos-demo-accounting \
+  --template-body file://cf_database-accounting-patched.yaml \
+  --parameters \
+    ParameterKey=ClusterName,ParameterValue=slurm-qos-demo-accounting \
+    ParameterKey=MinCapacity,ParameterValue=1 \
+    ParameterKey=MaxCapacity,ParameterValue=4 \
+    ParameterKey=VpcId,ParameterValue="$VPC_ID" \
+    ParameterKey=SubnetIds,ParameterValue="\"$PRIMARY_SUBNET,$SECONDARY_SUBNET\"" \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
+aws cloudformation wait stack-create-complete --stack-name slurm-qos-demo-accounting
+```
+
+Capture the outputs ParallelCluster will need:
+
+```bash
+DB_OUTPUTS=$(aws cloudformation describe-stacks \
+  --stack-name slurm-qos-demo-accounting \
+  --query 'Stacks[0].Outputs' --output json)
+
+DB_HOST=$(echo "$DB_OUTPUTS" | jq -r '.[] | select(.OutputKey=="DatabaseHost") | .OutputValue')
+DB_USER=$(echo "$DB_OUTPUTS" | jq -r '.[] | select(.OutputKey=="DatabaseAdminUser") | .OutputValue')
+DB_SECRET=$(echo "$DB_OUTPUTS" | jq -r '.[] | select(.OutputKey=="DatabaseSecretArn") | .OutputValue')
+DB_CLIENT_SG=$(echo "$DB_OUTPUTS" | jq -r '.[] | select(.OutputKey=="DatabaseClientSecurityGroup") | .OutputValue')
+
+echo "Connect head node to DB via SG: $DB_CLIENT_SG"
+```
+
+`DB_CLIENT_SG` is the critical handle: it's the security group whose only
+permission is to reach the Aurora cluster on TCP 3306. Anything you attach
+that SG to becomes a permitted DB client. The head node gets it; nothing
+else needs to.
+
+### Step 4 — S3 bucket for the post-install script
+
+ParallelCluster runs `CustomActions.OnNodeConfigured` on every compute node
+after it boots, fetching the script from S3. We need a bucket for that:
+
+```bash
+S3_BUCKET="adt-slurm-qos-demo-$(aws sts get-caller-identity --query Account --output text)-$AWS_REGION"
+aws s3 mb "s3://$S3_BUCKET"
+```
+
+The script itself is short and exactly what the
+[OpenLDAP-alternative AWS blog](https://aws.amazon.com/blogs/opensource/managing-aws-parallelcluster-ssh-users-with-openldap/)
+recommends — it reads `/home/shared/userlistfile` (a CSV of `username,uid` lines
+that the head node maintains) and `useradd`s each entry on the compute node:
+
+```bash
+cat > create-users.sh <<'EOF'
+#!/bin/bash
+. "/etc/parallelcluster/cfnconfig"
+
+IFS=","
+
+if [ "${cfn_node_type}" = "ComputeFleet" ]; then
+    while read USERNAME USERID
+    do
+        # -M do not create home since head node is exporting /homes via NFS
+        # -u to set UID to match what is set on the head node
+        if ! [ $(id -u $USERNAME 2>/dev/null || echo -1) -ge 0 ]; then
+            useradd -M -u $USERID $USERNAME
+        fi
+    done < "/home/shared/userlistfile"
+fi
+EOF
+chmod +x create-users.sh
+aws s3 cp create-users.sh "s3://$S3_BUCKET/"
+```
+
+We'll talk about *why* this script exists (and the LDAP alternative) in the
+multi-user section below. For now it's just sitting in the bucket waiting
+for the compute fleet to fetch it.
+
+### Step 5 — ParallelCluster itself
+
+ParallelCluster 3.3+ supports Slurm accounting natively via the
+[`SlurmSettings.Database`](https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-yaml-Database-section-v3.html)
+block. We give it the DB host, the admin user name, and the Secrets Manager
+ARN; ParallelCluster generates the `slurmdbd.conf` for us. We use
+`CustomSlurmSettings` to add GPU TRES tracking (so `sreport` can tell us
+who consumed how many GPU-hours):
+
+```yaml
+# slurm-qos-demo.yaml
+Region: us-east-1
+Imds:
+  ImdsSupport: v2.0
+Image:
+  Os: ubuntu2204
+HeadNode:
+  InstanceType: c5.xlarge
+  Networking:
+    SubnetId: ${PUBLIC_SUBNET}
+    AdditionalSecurityGroups:
+      - ${EFA_SG}
+      - ${DB_CLIENT_SG}              # critical: lets head node reach Aurora
+  LocalStorage:
+    RootVolume:
+      Size: 200
+      DeleteOnTermination: true
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+  Imds:
+    Secured: false
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    ScaledownIdletime: 60
+    QueueUpdateStrategy: DRAIN
+    Database:
+      Uri: ${DB_HOST}:3306
+      UserName: ${DB_USER}
+      PasswordSecretArn: ${DB_SECRET}
+    CustomSlurmSettings:
+      - AccountingStorageTRES: gres/gpu
+      - PriorityType: priority/multifactor
+      - PriorityDecayHalfLife: 7-0      # 7 days for fairshare decay
+      - PriorityWeightAge: 1000
+      - PriorityWeightFairshare: 100000
+      - PriorityWeightQOS: 10000
+      - PriorityWeightTRES: CPU=1000,Mem=2000,GRES/gpu=4000
+      - PreemptType: preempt/qos
+      - PreemptMode: REQUEUE
+  SlurmQueues:
+    - Name: gpu
+      CapacityType: ONDEMAND
+      Networking:
+        # Single subnet matching the AZ of our on-demand capacity reservation
+        # (ODCR). For an opportunistic deployment without a CR, list multiple
+        # subnets across AZs so PC can fall over when one AZ is capacity-
+        # constrained — but note that multi-AZ disables EFA and managed
+        # placement groups (see Operational guidance below).
+        SubnetIds:
+          - ${SUB_1A}              # us-east-1a — same AZ as the ODCR
+        AdditionalSecurityGroups:
+          - ${EFA_SG}
+        PlacementGroup:
+          Enabled: true            # single-AZ → can use a placement group
+      ComputeSettings:
+        LocalStorage:
+          EphemeralVolume:
+            MountDir: /scratch
+          RootVolume:
+            Size: 200
+      ComputeResources:
+        - Name: g6-48xl
+          # g6.48xlarge: 8× NVIDIA L4 GPUs per node; 2 nodes = 16 GPUs total.
+          # The walkthrough originally targeted g5.48xlarge but us-east-1 was
+          # capacity-constrained on that SKU across multiple AZs; we landed
+          # an on-demand capacity reservation (ODCR) for g6.48xlarge in
+          # us-east-1a instead. The QoS scenarios below assume 8 GPUs/node.
+          InstanceType: g6.48xlarge
+          MinCount: 2                    # keep both nodes warm for the demo
+          MaxCount: 2
+          Efa:
+            Enabled: true                # single-AZ → EFA OK
+          CapacityReservationTarget:
+            CapacityReservationId: cr-0d11c4b5795ff089d  # 4× g6.48xlarge in us-east-1a
+      CustomActions:
+        OnNodeConfigured:
+          Script: s3://${S3_BUCKET}/create-users.sh
+      Iam:
+        S3Access:
+          - BucketName: ${S3_BUCKET}
+SharedStorage:
+  - Name: home
+    MountDir: /home
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      VolumeId: ${FSXZ_VOL_ID}
+  - Name: fsx
+    MountDir: /fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      FileSystemId: ${FSXL_ID}
+Monitoring:
+  DetailedMonitoring: false
+  Logs:
+    CloudWatch:
+      Enabled: true
+```
+
+A few choices worth explaining:
+
+- The **multifactor priority weights** (Age, Fairshare, QOS, TRES) are set
+  to representative values, with Fairshare dominating (100,000 vs 10,000 for
+  QoS). These are the *relative* magnitudes you'd typically tune for a
+  research-team-vs-batch-vs-interactive cluster; we'll inspect them with
+  `sprio` in the QoS section.
+- **`PreemptType: preempt/qos`** turns on per-QoS preemption — the
+  preemption relationship is then declared on each QoS object via
+  `Preempt=<lower-qos>`. With `PreemptMode: REQUEUE`, preempted jobs go
+  back into the queue rather than being killed outright.
+- **`AccountingStorageTRES: gres/gpu`** is what tells `slurmdbd` to record
+  GPU usage as a TRES (Trackable RESource) on every job; without it,
+  `sreport` will only show CPU consumption.
+- The head node lands in the *public* subnet so we can `pcluster ssh` to
+  it directly. The compute fleet stays in the *primary private* subnet.
+- We deliberately attach **two security groups** to the head node: the EFA
+  SG (so it can talk to compute nodes) and the DB client SG (so it can
+  reach Aurora). This is the trick that wires everything together.
+
+Materialize the YAML and create:
+
+```bash
+envsubst < slurm-qos-demo.yaml.tpl > slurm-qos-demo.yaml
+pcluster create-cluster -n slurm-qos-demo -c slurm-qos-demo.yaml
+pcluster describe-cluster -n slurm-qos-demo --query clusterStatus
+# Wait for CREATE_COMPLETE (~15-20 min). Then SSH:
+pcluster ssh -n slurm-qos-demo
+```
+
+ParallelCluster uses SSM Session Manager when no SSH key is configured, so
+no key-pair management is required for a one-shot demo. Once you're on the
+head node, sanity-check the accounting plumbing:
+
+```bash
+$ sacctmgr show cluster -P
+Cluster|ControlHost|ControlPort|RPC|Share|GrpJobs|GrpTRES|GrpSubmit|MaxJobs|MaxTRES|MaxSubmit|MaxWall|QOS|Def QOS
+slurm-qos-demo|10.0.47.111|6820|11264|1||||||||normal|
+
+$ sinfo
+PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+gpu*         up   infinite      2   idle gpu-st-g6-48xl-[1-2]
+
+$ sacct
+JobID           JobName  Partition    Account  AllocCPUS      State ExitCode
+------------ ---------- ---------- ---------- ---------- ---------- --------
+```
+
+A row in `sacctmgr show cluster` (with the cluster talking to slurmctld
+on port 6820), two `idle` GPU nodes in `sinfo`, and an empty `sacct`
+confirms `slurmdbd` is connected, the schema is initialized, and the
+cluster has registered itself with the database. We're ready to onboard
+users.
+
+## Multi-user setup without LDAP
+
+ParallelCluster doesn't ship a user-management layer. The
+[canonical solution](https://aws.amazon.com/blogs/opensource/managing-aws-parallelcluster-ssh-users-with-openldap/)
+is to stand up an OpenLDAP server and join the cluster to it; that gives you
+real directory services, centralized password rotation, and group
+management. It's also a lot of moving parts for a small team.
+
+The shortcut — the one we use here — is to maintain users on the **head node**
+as the source of truth, and run a tiny post-install script on every compute
+node that mirrors the head node's UID database. There's no central
+authentication; SSH access is via key pairs, and Slurm enforces association
+limits using these accounts as identifiers. It scales to dozens of users on
+a small cluster, and it has the great virtue of being something you can read
+in 20 lines of bash.
+
+> **Don't use this for production.** Users share the same permissions
+> bucket (no group-based authorization, no centralized password rotation,
+> no audit log), and adding a user requires manually editing
+> `/home/shared/userlistfile` then bouncing the compute fleet. For real
+> multi-tenancy, the [OpenLDAP blog](https://aws.amazon.com/blogs/opensource/managing-aws-parallelcluster-ssh-users-with-openldap/)
+> remains the right starting point.
+
+### Step 1 — Create the users on the head node
+
+After `pcluster ssh -n slurm-qos-demo`, become root and provision three test
+users:
+
+```bash
+sudo su -
+
+for U in alice bob charlie; do
+  useradd -m -s /bin/bash "$U"
+  passwd -l "$U"                       # no password — SSH-key only
+  mkdir -p "/home/$U/.ssh"
+  ssh-keygen -t rsa -f "/home/$U/.ssh/id_rsa" -q -N ""
+  cat "/home/$U/.ssh/id_rsa.pub" > "/home/$U/.ssh/authorized_keys"
+  chown -R "$U:$U" "/home/$U/.ssh"
+  chmod 700 "/home/$U/.ssh"
+  chmod 600 "/home/$U/.ssh/"*
+done
+```
+
+This is straight out of the user's
+[ParallelCluster cookbook](https://aws.amazon.com/blogs/opensource/managing-aws-parallelcluster-ssh-users-with-openldap/)
+— `useradd -m` to create a home directory (which lands on the shared FSx
+OpenZFS `/home` because of how we mounted it in the cluster YAML), and a
+key pair per user so they can SSH between nodes for MPI launches.
+
+### Step 2 — Publish the UID list to compute nodes
+
+The compute fleet doesn't share `/etc/passwd` with the head node. Slurm
+needs the same UID on both sides — otherwise file ownership mismatches and
+job submissions silently fail. We solve this with a shared CSV file in
+the FSx OpenZFS `/home` mount, which both the head node and every compute
+node have read access to. Create a world-writable scratch dir for it
+first:
+
+```bash
+# Still as root on the head node:
+mkdir -p /home/shared
+chmod 1777 /home/shared
+rm -f /home/shared/userlistfile
+for U in alice bob charlie; do
+  echo "$U,$(id -u $U)" >> /home/shared/userlistfile
+done
+cat /home/shared/userlistfile
+```
+```
+alice,1001
+bob,1002
+charlie,1003
+```
+
+(Your UIDs may differ — `useradd` picks the next available.)
+
+### Step 3 — The post-install script
+
+Compute nodes consult `/etc/parallelcluster/cfnconfig` on boot to learn
+their role; if they're a `ComputeFleet` node, our
+[`create-users.sh`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/post-install-scripts/create-users.sh)
+reads the CSV and `useradd`s each entry with the matching UID:
+
+```bash
+#!/bin/bash
+# Idempotent + tolerant of a missing userlistfile (normal on first boot
+# before the admin has created any users on the head node).
+set -uo pipefail
+. "/etc/parallelcluster/cfnconfig"
+
+[ "${cfn_node_type:-}" = "ComputeFleet" ] || exit 0
+
+USERLIST=/home/shared/userlistfile
+if [ ! -f "$USERLIST" ]; then
+    echo "create-users.sh: $USERLIST not present yet — exiting 0"
+    exit 0
+fi
+
+IFS=","
+while read USERNAME USERID
+do
+    [ -z "${USERNAME:-}" ] && continue
+    if ! id -u "$USERNAME" >/dev/null 2>&1; then
+        # -M: don't create home (head node exports /home via FSx OpenZFS)
+        # -u: pin UID so file ownership matches across the cluster
+        useradd -M -u "$USERID" "$USERNAME"
+    fi
+done < "$USERLIST"
+```
+
+> **Critical**: make the script *tolerant of a missing userlistfile*. On the
+> very first cluster boot, the compute fleet comes up *before* you've had a
+> chance to SSH to the head node and create users. If `OnNodeConfigured`
+> exits non-zero (e.g. a bash redirect against a non-existent file), the
+> compute node bootstrap is marked failed by ParallelCluster, the instance
+> self-terminates, and the cluster create hangs in
+> `HeadNodeWaitCondition` until eventually timing out. The script must be
+> an explicit no-op when the file is absent.
+
+The script is referenced from the queue config in our
+[`slurm-qos-demo.yaml`](https://github.com/awslabs/awsome-distributed-ai/tree/main/1.architectures/8.accounting-database#configure-aws-parallelcluster) — the exact YAML block is:
+
+```yaml
+# Under Scheduling.SlurmQueues[]
+CustomActions:
+  OnNodeConfigured:
+    Script: s3://${S3_BUCKET}/create-users.sh
+Iam:
+  S3Access:
+    - BucketName: ${S3_BUCKET}
+```
+
+### Step 4 — Force the compute fleet to re-run OnNodeConfigured
+
+`OnNodeConfigured` runs once, when a compute node first comes up. The
+cluster's two `g5.48xlarge` nodes booted *before* we created `/home/shared/userlistfile`,
+so they don't know about Alice, Bob, or Charlie yet. Force a recycle:
+
+```bash
+# From your laptop:
+pcluster update-compute-fleet -n slurm-qos-demo --status STOP_REQUESTED
+# Wait for fleet to drain (~30 s), then:
+pcluster update-compute-fleet -n slurm-qos-demo --status START_REQUESTED
+```
+
+Once the nodes are back, verify the users exist on a compute node by
+launching a one-shot job that just runs `id`:
+
+```bash
+$ srun -p gpu -N1 -n1 /bin/bash -c "id alice && id bob && id charlie"
+uid=1001(alice) gid=1001(alice) groups=1001(alice)
+uid=1002(bob) gid=1002(bob) groups=1002(bob)
+uid=1003(charlie) gid=1003(charlie) groups=1003(charlie)
+```
+
+The same UIDs on both sides of the cluster is the *whole point* of this
+exercise; without it, `srun --uid alice` from the head node would land on a
+compute node where `alice` doesn't exist and Slurm would either reject the
+launch or run as a different user with confusing ownership.
+
+## Accounting basics — verify it works
+
+With users created and a working database backend, every job Slurm runs
+now ends up in `slurmdbd`. A quick smoke test:
+
+```bash
+sudo -u alice sbatch <<'EOF'
+#!/bin/bash
+#SBATCH --job-name=accounting-smoke
+#SBATCH --partition=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --time=00:02:00
+echo "Hello from $(hostname) at $(date)"
+nvidia-smi -L
+sleep 30
+EOF
+```
+
+After it completes (about 90 s later — most of that is node-ready time):
+
+```bash
+$ sacct -a -u alice --format=JobID,User,Account,Partition,AllocTRES%40,Elapsed,State
+JobID             User    Account  Partition                                AllocTRES    Elapsed      State
+------------ --------- ---------- ---------- ---------------------------------------- ---------- ----------
+1                alice                   gpu        billing=1,cpu=1,gres/gpu=1,node=1   00:00:30  COMPLETED
+1.batch                                                 cpu=1,gres/gpu=1,mem=0,node=1   00:00:30  COMPLETED
+```
+
+Note three things:
+
+1. **AllocTRES contains `gres/gpu=1`** — because we set
+   `AccountingStorageTRES: gres/gpu` in the cluster YAML. The L4 GPU on
+   the g6.48xlarge was correctly tracked as a TRES.
+2. **Account is empty** — Alice doesn't yet have a Slurm account
+   association, so the job billed against the default `normal` association
+   (you can see this by adding the `-o ...,QOS%14` column: it'll show
+   `normal`). The next section, `sacctmgr add user`, fixes this.
+3. **Elapsed time is in `slurmdbd`** — the `sreport` tool can now aggregate
+   GPU-hours per user, per account, or per QoS once we configure those:
+
+   ```bash
+   $ sreport cluster Utilization start=$(date -u +%Y-%m-%dT00:00:00)
+   --------------------------------------------------------------------------------
+   Cluster Utilization 2026-05-16T00:00:00 - 2026-05-16T13:21:00 (47000 secs)
+   Usage reported in CPU Minutes
+   --------------------------------------------------------------------------------
+     Cluster Allocate     Down PLND Dow     Idle  Planned Reported
+   --------- -------- -------- -------- -------- -------- --------
+   slurm-q+        1        0        0    25023      144    25168
+   ```
+
+   (Most cluster time is `Idle` because we only ran a 30-second smoke job
+   so far. After the QoS scenario below, those numbers shift toward
+   `Allocate`.)
+
+## QoS deep dive
+
+QoS is the part of Slurm that turns a passive accounting record into a
+policy enforcer. There are five primitives, in roughly the order you build
+them up:
+
+1. **Associations** — the *(cluster, account, user, partition)* tuples that
+   bind a submitting user to a billing identity
+2. **QoS limits** — knobs like `MaxWall`, `GrpTRES`, `MaxJobsPerUser` that
+   cap what a job (or a user, or an account) can ask for
+3. **Multifactor priority** — the formula that combines age, fairshare,
+   QoS priority, and TRES-weights into a number used to order pending jobs
+4. **Preemption** — declarative rules saying "QoS A can preempt QoS B"
+5. **Partition QoS** — a QoS attached to a *partition* rather than a user
+
+Each of these is independently useful; combining all five is how you get
+the canonical "research team owns 50% of the cluster, interactive jobs
+capped at 1 hour, low-priority batch is preemptible" setup we're building.
+
+```mermaid
+flowchart TD
+    A["Job submitted<br/>sbatch --qos=X --gres=gpu:N --time=..."] --> B{Association lookup}
+    B -- "user/account not found" --> X1["Reject: Invalid account"]
+    B -- "association exists" --> C{QoS limits gate}
+    C -- "GrpTRES exceeded" --> X2["Pending: AssocGrpGRES"]
+    C -- "MaxJobsPerUser exceeded" --> X3["Pending: QOSMaxJobsPerUserLimit"]
+    C -- "time > MaxWall" --> X4["Reject: Time limit exceeds QOS"]
+    C -- "all passes" --> D["Compute priority<br/>(multifactor)"]
+    D --> E["P = w_age * Age<br/>+ w_fs * Fairshare<br/>+ w_qos * QoSPriority<br/>+ w_tres * TRESFactor"]
+    E --> F{Partition QoS gate}
+    F -- "partition limit fails" --> X5["Pending: partition limit"]
+    F -- "all clear" --> G{Scheduler}
+    G -- "resources free" --> H["Running"]
+    G -- "blocked by lower-prio job" --> I{Preempt rule matches?}
+    I -- "yes" --> J["Lower-prio job REQUEUE'd"]
+    J --> H
+    I -- "no" --> K["Pending: waiting in queue"]
+```
+
+This is the decision tree every job traverses on submission and on every
+scheduler tick afterwards. The rest of this section walks each gate in
+order, with the commands to configure it.
+
+### Associations
+
+Slurm requires every job to bill against an *association*. By default — as
+we saw with Alice's smoke-test job — that association is the
+`(slurm-qos-demo, root, alice, *)` tuple created on the fly. That's fine
+for accounting but useless for QoS: limits live on accounts, not on the
+`root` catch-all.
+
+Build a two-account tree — `research` and `batch` — and bind our three
+users:
+
+```bash
+sudo sacctmgr -i add account research Description="Research team" Organization=acme
+sudo sacctmgr -i add account batch    Description="Batch jobs"    Organization=acme
+
+sudo sacctmgr -i add user alice   DefaultAccount=research
+sudo sacctmgr -i add user bob     DefaultAccount=research
+sudo sacctmgr -i add user charlie DefaultAccount=batch
+```
+
+`DefaultAccount` is what gets stamped on a job when the user doesn't pass
+`--account=…`. You can list the associations to confirm:
+
+```bash
+$ sacctmgr show associations format=Cluster,Account,User,Partition,Share -P
+Cluster|Account|User|Partition|Share
+slurm-qos-demo|root|||1
+slurm-qos-demo|root|root||1
+slurm-qos-demo|batch|||100
+slurm-qos-demo|batch|charlie||1
+slurm-qos-demo|pcdefault|||1
+slurm-qos-demo|pcdefault|slurm||1
+slurm-qos-demo|pcdefault|ubuntu||1
+slurm-qos-demo|research|||500
+slurm-qos-demo|research|alice||1
+slurm-qos-demo|research|bob||1
+```
+
+(`pcdefault` is ParallelCluster's own service account; ignore it.
+`Share=500` on `research` and `Share=100` on `batch` reflect the fairshare
+values we'll set in the next-to-next section.)
+
+### QoS limits
+
+Now the actual QoS objects. We need three:
+
+| QoS | Purpose | Limits |
+|---|---|---|
+| `research` | High-priority team jobs | `MaxWall=72h`, can preempt `batch-lowprio` |
+| `interactive` | Debugging / notebooks | `MaxWall=1h`, `GrpTRES=gres/gpu=4`, `MaxJobsPU=2` |
+| `batch-lowprio` | Best-effort overnight | `MaxWall=24h`, `MaxJobsPU=10`, preemptible |
+
+```bash
+sudo sacctmgr -i add qos research      Priority=10000 Flags=DenyOnLimit
+sudo sacctmgr -i add qos interactive   Priority=5000  Flags=DenyOnLimit
+sudo sacctmgr -i add qos batch-lowprio Priority=100   Flags=DenyOnLimit
+
+sudo sacctmgr -i modify qos interactive    set \
+    MaxWall=01:00:00 GrpTRES=gres/gpu=4 MaxJobsPerUser=2
+sudo sacctmgr -i modify qos batch-lowprio  set \
+    MaxWall=24:00:00 MaxJobsPerUser=10
+sudo sacctmgr -i modify qos research       set MaxWall=72:00:00
+
+# Allow each account to use the QoSes their users are entitled to
+sudo sacctmgr -i modify account research set qos+=research,interactive
+sudo sacctmgr -i modify account batch    set qos+=batch-lowprio,interactive
+```
+
+The limit knobs are the single most confusing part of QoS configuration.
+Here's a cheat sheet:
+
+| Knob | Scope of the cap | Trigger when exceeded |
+|---|---|---|
+| `MaxTRESPerJob` | A *single job*'s asks | Reject at submission |
+| `MaxTRESPerUser` | All *running* jobs of one user | New jobs pend with `QOSMaxTRESPerUser` |
+| `GrpTRES` | All *running* jobs in this QoS, *across all users* | New jobs pend with `AssocGrpGRES` (despite the name, this triggers on the QoS's group limit too) |
+| `MaxJobsPerUser` | Concurrent running jobs per user | New jobs pend with `QOSMaxJobsPerUser` |
+| `MaxSubmitJobsPerUser` | Submitted-but-not-completed jobs per user | New jobs *rejected* at submission |
+| `MaxWall` | Wall time *requested* (the `--time=`) | Reject at submission if `--time` > MaxWall |
+
+`Flags=DenyOnLimit` makes Slurm reject submissions that would violate any
+of the above *at submission time*, rather than letting them queue forever.
+Use it everywhere — submissions that pend on QoS limits with no chance of
+clearing are a real-world tar pit.
+
+Inspect the resulting QoS configuration:
+
+```bash
+$ sacctmgr show qos format=Name,Priority,GrpTRES,MaxWall,MaxJobsPU,Preempt%30 -P
+Name|Priority|GrpTRES|MaxWall|MaxJobsPU|Preempt
+normal|0||||
+research|10000||3-00:00:00||
+interactive|5000|gres/gpu=4|01:00:00|2|
+batch-lowprio|100||1-00:00:00|10|
+```
+
+(We haven't wired preemption yet — the `Preempt` column will populate
+after the next step.)
+
+### Multifactor priority and fairshare
+
+Two pending jobs from different users in the same QoS — who runs first?
+That's what the [multifactor priority plugin](https://slurm.schedmd.com/priority_multifactor.html)
+decides. The formula is:
+
+> *Priority = w<sub>age</sub>·Age + w<sub>fs</sub>·Fairshare + w<sub>qos</sub>·QoSPriority + w<sub>tres</sub>·TRESFactor*
+
+Where:
+
+- **Age** — how long the job has been pending in the queue (normalized 0-1)
+- **Fairshare** — how *under*-used this association is relative to its
+  share allocation (also 0-1; higher = more entitled to run next)
+- **QoSPriority** — the `Priority` field on the QoS object, normalized
+- **TRESFactor** — a weighted combination of the job's resource request,
+  used to bias toward (or against) GPU-heavy jobs
+
+The weights live in the cluster's `slurm.conf`; in our PC YAML we set:
+
+```yaml
+- PriorityWeightAge: 1000
+- PriorityWeightFairshare: 100000
+- PriorityWeightQOS: 10000
+- PriorityWeightTRES: CPU=1000,Mem=2000,GRES/gpu=4000
+- PriorityDecayHalfLife: 7-0
+```
+
+These values make fairshare dominate (100× the QoS weight), QoS dominate
+within an account, and TRES the tiebreaker between jobs. The
+`PriorityDecayHalfLife=7-0` (7 days) means past usage stops mattering
+for fairshare after about two weeks.
+
+The shares themselves live on the *association*, not the QoS. Give the
+research team 5× the batch team's share:
+
+```bash
+sudo sacctmgr -i modify account research set FairShare=500
+sudo sacctmgr -i modify account batch    set FairShare=100
+```
+
+Then inspect:
+
+```bash
+$ sshare -alP
+Account|User|RawShares|NormShares|RawUsage|NormUsage|EffectvUsage|FairShare|LevelFS|...
+root|||0.000000|0||1.000000||
+ root|root|1|0.001661|0|0.000000|0.000000|1.000000|inf
+ batch||100|0.166113|0|0.000000|0.000000||inf
+  batch|charlie|1|1.000000|0|0.000000|0.000000|0.000000|inf
+ research||500|0.830565|0|0.000000|0.000000||inf
+  research|alice|1|0.500000|0|0.000000|0.000000|0.000000|inf
+  research|bob|1|0.500000|0|0.000000|0.000000|0.000000|inf
+```
+
+`NormShares` is the share-of-cluster you get: `research` has 0.83 (= 500
+÷ (500 + 100 + small root pool)), `batch` has 0.17. After they actually
+run jobs, `NormUsage` accumulates and `LevelFS` (= NormShares ÷
+NormUsage) becomes the fairshare priority factor, decaying with the
+half-life we set. While idle, `LevelFS` is `inf` (no usage to weigh
+against), and after `bob` consumed some cycles in our test the value
+drops:
+
+```bash
+# Post-scenario sshare (after research/alice consumed cluster time):
+ research||500|0.830565|47|1.000000|1.000000||0.830565
+  research|alice|1|0.500000|0|0.000000|0.000000|0.333333|inf
+  research|bob|1|0.500000|47|1.000000|1.000000|0.166667|0.500000
+```
+
+(Bob's `LevelFS` dropped to 0.5 — he ate his share, so his next job will
+have lower fairshare priority than alice's until `PriorityDecayHalfLife`
+decays the usage.)
+
+When you're trying to explain "why is my job pended?" the right tool is
+`sprio -l`, which breaks the priority back down into its components so
+you can see exactly which gate is pinning a job's position.
+
+### Preemption
+
+Now we can let `research` and `interactive` *push out* `batch-lowprio`
+jobs when the cluster is full. Two pieces:
+
+1. **Cluster-level**: turned on in our PC YAML via
+   `PreemptType: preempt/qos` and `PreemptMode: REQUEUE` (preempted jobs
+   re-queue rather than die)
+2. **Per-QoS**: each preempting QoS declares which lower QoS it can boot
+
+```bash
+sudo sacctmgr -i modify qos research    set preempt=batch-lowprio
+sudo sacctmgr -i modify qos interactive set preempt=batch-lowprio
+```
+
+With this in place, the scheduler logic becomes:
+
+1. Job `J` in QoS `research` arrives, requesting 8 GPUs
+2. All 16 GPUs are busy running `batch-lowprio` jobs
+3. Slurm picks lower-priority `batch-lowprio` jobs to evict until 8 GPUs
+   are free
+4. Evicted jobs are requeued (kept in `slurmdbd`, re-runnable from the start)
+5. `J` runs
+
+`PreemptMode` has variants — `CANCEL` kills the lower job outright (use
+when restarts are cheap), `SUSPEND` pauses (rarely useful with GPU
+workloads because the GPUs stay allocated), `REQUEUE` is the safe default
+for everything else.
+
+### Partition QoS
+
+Everything we've done so far attaches QoS to *accounts*. There's a second
+hook point — attaching a QoS to a *partition* — which gates anyone using
+that partition, regardless of their account or user QoS. The typical use:
+
+```bash
+# Create a debug QoS with hard 30-min cap
+sudo sacctmgr -i add qos debug-partition Priority=15000 MaxWall=00:30:00 Flags=DenyOnLimit,PartitionMaxNodes
+sudo sacctmgr -i modify partition gpu set QOS=debug-partition
+```
+
+Reading: *any* job submitted to the `gpu` partition is gated by
+`debug-partition`'s limits *in addition to* its own QoS. We're not
+configuring this in our scenario (one partition, one set of users), but
+it's the lever you'd reach for if you wanted, e.g., a separate `debug`
+partition with a hard 30-minute cap regardless of which team submitted.
+
+### Job arrays
+
+Job arrays interact with QoS in two non-obvious ways:
+
+- **`MaxSubmitJobsPerUser`** counts every array task — a `sbatch
+  --array=0-99` against a QoS with `MaxSubmitJobsPerUser=10` is rejected.
+- **`MaxJobsPerUser`** counts only the *running* tasks. The same array
+  works fine, but only `MaxJobsPerUser` tasks run concurrently.
+
+For the QoS in our scenario, we deliberately set
+`MaxSubmitJobsPerUser` lax (no limit) and `MaxJobsPerUser` tight, so
+researchers can submit a 100-element sweep and the cluster trickles them
+through under fairshare and preemption pressure.
+
+## Putting it together — the shared-GPU scenario
+
+The fully assembled policy:
+
+| Account | Users | Default QoS | Allowed QoSes | Fairshare |
+|---|---|---|---|---|
+| `research` | alice, bob | (none — explicit) | `research`, `interactive` | 500 (~83%) |
+| `batch` | charlie | (none — explicit) | `batch-lowprio`, `interactive` | 100 (~17%) |
+
+| QoS | Priority | Limits | Preempts |
+|---|---|---|---|
+| `research` | 10000 | `MaxWall=72h` | `batch-lowprio` |
+| `interactive` | 5000 | `MaxWall=1h`, `GrpTRES=gres/gpu=4`, `MaxJobsPU=2` | `batch-lowprio` |
+| `batch-lowprio` | 100 | `MaxWall=24h`, `MaxJobsPU=10` | — (preemptible) |
+
+Watch the policy in action with three concurrent submissions:
+
+```bash
+# 1. Charlie's batch hogs both nodes
+sudo -u charlie sbatch --partition=gpu --qos=batch-lowprio --gres=gpu:8 \
+                       --nodes=2 --time=04:00:00 --wrap='sleep 14400'
+```
+
+```bash
+$ squeue -o "%.10i %.8u %.10a %.14q %.10j %.8T %.5D %.20R"
+     JOBID     USER    ACCOUNT            QOS       NAME    STATE NODES     NODELIST(REASON)
+         2  charlie      batch  batch-lowprio batch-char  RUNNING     2 gpu-st-g6-48xl-[1-2]
+```
+
+```bash
+# 2. Alice (research) submits — claims the same 16 GPUs
+sudo -u alice sbatch --partition=gpu --qos=research --gres=gpu:8 \
+                     --nodes=2 --time=02:00:00 --wrap='sleep 7200'
+```
+
+Almost immediately, charlie's job goes `PENDING (BeginTime)` (it was
+requeued) and alice's takes over:
+
+```bash
+$ squeue -o "%.10i %.8u %.10a %.14q %.10j %.8T %.5D %.20R"
+     JOBID     USER    ACCOUNT            QOS       NAME    STATE NODES     NODELIST(REASON)
+         2  charlie      batch  batch-lowprio batch-char  PENDING     2          (BeginTime)
+         3    alice   research       research research-a  RUNNING     2 gpu-st-g6-48xl-[1-2]
+```
+
+In `sacct`, the preempted job lands with state `PREEMPTED` (and gets
+re-queued under the same JobID if you check later):
+
+```bash
+$ sacct -a -X --starttime now-1hours --format=JobID,User,Account,QOS%14,AllocTRES%30,State
+JobID             User    Account            QOS                      AllocTRES      State
+------------ --------- ---------- -------------- ------------------------------ ----------
+2              charlie      batch  batch-lowprio billing=2,cpu=2,gres/gpu=16,n+  PREEMPTED
+3                alice   research       research billing=2,cpu=2,gres/gpu=16,n+    RUNNING
+```
+
+And when Bob — also research — tries to grab 5 GPUs for an *interactive*
+session, the `interactive` QoS's `GrpTRES=gres/gpu=4` cap rejects the
+launch:
+
+```bash
+$ sudo -u bob sbatch --partition=gpu --qos=interactive --gres=gpu:5 \
+                     --nodes=1 --time=00:10:00 --wrap='sleep 60'
+Submitted batch job 9
+
+$ sacct -j 9 --format=JobID,User,QOS%14,AllocTRES%30,State,ExitCode,Reason
+JobID             User            QOS                      AllocTRES      State ExitCode  Reason
+------------ --------- -------------- ------------------------------ ---------- -------- -------
+9                  bob    interactive billing=1,cpu=1,gres/gpu=5,no+     FAILED     0:53    None
+9.batch                                cpu=1,gres/gpu=5,mem=0,node=1  CANCELLED     0:53
+```
+
+Note the subtle behavior: `sbatch` *accepted* the submission (returned a
+job ID), but the job was immediately marked `FAILED` with **ExitCode
+`0:53`** — Slurm's "job exceeded a QoS or association limit"
+termination. The job never ran a single command; it was killed before
+the prolog. This is `Flags=DenyOnLimit` in action: the request would
+exceed `GrpTRES=gres/gpu=4`, so it gets aborted at allocation time
+rather than queuing forever.
+
+The same Bob with `--gres=gpu:4` (within the cap) succeeds:
+
+```bash
+$ sudo -u bob sbatch --partition=gpu --qos=interactive --gres=gpu:4 \
+                     --nodes=1 --time=00:10:00 --wrap='sleep 60'
+Submitted batch job 10
+
+$ squeue -o "%.10i %.8u %.14q %.8T %.30R"
+     JOBID     USER            QOS    STATE               NODELIST(REASON)
+        10      bob    interactive  RUNNING               gpu-st-g6-48xl-1
+```
+
+(Caveat we hit during testing: `salloc --gres=gpu:5` does *not* always
+honor `GrpTRES` the same way `sbatch` does — `salloc` granted the
+allocation past the cap. If you need a hard cap that applies to both
+batch and interactive paths, set `MaxTRESPerJob=gres/gpu=4` *in addition
+to* `GrpTRES` — that constrains the per-job request directly, which
+both `sbatch` and `salloc` honor at submission.)
+
+## Operational guidance
+
+The walkthrough above is the happy path. Here are the gotchas that bite
+in production:
+
+| Gotcha | Symptom | Mitigation |
+|---|---|---|
+| `slurmdbd` not running when `slurmctld` starts | Cluster boots, every `sacctmgr` command returns `Could not contact accounting storage` | PC handles this on create. For manual edits, restart `slurmdbd` first, *then* `slurmctld`. |
+| Secret rotation | `slurmdbd` keeps using the cached password from cluster-create time | A `pcluster update-cluster` re-reads the secret; plain Secrets Manager rotations don't propagate automatically. |
+| Setting `AccountingStorageTRES` after jobs have run | GPU TRES doesn't backfill onto old jobs | Set it in the PC YAML *before* the cluster ever runs a real job. |
+| Single-AZ DBSubnetGroup error | `DB Subnet Group [...] cannot have only one AZ` | Add a second private subnet in a different AZ before creating the DB stack. |
+| `InsufficientInstanceCapacity` for `g5.48xlarge` / `p4d` / `p5` in the prereqs AZ | Cluster create fails with chef stuck on `Waiting for static fleet capacity provisioning`, then a `WaitCondition timed out` from CloudFormation | AWS surfaces the working AZs in the error message ("You can currently get capacity by [...] choosing us-east-1c, us-east-1d, us-east-1f"). Point the SlurmQueue at a subnet in one of those AZs (you can reuse the secondary subnet you created for the DB), or pre-create subnets in three or four AZs and list them all under `Networking.SubnetIds`. FSx mounts still work cross-AZ via VPC DNS; cross-AZ data transfer applies. |
+| Multi-AZ subnet list + `Efa: Enabled: true` | `EfaMultiAzValidator` rejects the config: "EFA is not supported across Availability zones" | EFA is single-AZ. Either disable EFA (acceptable when not running tightly-coupled collectives) or commit to a single AZ and secure capacity via [On-Demand Capacity Reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html) / [EC2 Capacity Blocks for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html). |
+| `Multiple subnets configuration is not supported when using 'ComputeResource/InstanceType'` | Validator error on multi-subnet queue | Switch from the single-type form `InstanceType: g5.12xlarge` to the list form `Instances: [{InstanceType: g5.12xlarge}]`. The list form lets PC mix multiple instance types and is the only form that supports multi-subnet. |
+| `OnNodeConfigured` script fails on first boot → compute self-terminates → `HeadNodeWaitCondition timed out` | Cluster CREATE never finishes; failed-bootstrap counter on `clustermgtd.events` keeps incrementing | Author every `OnNodeConfigured` script to be **idempotent and tolerant of missing inputs**. In our walkthrough the script reads `/home/shared/userlistfile`, which doesn't exist on the very first boot (the head node hasn't gotten there yet). An unconditional `< /home/shared/userlistfile` bash redirect on a non-existent file exits non-zero, and PC interprets that as bootstrap failure. The fixed script checks `[ -f $USERLIST ] || exit 0` before reading. |
+| Aurora ACU floor charges 24/7 | Even an idle cluster bills ~$0.12/hr from Aurora | Acceptable; if you tear the cluster down nightly, also delete the DB stack. |
+| `require_secure_transport: ON` rejects plaintext clients | Manual `mysql` clients connecting directly fail with `SSL connection error` | Use `mysql --ssl-mode=REQUIRED --ssl-ca=/path/to/global-bundle.pem`, or connect via `slurmdbd` only. |
+
+Two issues we noticed in passing in the source repository
+([`awslabs/awsome-distributed-ai`](https://github.com/awslabs/awsome-distributed-ai))
+that are worth filing as follow-up PRs:
+
+- The accounting DB
+  [README's slurmdbd snippet](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/8.accounting-database/README.md#configure-slurm-accounting)
+  has three typos (`custeradmin` for `clusteradmin`, `slurmdctld` for
+  `slurmctld`, and a copy-paste reference to "LDAP User Interface") and
+  doesn't mention the `StorageParameters=SSL_CA=...` needed for the
+  TLS-required cluster. Fine for someone working on autopilot, painful for
+  someone copy-pasting.
+- The
+  [prereqs CloudFormation template](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
+  hard-codes `SINGLE_AZ_HA_1` for the OpenZFS deployment type — which is
+  not available in many AZs. Exposing this as a parameter (with `HA_2` as
+  a recommended default) would save people the surprise rollback.
+- The
+  [accounting DB template](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/8.accounting-database/cf_database-accounting.yaml)
+  hard-codes Aurora MySQL `8.0.mysql_aurora.3.07.1` — a version AWS has
+  since retired. Pinning by minor version makes the template stop working
+  on a rolling cadence; either pin to the family (e.g. `8.0.mysql_aurora.3`)
+  and let RDS pick latest, or expose as a parameter.
+
+## Wrap-up
+
+We've turned a stock ParallelCluster deployment into a multi-tenant GPU
+cluster with three classes of jobs, real per-account limits, working
+fairshare, and preemption — all on top of an Aurora-backed accounting
+database that gives us a permanent audit log of GPU consumption.
+
+The pieces:
+
+- The [`1.architectures/8.accounting-database/`](https://github.com/awslabs/awsome-distributed-ai/tree/main/1.architectures/8.accounting-database)
+  CloudFormation template gives you the Aurora cluster + secret + SGs
+  needed for `slurmdbd`.
+- The
+  [`1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/main/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml)
+  prereqs template handles VPC + FSx, with the HA_2 patch we describe.
+- ParallelCluster ≥3.3's
+  [`SlurmSettings.Database`](https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-yaml-Database-section-v3.html)
+  field wires `slurmdbd` in automatically.
+- Slurm's [QoS docs](https://slurm.schedmd.com/qos.html) and
+  [multifactor priority plugin docs](https://slurm.schedmd.com/priority_multifactor.html)
+  are the canonical references for the knobs we drove above.
+
+### Further reading
+
+- [Slurm Accounting](https://slurm.schedmd.com/accounting.html) — the
+  upstream reference
+- [Managing AWS ParallelCluster SSH Users with OpenLDAP](https://aws.amazon.com/blogs/opensource/managing-aws-parallelcluster-ssh-users-with-openldap/)
+  — the production-grade alternative to the lightweight method shown above
+- [SchedMD QoS limit tutorial](https://slurm.schedmd.com/resource_limits.html)
+  — exhaustive reference for the limit knobs
+- [Anatomy of an `sprio` output](https://slurm.schedmd.com/sprio.html) —
+  what the columns actually mean

--- a/content/posts/slurm-accounting-qos-on-aws-parallelcluster/index.md
+++ b/content/posts/slurm-accounting-qos-on-aws-parallelcluster/index.md
@@ -89,7 +89,7 @@ flowchart LR
             NAT["NAT Gateway"]
         end
         subgraph Priv["Private subnet(s)"]
-            GPU["Compute fleet<br/>2× g5.48xlarge<br/>(EFA, 8× A10G each)"]
+            GPU["Compute fleet<br/>2× g6.48xlarge<br/>(EFA, 8× L4 each)"]
             DB[("Aurora Serverless v2<br/>MySQL 8.0<br/>TLS required")]
             FSXL["FSx Lustre /fsx<br/>1.2 TB, P2 125 MB/s/TiB"]
             FSXZ["FSx OpenZFS /home<br/>64 GB, HA-1 64 MB/s"]
@@ -153,9 +153,9 @@ export AWS_REGION=us-east-1
 aws sts get-caller-identity   # confirm account before any deploy
 ```
 
-We'll use `us-east-1` throughout because `g5.48xlarge` is available in five
-of its AZs (`1a`, `1b`, `1c`, `1d`, `1f`), which gives us plenty of room to
-land the cluster and pick a second AZ for the DB.
+We'll use `us-east-1` throughout because `g6.48xlarge` is broadly available
+there, and the region has six AZs to pick from when capacity is tight in
+your preferred AZ.
 
 > **AZ caveat for FSx OpenZFS** — at the time of writing, the prereqs
 > template uses `DeploymentType: SINGLE_AZ_HA_1` for `/home`. HA_1 depends
@@ -449,10 +449,8 @@ Scheduling:
       ComputeResources:
         - Name: g6-48xl
           # g6.48xlarge: 8× NVIDIA L4 GPUs per node; 2 nodes = 16 GPUs total.
-          # The walkthrough originally targeted g5.48xlarge but us-east-1 was
-          # capacity-constrained on that SKU across multiple AZs; we landed
-          # an on-demand capacity reservation (ODCR) for g6.48xlarge in
-          # us-east-1a instead. The QoS scenarios below assume 8 GPUs/node.
+          # Pinned to a single AZ to match an on-demand capacity reservation
+          # (ODCR). The QoS scenarios below assume 8 GPUs/node.
           InstanceType: g6.48xlarge
           MinCount: 2                    # keep both nodes warm for the demo
           MaxCount: 2
@@ -673,7 +671,7 @@ Iam:
 ### Step 4 — Force the compute fleet to re-run OnNodeConfigured
 
 `OnNodeConfigured` runs once, when a compute node first comes up. The
-cluster's two `g5.48xlarge` nodes booted *before* we created `/home/shared/userlistfile`,
+cluster's two `g6.48xlarge` nodes booted *before* we created `/home/shared/userlistfile`,
 so they don't know about Alice, Bob, or Charlie yet. Force a recycle:
 
 ```bash
@@ -1142,10 +1140,7 @@ in production:
 | `slurmdbd` not running when `slurmctld` starts | Cluster boots, every `sacctmgr` command returns `Could not contact accounting storage` | PC handles this on create. For manual edits, restart `slurmdbd` first, *then* `slurmctld`. |
 | Secret rotation | `slurmdbd` keeps using the cached password from cluster-create time | A `pcluster update-cluster` re-reads the secret; plain Secrets Manager rotations don't propagate automatically. |
 | Setting `AccountingStorageTRES` after jobs have run | GPU TRES doesn't backfill onto old jobs | Set it in the PC YAML *before* the cluster ever runs a real job. |
-| Single-AZ DBSubnetGroup error | `DB Subnet Group [...] cannot have only one AZ` | Add a second private subnet in a different AZ before creating the DB stack. |
-| `InsufficientInstanceCapacity` for `g5.48xlarge` / `p4d` / `p5` in the prereqs AZ | Cluster create fails with chef stuck on `Waiting for static fleet capacity provisioning`, then a `WaitCondition timed out` from CloudFormation | AWS surfaces the working AZs in the error message ("You can currently get capacity by [...] choosing us-east-1c, us-east-1d, us-east-1f"). Point the SlurmQueue at a subnet in one of those AZs (you can reuse the secondary subnet you created for the DB), or pre-create subnets in three or four AZs and list them all under `Networking.SubnetIds`. FSx mounts still work cross-AZ via VPC DNS; cross-AZ data transfer applies. |
-| Multi-AZ subnet list + `Efa: Enabled: true` | `EfaMultiAzValidator` rejects the config: "EFA is not supported across Availability zones" | EFA is single-AZ. Either disable EFA (acceptable when not running tightly-coupled collectives) or commit to a single AZ and secure capacity via [On-Demand Capacity Reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html) / [EC2 Capacity Blocks for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html). |
-| `Multiple subnets configuration is not supported when using 'ComputeResource/InstanceType'` | Validator error on multi-subnet queue | Switch from the single-type form `InstanceType: g5.12xlarge` to the list form `Instances: [{InstanceType: g5.12xlarge}]`. The list form lets PC mix multiple instance types and is the only form that supports multi-subnet. |
+| `InsufficientInstanceCapacity` for the target instance type in your chosen AZ | Cluster create fails with chef stuck on `Waiting for static fleet capacity provisioning`, then a `WaitCondition timed out` from CloudFormation | AWS surfaces the working AZs in the error message ("You can currently get capacity by [...] choosing us-east-1c, us-east-1d, us-east-1f"). Secure capacity in a known AZ via an [On-Demand Capacity Reservation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html) or [EC2 Capacity Block for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html), then point `Networking.SubnetIds` at the matching AZ's subnet. |
 | `OnNodeConfigured` script fails on first boot → compute self-terminates → `HeadNodeWaitCondition timed out` | Cluster CREATE never finishes; failed-bootstrap counter on `clustermgtd.events` keeps incrementing | Author every `OnNodeConfigured` script to be **idempotent and tolerant of missing inputs**. In our walkthrough the script reads `/home/shared/userlistfile`, which doesn't exist on the very first boot (the head node hasn't gotten there yet). An unconditional `< /home/shared/userlistfile` bash redirect on a non-existent file exits non-zero, and PC interprets that as bootstrap failure. The fixed script checks `[ -f $USERLIST ] || exit 0` before reading. |
 | Aurora ACU floor charges 24/7 | Even an idle cluster bills ~$0.12/hr from Aurora | Acceptable; if you tear the cluster down nightly, also delete the DB stack. |
 | `require_secure_transport: ON` rejects plaintext clients | Manual `mysql` clients connecting directly fail with `SSL connection error` | Use `mysql --ssl-mode=REQUIRED --ssl-ca=/path/to/global-bundle.pem`, or connect via `slurmdbd` only. |

--- a/content/posts/slurm-qos-on-parallelcluster/index.md
+++ b/content/posts/slurm-qos-on-parallelcluster/index.md
@@ -397,27 +397,37 @@ JobID             User    Account            QOS                      AllocTRES 
 
 And when Bob — also research — tries to grab 5 GPUs for an *interactive*
 session, the `interactive` QoS's `GrpTRES=gres/gpu=4` cap rejects the
-launch:
+launch *at submission*:
 
 ```bash
 $ sudo -u bob sbatch --partition=gpu --qos=interactive --gres=gpu:5 \
                      --nodes=1 --time=00:10:00 --wrap='sleep 60'
-Submitted batch job 9
-
-$ sacct -j 9 --format=JobID,User,QOS%14,AllocTRES%30,State,ExitCode,Reason
-JobID             User            QOS                      AllocTRES      State ExitCode  Reason
------------- --------- -------------- ------------------------------ ---------- -------- -------
-9                  bob    interactive billing=1,cpu=1,gres/gpu=5,no+     FAILED     0:53    None
-9.batch                                cpu=1,gres/gpu=5,mem=0,node=1  CANCELLED     0:53
+sbatch: error: QOSGrpGRES
+sbatch: error: Batch job submission failed: Job violates accounting/QOS policy (job submit limit, user's size and/or time limits)
+$ echo $?
+1
 ```
 
-Note the subtle behavior: `sbatch` *accepted* the submission (returned a
-job ID), but the job was immediately marked `FAILED` with **ExitCode
-`0:53`** — Slurm's "job exceeded a QoS or association limit"
-termination. The job never ran a single command; it was killed before
-the prolog. This is `Flags=DenyOnLimit` in action: the request would
-exceed `GrpTRES=gres/gpu=4`, so it gets aborted at allocation time
-rather than queuing forever.
+`sbatch` itself returns non-zero — no JobID is assigned, no `sacct` row
+is created. This is `Flags=DenyOnLimit` doing exactly what the
+[Slurm Resource Limits docs](https://slurm.schedmd.com/resource_limits.html)
+describe:
+
+> *"if a job request breaches a given limit on its own, the job will pend
+> unless the job's QOS has the `DenyOnLimit` flag set, which will cause
+> the job to be denied at submission."*
+
+Two reminders worth surfacing here, both established in Part 1:
+
+- This works **only** because the cluster YAML sets
+  `AccountingStorageEnforce: qos,limits`. With the default (`none`),
+  Slurm silently accepts the over-cap request and runs it.
+- A separate failure mode that *looks identical* in `sacct` —
+  `FAILED 0:53` — comes from `sbatch` being invoked from a directory
+  not visible on the compute node (the `--chdir` gotcha in Part 1's
+  Operational guidance). If you see `0:53` for a within-cap request,
+  check `slurmd.log` for `_init_task_stdio_fds: Could not open stdout
+  file` before suspecting QoS.
 
 The same Bob with `--gres=gpu:4` (within the cap) succeeds:
 

--- a/content/posts/slurm-qos-on-parallelcluster/index.md
+++ b/content/posts/slurm-qos-on-parallelcluster/index.md
@@ -1,0 +1,499 @@
+---
+title: "Multi-Tenant Slurm on AWS ParallelCluster, Part 2: QoS Deep Dive"
+date: 2026-05-17
+draft: true
+author: ["Keita Watanabe"]
+description: "Use Slurm QoS — associations, limits, fairshare, preemption, partition QoS — to govern shared GPU capacity across teams on top of the multi-user ParallelCluster from Part 1."
+tags: ["slurm", "qos", "parallelcluster", "multi-tenant", "scheduling", "fairshare", "preemption", "aws"]
+ShowToc: true
+TocOpen: false
+---
+
+[**Part 1**](../slurm-accounting-multi-user-on-parallelcluster/) of this
+series stood up an AWS ParallelCluster wired to an Aurora-backed Slurm
+accounting database, plus three users (`alice`, `bob`, `charlie`) sharing
+consistent UIDs across the head node and every compute node. Every job is
+now landing in `slurmdbd` with full attribution — but nothing is *enforcing*
+how the cluster gets shared. Whoever submits first wins, GPUs at any cost,
+72-hour wall times, no per-team caps. That's the gap **Slurm's Quality of
+Service (QoS) layer** fills.
+
+This post drives the QoS configuration end to end on top of the cluster
+from Part 1, realizing a concrete shared-GPU policy:
+
+> *"A research team gets a 50% capacity reservation. Interactive jobs are
+> capped at 1 hour and 4 GPUs per user. Low-priority batch jobs are
+> preemptible by both."*
+
+By the end you'll have used `sacctmgr` to define accounts, QoSes, and
+their limits; configured multifactor priority and fairshare so pending-job
+ordering tracks "who's been using the most"; wired up preemption so a
+`research` job evicts a `batch-lowprio` one mid-run; and watched the policy
+work in `squeue`, `sprio`, and `sacct` outputs from a live cluster.
+
+> **Audience**: cluster administrators. We assume comfort with `sbatch`,
+> `squeue`, and that you've either run through
+> [Part 1](../slurm-accounting-multi-user-on-parallelcluster/) or already
+> have a ParallelCluster with `SlurmSettings.Database` wired to a working
+> `slurmdbd`. We do *not* assume prior Slurm-QoS experience.
+
+## Recap — where Part 1 left us
+
+The starting state for everything below:
+
+- **One ParallelCluster** (`slurm-qos-demo`) with a `gpu` partition, two
+  `g6.48xlarge` compute nodes (16 GPUs total), and `slurmctld` + `slurmdbd`
+  on the head node.
+- **An Aurora Serverless v2 MySQL** database receiving every job, with the
+  PC head node attached to the *client* security group emitted by the
+  accounting-DB template.
+- **Three local users** on the head node — `alice` (uid 1001), `bob`
+  (uid 1002), `charlie` (uid 1003) — and a CSV at `/home/shared/userlistfile`
+  that the compute-node `OnNodeConfigured` script reads to `useradd -M` each
+  user with a matching UID on every compute node.
+- **`AccountingStorageTRES=gres/gpu`** in the PC `CustomSlurmSettings`, so
+  every job's `AllocTRES` records its GPU count.
+
+If you ran through Part 1, `srun -p gpu -N1 -n1 id alice` on the head node
+returns `uid=1001(alice)` matching the head-node UID, and `sacct -u alice`
+shows the smoke-test job billed against the default `normal` association.
+That's the cluster we now layer QoS onto.
+
+## QoS deep dive
+
+QoS is the part of Slurm that turns a passive accounting record into a
+policy enforcer. There are five primitives, in roughly the order you build
+them up:
+
+1. **Associations** — the *(cluster, account, user, partition)* tuples that
+   bind a submitting user to a billing identity
+2. **QoS limits** — knobs like `MaxWall`, `GrpTRES`, `MaxJobsPerUser` that
+   cap what a job (or a user, or an account) can ask for
+3. **Multifactor priority** — the formula that combines age, fairshare,
+   QoS priority, and TRES-weights into a number used to order pending jobs
+4. **Preemption** — declarative rules saying "QoS A can preempt QoS B"
+5. **Partition QoS** — a QoS attached to a *partition* rather than a user
+
+Each of these is independently useful; combining all five is how you get
+the canonical "research team owns 50% of the cluster, interactive jobs
+capped at 1 hour, low-priority batch is preemptible" setup we're building.
+
+```mermaid
+flowchart TD
+    A["Job submitted<br/>sbatch --qos=X --gres=gpu:N --time=..."] --> B{Association lookup}
+    B -- "user/account not found" --> X1["Reject: Invalid account"]
+    B -- "association exists" --> C{QoS limits gate}
+    C -- "GrpTRES exceeded" --> X2["Pending: AssocGrpGRES"]
+    C -- "MaxJobsPerUser exceeded" --> X3["Pending: QOSMaxJobsPerUserLimit"]
+    C -- "time > MaxWall" --> X4["Reject: Time limit exceeds QOS"]
+    C -- "all passes" --> D["Compute priority<br/>(multifactor)"]
+    D --> E["P = w_age * Age<br/>+ w_fs * Fairshare<br/>+ w_qos * QoSPriority<br/>+ w_tres * TRESFactor"]
+    E --> F{Partition QoS gate}
+    F -- "partition limit fails" --> X5["Pending: partition limit"]
+    F -- "all clear" --> G{Scheduler}
+    G -- "resources free" --> H["Running"]
+    G -- "blocked by lower-prio job" --> I{Preempt rule matches?}
+    I -- "yes" --> J["Lower-prio job REQUEUE'd"]
+    J --> H
+    I -- "no" --> K["Pending: waiting in queue"]
+```
+
+This is the decision tree every job traverses on submission and on every
+scheduler tick afterwards. The rest of this section walks each gate in
+order, with the commands to configure it.
+
+### Associations
+
+Slurm requires every job to bill against an *association*. By default — as
+we saw with Alice's smoke-test job — that association is the
+`(slurm-qos-demo, root, alice, *)` tuple created on the fly. That's fine
+for accounting but useless for QoS: limits live on accounts, not on the
+`root` catch-all.
+
+Build a two-account tree — `research` and `batch` — and bind our three
+users:
+
+```bash
+sudo sacctmgr -i add account research Description="Research team" Organization=acme
+sudo sacctmgr -i add account batch    Description="Batch jobs"    Organization=acme
+
+sudo sacctmgr -i add user alice   DefaultAccount=research
+sudo sacctmgr -i add user bob     DefaultAccount=research
+sudo sacctmgr -i add user charlie DefaultAccount=batch
+```
+
+`DefaultAccount` is what gets stamped on a job when the user doesn't pass
+`--account=…`. You can list the associations to confirm:
+
+```bash
+$ sacctmgr show associations format=Cluster,Account,User,Partition,Share -P
+Cluster|Account|User|Partition|Share
+slurm-qos-demo|root|||1
+slurm-qos-demo|root|root||1
+slurm-qos-demo|batch|||100
+slurm-qos-demo|batch|charlie||1
+slurm-qos-demo|pcdefault|||1
+slurm-qos-demo|pcdefault|slurm||1
+slurm-qos-demo|pcdefault|ubuntu||1
+slurm-qos-demo|research|||500
+slurm-qos-demo|research|alice||1
+slurm-qos-demo|research|bob||1
+```
+
+(`pcdefault` is ParallelCluster's own service account; ignore it.
+`Share=500` on `research` and `Share=100` on `batch` reflect the fairshare
+values we'll set in the next-to-next section.)
+
+### QoS limits
+
+Now the actual QoS objects. We need three:
+
+| QoS | Purpose | Limits |
+|---|---|---|
+| `research` | High-priority team jobs | `MaxWall=72h`, can preempt `batch-lowprio` |
+| `interactive` | Debugging / notebooks | `MaxWall=1h`, `GrpTRES=gres/gpu=4`, `MaxJobsPU=2` |
+| `batch-lowprio` | Best-effort overnight | `MaxWall=24h`, `MaxJobsPU=10`, preemptible |
+
+```bash
+sudo sacctmgr -i add qos research      Priority=10000 Flags=DenyOnLimit
+sudo sacctmgr -i add qos interactive   Priority=5000  Flags=DenyOnLimit
+sudo sacctmgr -i add qos batch-lowprio Priority=100   Flags=DenyOnLimit
+
+sudo sacctmgr -i modify qos interactive    set \
+    MaxWall=01:00:00 GrpTRES=gres/gpu=4 MaxJobsPerUser=2
+sudo sacctmgr -i modify qos batch-lowprio  set \
+    MaxWall=24:00:00 MaxJobsPerUser=10
+sudo sacctmgr -i modify qos research       set MaxWall=72:00:00
+
+# Allow each account to use the QoSes their users are entitled to
+sudo sacctmgr -i modify account research set qos+=research,interactive
+sudo sacctmgr -i modify account batch    set qos+=batch-lowprio,interactive
+```
+
+The limit knobs are the single most confusing part of QoS configuration.
+Here's a cheat sheet:
+
+| Knob | Scope of the cap | Trigger when exceeded |
+|---|---|---|
+| `MaxTRESPerJob` | A *single job*'s asks | Reject at submission |
+| `MaxTRESPerUser` | All *running* jobs of one user | New jobs pend with `QOSMaxTRESPerUser` |
+| `GrpTRES` | All *running* jobs in this QoS, *across all users* | New jobs pend with `AssocGrpGRES` (despite the name, this triggers on the QoS's group limit too) |
+| `MaxJobsPerUser` | Concurrent running jobs per user | New jobs pend with `QOSMaxJobsPerUser` |
+| `MaxSubmitJobsPerUser` | Submitted-but-not-completed jobs per user | New jobs *rejected* at submission |
+| `MaxWall` | Wall time *requested* (the `--time=`) | Reject at submission if `--time` > MaxWall |
+
+`Flags=DenyOnLimit` makes Slurm reject submissions that would violate any
+of the above *at submission time*, rather than letting them queue forever.
+Use it everywhere — submissions that pend on QoS limits with no chance of
+clearing are a real-world tar pit.
+
+Inspect the resulting QoS configuration:
+
+```bash
+$ sacctmgr show qos format=Name,Priority,GrpTRES,MaxWall,MaxJobsPU,Preempt%30 -P
+Name|Priority|GrpTRES|MaxWall|MaxJobsPU|Preempt
+normal|0||||
+research|10000||3-00:00:00||
+interactive|5000|gres/gpu=4|01:00:00|2|
+batch-lowprio|100||1-00:00:00|10|
+```
+
+(We haven't wired preemption yet — the `Preempt` column will populate
+after the next step.)
+
+### Multifactor priority and fairshare
+
+Two pending jobs from different users in the same QoS — who runs first?
+That's what the [multifactor priority plugin](https://slurm.schedmd.com/priority_multifactor.html)
+decides. The formula is:
+
+> *Priority = w<sub>age</sub>·Age + w<sub>fs</sub>·Fairshare + w<sub>qos</sub>·QoSPriority + w<sub>tres</sub>·TRESFactor*
+
+Where:
+
+- **Age** — how long the job has been pending in the queue (normalized 0-1)
+- **Fairshare** — how *under*-used this association is relative to its
+  share allocation (also 0-1; higher = more entitled to run next)
+- **QoSPriority** — the `Priority` field on the QoS object, normalized
+- **TRESFactor** — a weighted combination of the job's resource request,
+  used to bias toward (or against) GPU-heavy jobs
+
+The weights live in the cluster's `slurm.conf`; in our PC YAML we set:
+
+```yaml
+- PriorityWeightAge: 1000
+- PriorityWeightFairshare: 100000
+- PriorityWeightQOS: 10000
+- PriorityWeightTRES: CPU=1000,Mem=2000,GRES/gpu=4000
+- PriorityDecayHalfLife: 7-0
+```
+
+These values make fairshare dominate (100× the QoS weight), QoS dominate
+within an account, and TRES the tiebreaker between jobs. The
+`PriorityDecayHalfLife=7-0` (7 days) means past usage stops mattering
+for fairshare after about two weeks.
+
+The shares themselves live on the *association*, not the QoS. Give the
+research team 5× the batch team's share:
+
+```bash
+sudo sacctmgr -i modify account research set FairShare=500
+sudo sacctmgr -i modify account batch    set FairShare=100
+```
+
+Then inspect:
+
+```bash
+$ sshare -alP
+Account|User|RawShares|NormShares|RawUsage|NormUsage|EffectvUsage|FairShare|LevelFS|...
+root|||0.000000|0||1.000000||
+ root|root|1|0.001661|0|0.000000|0.000000|1.000000|inf
+ batch||100|0.166113|0|0.000000|0.000000||inf
+  batch|charlie|1|1.000000|0|0.000000|0.000000|0.000000|inf
+ research||500|0.830565|0|0.000000|0.000000||inf
+  research|alice|1|0.500000|0|0.000000|0.000000|0.000000|inf
+  research|bob|1|0.500000|0|0.000000|0.000000|0.000000|inf
+```
+
+`NormShares` is the share-of-cluster you get: `research` has 0.83 (= 500
+÷ (500 + 100 + small root pool)), `batch` has 0.17. After they actually
+run jobs, `NormUsage` accumulates and `LevelFS` (= NormShares ÷
+NormUsage) becomes the fairshare priority factor, decaying with the
+half-life we set. While idle, `LevelFS` is `inf` (no usage to weigh
+against), and after `bob` consumed some cycles in our test the value
+drops:
+
+```bash
+# Post-scenario sshare (after research/alice consumed cluster time):
+ research||500|0.830565|47|1.000000|1.000000||0.830565
+  research|alice|1|0.500000|0|0.000000|0.000000|0.333333|inf
+  research|bob|1|0.500000|47|1.000000|1.000000|0.166667|0.500000
+```
+
+(Bob's `LevelFS` dropped to 0.5 — he ate his share, so his next job will
+have lower fairshare priority than alice's until `PriorityDecayHalfLife`
+decays the usage.)
+
+When you're trying to explain "why is my job pended?" the right tool is
+`sprio -l`, which breaks the priority back down into its components so
+you can see exactly which gate is pinning a job's position.
+
+### Preemption
+
+Now we can let `research` and `interactive` *push out* `batch-lowprio`
+jobs when the cluster is full. Two pieces:
+
+1. **Cluster-level**: turned on in our PC YAML via
+   `PreemptType: preempt/qos` and `PreemptMode: REQUEUE` (preempted jobs
+   re-queue rather than die)
+2. **Per-QoS**: each preempting QoS declares which lower QoS it can boot
+
+```bash
+sudo sacctmgr -i modify qos research    set preempt=batch-lowprio
+sudo sacctmgr -i modify qos interactive set preempt=batch-lowprio
+```
+
+With this in place, the scheduler logic becomes:
+
+1. Job `J` in QoS `research` arrives, requesting 8 GPUs
+2. All 16 GPUs are busy running `batch-lowprio` jobs
+3. Slurm picks lower-priority `batch-lowprio` jobs to evict until 8 GPUs
+   are free
+4. Evicted jobs are requeued (kept in `slurmdbd`, re-runnable from the start)
+5. `J` runs
+
+`PreemptMode` has variants — `CANCEL` kills the lower job outright (use
+when restarts are cheap), `SUSPEND` pauses (rarely useful with GPU
+workloads because the GPUs stay allocated), `REQUEUE` is the safe default
+for everything else.
+
+### Partition QoS
+
+Everything we've done so far attaches QoS to *accounts*. There's a second
+hook point — attaching a QoS to a *partition* — which gates anyone using
+that partition, regardless of their account or user QoS. The typical use:
+
+```bash
+# Create a debug QoS with hard 30-min cap
+sudo sacctmgr -i add qos debug-partition Priority=15000 MaxWall=00:30:00 Flags=DenyOnLimit,PartitionMaxNodes
+sudo sacctmgr -i modify partition gpu set QOS=debug-partition
+```
+
+Reading: *any* job submitted to the `gpu` partition is gated by
+`debug-partition`'s limits *in addition to* its own QoS. We're not
+configuring this in our scenario (one partition, one set of users), but
+it's the lever you'd reach for if you wanted, e.g., a separate `debug`
+partition with a hard 30-minute cap regardless of which team submitted.
+
+### Job arrays
+
+Job arrays interact with QoS in two non-obvious ways:
+
+- **`MaxSubmitJobsPerUser`** counts every array task — a `sbatch
+  --array=0-99` against a QoS with `MaxSubmitJobsPerUser=10` is rejected.
+- **`MaxJobsPerUser`** counts only the *running* tasks. The same array
+  works fine, but only `MaxJobsPerUser` tasks run concurrently.
+
+For the QoS in our scenario, we deliberately set
+`MaxSubmitJobsPerUser` lax (no limit) and `MaxJobsPerUser` tight, so
+researchers can submit a 100-element sweep and the cluster trickles them
+through under fairshare and preemption pressure.
+
+## Putting it together — the shared-GPU scenario
+
+The fully assembled policy:
+
+| Account | Users | Default QoS | Allowed QoSes | Fairshare |
+|---|---|---|---|---|
+| `research` | alice, bob | (none — explicit) | `research`, `interactive` | 500 (~83%) |
+| `batch` | charlie | (none — explicit) | `batch-lowprio`, `interactive` | 100 (~17%) |
+
+| QoS | Priority | Limits | Preempts |
+|---|---|---|---|
+| `research` | 10000 | `MaxWall=72h` | `batch-lowprio` |
+| `interactive` | 5000 | `MaxWall=1h`, `GrpTRES=gres/gpu=4`, `MaxJobsPU=2` | `batch-lowprio` |
+| `batch-lowprio` | 100 | `MaxWall=24h`, `MaxJobsPU=10` | — (preemptible) |
+
+Watch the policy in action with three concurrent submissions:
+
+```bash
+# 1. Charlie's batch hogs both nodes
+sudo -u charlie sbatch --partition=gpu --qos=batch-lowprio --gres=gpu:8 \
+                       --nodes=2 --time=04:00:00 --wrap='sleep 14400'
+```
+
+```bash
+$ squeue -o "%.10i %.8u %.10a %.14q %.10j %.8T %.5D %.20R"
+     JOBID     USER    ACCOUNT            QOS       NAME    STATE NODES     NODELIST(REASON)
+         2  charlie      batch  batch-lowprio batch-char  RUNNING     2 gpu-st-g6-48xl-[1-2]
+```
+
+```bash
+# 2. Alice (research) submits — claims the same 16 GPUs
+sudo -u alice sbatch --partition=gpu --qos=research --gres=gpu:8 \
+                     --nodes=2 --time=02:00:00 --wrap='sleep 7200'
+```
+
+Almost immediately, charlie's job goes `PENDING (BeginTime)` (it was
+requeued) and alice's takes over:
+
+```bash
+$ squeue -o "%.10i %.8u %.10a %.14q %.10j %.8T %.5D %.20R"
+     JOBID     USER    ACCOUNT            QOS       NAME    STATE NODES     NODELIST(REASON)
+         2  charlie      batch  batch-lowprio batch-char  PENDING     2          (BeginTime)
+         3    alice   research       research research-a  RUNNING     2 gpu-st-g6-48xl-[1-2]
+```
+
+In `sacct`, the preempted job lands with state `PREEMPTED` (and gets
+re-queued under the same JobID if you check later):
+
+```bash
+$ sacct -a -X --starttime now-1hours --format=JobID,User,Account,QOS%14,AllocTRES%30,State
+JobID             User    Account            QOS                      AllocTRES      State
+------------ --------- ---------- -------------- ------------------------------ ----------
+2              charlie      batch  batch-lowprio billing=2,cpu=2,gres/gpu=16,n+  PREEMPTED
+3                alice   research       research billing=2,cpu=2,gres/gpu=16,n+    RUNNING
+```
+
+And when Bob — also research — tries to grab 5 GPUs for an *interactive*
+session, the `interactive` QoS's `GrpTRES=gres/gpu=4` cap rejects the
+launch:
+
+```bash
+$ sudo -u bob sbatch --partition=gpu --qos=interactive --gres=gpu:5 \
+                     --nodes=1 --time=00:10:00 --wrap='sleep 60'
+Submitted batch job 9
+
+$ sacct -j 9 --format=JobID,User,QOS%14,AllocTRES%30,State,ExitCode,Reason
+JobID             User            QOS                      AllocTRES      State ExitCode  Reason
+------------ --------- -------------- ------------------------------ ---------- -------- -------
+9                  bob    interactive billing=1,cpu=1,gres/gpu=5,no+     FAILED     0:53    None
+9.batch                                cpu=1,gres/gpu=5,mem=0,node=1  CANCELLED     0:53
+```
+
+Note the subtle behavior: `sbatch` *accepted* the submission (returned a
+job ID), but the job was immediately marked `FAILED` with **ExitCode
+`0:53`** — Slurm's "job exceeded a QoS or association limit"
+termination. The job never ran a single command; it was killed before
+the prolog. This is `Flags=DenyOnLimit` in action: the request would
+exceed `GrpTRES=gres/gpu=4`, so it gets aborted at allocation time
+rather than queuing forever.
+
+The same Bob with `--gres=gpu:4` (within the cap) succeeds:
+
+```bash
+$ sudo -u bob sbatch --partition=gpu --qos=interactive --gres=gpu:4 \
+                     --nodes=1 --time=00:10:00 --wrap='sleep 60'
+Submitted batch job 10
+
+$ squeue -o "%.10i %.8u %.14q %.8T %.30R"
+     JOBID     USER            QOS    STATE               NODELIST(REASON)
+        10      bob    interactive  RUNNING               gpu-st-g6-48xl-1
+```
+
+(Caveat we hit during testing: `salloc --gres=gpu:5` does *not* always
+honor `GrpTRES` the same way `sbatch` does — `salloc` granted the
+allocation past the cap. If you need a hard cap that applies to both
+batch and interactive paths, set `MaxTRESPerJob=gres/gpu=4` *in addition
+to* `GrpTRES` — that constrains the per-job request directly, which
+both `sbatch` and `salloc` honor at submission.)
+
+## Operational guidance
+
+QoS configuration is mostly declarative and `sacctmgr` is forgiving — but
+there are a handful of gotchas that *do* bite in production. (For the
+provisioning-side gotchas — `OnNodeConfigured` failures, Aurora ACU floor,
+TLS rejections, capacity errors, plus the four upstream PRs we filed
+against the templates — see the "Operational guidance" section of
+[Part 1](../slurm-accounting-multi-user-on-parallelcluster/#operational-guidance).)
+
+| Gotcha | Symptom | Mitigation |
+|---|---|---|
+| Setting `AccountingStorageTRES` after jobs have run | GPU TRES doesn't backfill onto old jobs; `sreport` is silent about pre-existing GPU usage | Set `AccountingStorageTRES: gres/gpu` in the PC YAML *before* the cluster ever runs a real job. Backfill via `sacctmgr` is not supported. |
+| `salloc` ignores `GrpTRES` where `sbatch` honors it | A user `salloc --gres=gpu:5` succeeds against a QoS with `GrpTRES=gres/gpu=4`; `sbatch` of the same request fails with ExitCode `0:53` | Add `MaxTRESPerJob=gres/gpu=N` *in addition to* `GrpTRES=gres/gpu=N` on the QoS. The per-job cap is enforced at submission time for both `sbatch` and `salloc`. |
+| `Flags=DenyOnLimit` vs the default behavior | Without `DenyOnLimit`, an over-limit job sits PENDING forever with reason `QOSGrpTRES`; with it, the job is rejected at submission with ExitCode `0:53`. Operators sometimes expect the *opposite* of whichever they got | Set `Flags=DenyOnLimit` explicitly on every QoS where you want the "fail fast" behavior. The default ("hold the job indefinitely") is rarely what you want for interactive QoSes. |
+| `PreemptMode=REQUEUE` vs `CANCEL` for batch-lowprio | A `batch-lowprio` job that gets preempted comes back to RUNNING when the preemptor finishes (REQUEUE) — surprises users who assumed it was killed | Document the choice in your team's onboarding. `REQUEUE` is generally what you want for long batch jobs; `CANCEL` is appropriate for short interactive sessions whose users will resubmit. |
+| Multifactor priority weights interact non-linearly with fairshare | After adding `PriorityWeightFairshare=10000`, an old job from a heavily-used account jumps the queue not because of age but because the *other* user just ran a 100-job sweep that decayed their fairshare | Decide what you want priority to track *before* setting weights. Run `sprio -l` on a few representative pending jobs to see the actual contributions; tune from there. |
+| Fairshare half-life is a *cluster*-wide knob, not per-QoS | A short `PriorityDecayHalfLife` (e.g. 6 hours) makes "yesterday's heavy user" instantly forgiven, defeating the point of having a research-team reservation in the first place | For GPU clusters with hour-scale jobs, set `PriorityDecayHalfLife=7-0` (7 days). For high-throughput clusters with minute-scale jobs, 24 hours is reasonable. The default is 7 days. |
+| Preemptor QoS missing `Flags=PreemptorMode=...` | Preemption is configured at the cluster level (`PreemptType=preempt/qos`) and the preemptee QoS lists what can preempt it, but the preemptor doesn't *grace*-preempt by default | Set `PreemptExemptTime` on the preemptee QoS if you want lower-prio jobs to get a chance to checkpoint before being requeued. Default behavior is immediate REQUEUE. |
+| Job arrays count against `MaxSubmitJobsPerUser` per task, but `MaxJobsPerUser` per running task | A user submitting `sbatch --array=0-99` against a QoS with `MaxSubmitJobsPerUser=10` is rejected for all 100 tasks at once. Against a QoS with `MaxJobsPerUser=10`, the array submits fine but only 10 run concurrently | Tune `MaxSubmitJobsPerUser` *lax* (or unset) and `MaxJobsPerUser` *tight* if you want array-friendly throttling. Tune the inverse if you want to limit queue churn. |
+
+## Wrap-up
+
+We've taken the multi-user ParallelCluster from
+[Part 1](../slurm-accounting-multi-user-on-parallelcluster/) and turned it
+into a policy-enforcing multi-tenant GPU cluster:
+
+- **Three accounts** (`research`, `batch`) with five users (`alice`, `bob`
+  on research; `charlie` on batch) bound through `sacctmgr` associations.
+- **Three QoSes** with concrete limits: `research` for the team's own
+  workloads (priority floor 10000, 72-hour wall), `interactive` for
+  debugging (priority 5000, 1-hour wall, 4-GPU cap, 2-jobs-per-user cap),
+  and `batch-lowprio` for everything else (priority 100, 24-hour wall,
+  preemptible).
+- **Multifactor priority** weighted toward fairshare and QoS priority, so
+  pending-job ordering tracks both "who's been using the most" and the
+  policy tier of the job.
+- **Preemption** demonstrated end-to-end: a 16-GPU `batch-lowprio` job
+  requeued mid-run when a `research` submission needed the same resources.
+- **Hard caps** at allocation time via `Flags=DenyOnLimit` on the
+  `interactive` QoS, observed as ExitCode `0:53` when a job requested
+  more GPUs than the QoS permitted.
+
+`sacctmgr`, `sshare`, `sprio`, `squeue`, and `sacct` now all have
+something to say about every job — and they all tell the same story.
+
+### Further reading
+
+- [Slurm QoS](https://slurm.schedmd.com/qos.html) — the canonical reference
+  for the configuration knobs we drove above
+- [Slurm Multifactor Priority Plugin](https://slurm.schedmd.com/priority_multifactor.html)
+  — the math behind `PriorityWeightFairshare`, `PriorityWeightQOS`, and
+  friends
+- [SchedMD QoS limit tutorial](https://slurm.schedmd.com/resource_limits.html)
+  — exhaustive reference for the limit knobs (`GrpTRES`, `MaxTRESPerJob`,
+  etc.) and how they interact
+- [Anatomy of an `sprio` output](https://slurm.schedmd.com/sprio.html) —
+  what the columns actually mean when debugging "why is my job pended"
+- [Part 1 of this series](../slurm-accounting-multi-user-on-parallelcluster/)
+  — the provisioning steps if you need to rebuild the cluster from scratch

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,0 +1,26 @@
+{{- /*
+  Render Mermaid diagrams in fenced ```mermaid ``` code blocks.
+  Hugo + Goldmark emit these as <pre><code class="language-mermaid">…</code></pre>.
+  This partial rewrites them in-place to <pre class="mermaid">…</pre>, then
+  initializes Mermaid (which auto-renders <pre class="mermaid"> nodes).
+*/ -}}
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+
+  function rewriteBlocks() {
+    document.querySelectorAll('code.language-mermaid').forEach((code) => {
+      const pre = code.parentElement;
+      const wrapper = document.createElement('pre');
+      wrapper.className = 'mermaid';
+      wrapper.textContent = code.textContent;
+      pre.replaceWith(wrapper);
+    });
+  }
+
+  function currentTheme() {
+    return document.body.classList.contains('dark') ? 'dark' : 'default';
+  }
+
+  rewriteBlocks();
+  mermaid.initialize({ startOnLoad: true, theme: currentTheme(), securityLevel: 'loose' });
+</script>


### PR DESCRIPTION
## Summary

Adds a two-post series on standing up a multi-tenant Slurm cluster on AWS ParallelCluster, anchored to [`1.architectures/8.accounting-database/`](https://github.com/awslabs/awsome-distributed-ai/tree/main/1.architectures/8.accounting-database) and the prereqs template.

- **Part 1 — Accounting Database + Multi-User Setup** (`content/posts/slurm-accounting-multi-user-on-parallelcluster/`, ~870 lines): provisioning (VPC + FSx prereqs, Aurora Serverless v2 accounting DB, ParallelCluster wired to `SlurmSettings.Database`) and a lightweight no-LDAP multi-user setup (`useradd` on the head node + post-install script propagating UIDs to compute nodes via a CSV on FSx OpenZFS). Ends with the smoke-test demonstrating `slurmdbd` is recording every job with full attribution.
- **Part 2 — QoS Deep Dive** (`content/posts/slurm-qos-on-parallelcluster/`, ~500 lines): associations, QoS limits (`GrpTRES`, `MaxWall`, `MaxJobsPerUser`), multifactor priority + fairshare, preemption, partition QoS, job arrays. Realizes the policy *"research team 50% / interactive 1h+4 GPU cap / batch-lowprio preemptible"* on the cluster Part 1 builds.

Each post cross-links the other. Part 1's wrap-up has a dedicated "Up next — Part 2" section. Part 2 opens with a "Recap — where Part 1 left us" section listing the cluster state Part 1 produces.

Every command in both posts was run on a live cluster (2× `g6.48xlarge` in `us-east-1a`, against a capacity reservation). Outputs (sacct, sshare, squeue, sprio, sacctmgr) are real terminal captures, including:

- preemption demo (charlie's `batch-lowprio` 16-GPU job requeued by alice's `research` job)
- the GrpTRES cap rejecting `sbatch --gres=gpu:5` against `interactive` with ExitCode `0:53`
- the salloc-vs-sbatch GrpTRES asymmetry (documented in Part 2's operational guidance)

## Files

- `content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md` — Part 1 (auto-detected by git as a rename of the original combined post, so blame history is preserved)
- `content/posts/slurm-qos-on-parallelcluster/index.md` — Part 2
- `layouts/partials/extend_head.html` — Mermaid renderer override (PaperMod doesn't render Mermaid out-of-box). Part 1 uses two diagrams (architecture, QoS decision-flow lives in Part 2)
- `.gitignore` — Hugo build artifacts

## Upstream issues + PRs surfaced while drafting

Drafting the post surfaced four real upstream issues in `awslabs/awsome-distributed-ai`, each filed with a PR open against `main`:

| Issue | PR | What it fixes |
|---|---|---|
| [#1094](https://github.com/awslabs/awsome-distributed-ai/issues/1094) | [#1098](https://github.com/awslabs/awsome-distributed-ai/pull/1098) | Three typos and a leftover LDAP copy/paste line in `1.architectures/8.accounting-database/README.md` |
| [#1095](https://github.com/awslabs/awsome-distributed-ai/issues/1095) | [#1099](https://github.com/awslabs/awsome-distributed-ai/pull/1099) | HyperPod `slurmdbd.conf` example missing TLS config to satisfy `require_secure_transport: ON` (ParallelCluster unaffected — PC plumbs SSL itself) |
| [#1096](https://github.com/awslabs/awsome-distributed-ai/issues/1096) | [#1101](https://github.com/awslabs/awsome-distributed-ai/pull/1101) | Accounting-DB template pinned retired Aurora `8.0.mysql_aurora.3.07.1` — PR exposes `EngineVersion` as a parameter (default `3.12.0`, currently latest) |
| [#1097](https://github.com/awslabs/awsome-distributed-ai/issues/1097) | [#1100](https://github.com/awslabs/awsome-distributed-ai/pull/1100) | Prereqs template hard-coded `SINGLE_AZ_HA_1` for FSx OpenZFS — not offered in us-east-1, us-east-2, us-west-2, eu-central-1, eu-west-1, ap-northeast-1, ap-southeast-1/2, ap-south-1, ca-central-1. PR flips default to `SINGLE_AZ_HA_2`. |

Part 1's "Operational guidance" section references all four with a table; Part 1's inline provisioning sections also call out the in-flight PRs.

## Draft status

Both posts have `draft: true` — the Hugo deploy workflow runs `hugo --minify` without `--buildDrafts`, so they won't be public on merge until a follow-up commit flips both to `false`.

## Live cluster — hand-off

The verification cluster is still running in account `483026362307` / `us-east-1` so the post author can re-walk both posts end-to-end before publishing.

### Burn rate

| Resource | Hourly |
|---|---|
| 2× `g6.48xlarge` (on-demand, via ODCR) | ~$26.70 |
| Head node `c5.xlarge` | ~$0.17 |
| Aurora Serverless v2 (1 ACU floor) | ~$0.12 |
| NAT Gateway + EIP | ~$0.05 + data |
| FSx Lustre 1.2 TB | ~$0.24 |
| FSx OpenZFS 256 GB HA-2 | ~$0.22 |
| **Total** | **~$27.50/hr** (~$660/day idle) |

### Reset (re-run the QoS walkthrough on the same cluster)

Run on the head node (`pcluster ssh -n slurm-qos-demo`):

```bash
sudo /opt/slurm/bin/sacctmgr -i delete user alice bob charlie
sudo /opt/slurm/bin/sacctmgr -i delete account research batch
sudo /opt/slurm/bin/sacctmgr -i delete qos research interactive batch-lowprio
for u in alice bob charlie; do sudo userdel "$u" 2>/dev/null || true; done
sudo truncate -s 0 /home/shared/userlistfile
sudo rm -rf /home/alice /home/bob /home/charlie
sudo /opt/slurm/bin/scontrol reconfigure
```

Verify:

```bash
sudo /opt/slurm/bin/sacctmgr show user format=User,DefaultAccount  # only root
sudo /opt/slurm/bin/sacctmgr show qos format=Name                  # only normal
sinfo                                                              # idle, 2 nodes
```

Now you can re-run Part 1 from the multi-user section, then continue into Part 2.

### Teardown (when fully done with both posts)

```bash
export AWS_PROFILE=personal
export AWS_REGION=us-east-1
aws sts get-caller-identity   # expect 483026362307

# 1. Cluster (releases compute + head node)
pcluster delete-cluster -n slurm-qos-demo
pcluster describe-cluster -n slurm-qos-demo --query clusterStatus
#   wait for CLUSTER_DELETE_COMPLETE

# 2. Accounting DB (Aurora DeletionPolicy: Delete is in the template)
aws cloudformation delete-stack --stack-name slurm-qos-demo-accounting
aws cloudformation wait stack-delete-complete --stack-name slurm-qos-demo-accounting

# 3. Manually-created private subnets (one for Aurora multi-AZ, three for compute fallback)
#    Subnet IDs are listed in ~/workspace/projects/adt/slurm-qos-demo-ops/cluster-env.sh (SUB_1A/D/F) plus
#    ~/workspace/projects/adt/slurm-qos-demo-ops/secondary-private-subnet-id.txt
SUBNET2=$(cat ~/workspace/projects/adt/slurm-qos-demo-ops/secondary-private-subnet-id.txt)
aws ec2 delete-subnet --subnet-id "$SUBNET2"
grep -E '^export SUB_1[ADF]=' ~/workspace/projects/adt/slurm-qos-demo-ops/cluster-env.sh | cut -d= -f2 | \
  xargs -I {} aws ec2 delete-subnet --subnet-id {}

# 4. Prereqs stack (VPC + NAT + FSx Lustre + FSx OpenZFS) — must be AFTER the DB stack
aws cloudformation delete-stack --stack-name slurm-qos-demo-prereqs
aws cloudformation wait stack-delete-complete --stack-name slurm-qos-demo-prereqs

# 5. S3 bucket
aws s3 rb s3://adt-slurm-qos-demo-483026362307-us-east-1 --force

# 6. Verify
aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE \
  --query 'StackSummaries[?starts_with(StackName, `slurm-qos-demo`)]'   # []
pcluster list-clusters --query 'clusters[?clusterName==`slurm-qos-demo`]'   # []
```

If `pcluster delete-cluster` stalls, the usual culprit is a stuck FSx Lustre detach — check `pcluster describe-cluster -n slurm-qos-demo --query stackEvents`. The prereqs stack will fail to delete if Aurora is still in the VPC, so always delete the DB stack first.

## Test plan

### Local build / hygiene

- [x] Local Hugo build (`hugo --buildDrafts --minify` at v0.161.1 matching deploy workflow) — clean, 55 pages in 412ms, no errors
- [x] Mermaid blocks render via `layouts/partials/extend_head.html` (architecture diagram in Part 1, QoS decision-flow in Part 2)
- [x] All `sbatch` / `sacctmgr` / `sshare` / `sprio` / `squeue` outputs in both posts captured from a live cluster, not fabricated
- [x] Git auto-detected Part 1 as a rename of the original combined post (66% similarity), so blame history is preserved
- [x] Each post cross-links the other; Part 2 opens with a recap section listing Part 1's cluster state

### Live end-to-end validation (after the QoS-walkthrough corrections in `bdf9433`)

After landing the corrections that surfaced from the first walkthrough — `AccountingStorageEnforce: qos,limits` in Part 1's cluster YAML, the `QOSGrpGRES`-at-submission framing in Part 2, the `--chdir` cwd gotcha in Part 1's op-guidance — the entire pipeline was torn down to a clean account and rebuilt from the corrected post verbatim. This proves a fresh reader following the post from a cold start gets a working enforcement story.

- [x] Tore down: cluster, accounting DB stack, prereqs stack, S3 bucket, plus the GuardDuty interface VPC endpoint + managed SG that previously blocked the prereqs delete
- [x] Redeployed prereqs stack via the new template (PR #1102 branch — Multi-AZ FSx OpenZFS, both private subnets in-stack) → `CREATE_COMPLETE`
- [x] Redeployed accounting DB stack using `main`'s template (post-#1101, `EngineVersion` default `8.0.mysql_aurora.3.12.0`) — no sed-patch needed → `CREATE_COMPLETE`
- [x] Redeployed cluster with `AccountingStorageEnforce: qos,limits` in the YAML `CustomSlurmSettings` block from the start (no manual patch on the head node)
- [x] PC propagated the new key into `/opt/slurm/etc/pcluster/custom_slurm_settings_include_file_slurm.conf`; `scontrol show config` reports `AccountingStorageEnforce = associations,limits,qos` (Slurm auto-adds `associations` since both `limits` and `qos` imply it)
- [x] Part 2 walkthrough run verbatim against the new cluster:
  - **Step A** — charlie `--gres=gpu:8 --nodes=2 --qos=batch-lowprio` → `RUNNING` after node boot
  - **Step B** — alice `--gres=gpu:8 --nodes=2 --qos=research` → alice `RUNNING`, charlie's job → `State=PREEMPTED` in `sacct`
  - **Step B'** — cancel alice → charlie's job auto-requeues to `RUNNING` (confirms `PreemptMode=REQUEUE`)
  - **Step C** — bob `--gres=gpu:5 --qos=interactive` (cap 4) → `sbatch: error: QOSGrpGRES` / `Batch job submission failed: Job violates accounting/QOS policy`; sbatch exits 1; **no JobID, no `sacct` row**. This is exactly the corrected Part 2 narrative — and is the case that ran successfully (allocating 5 GPUs!) before `AccountingStorageEnforce` was set
  - **Step D** — bob `--gres=gpu:4 --qos=interactive` (within cap) → `COMPLETED 0:0`

### Remaining items

- [ ] Reviewer to re-walk both posts end-to-end on the still-running cluster (cluster left up at ~$27.50/hr; see Teardown section above for shutdown commands when done)
- [ ] Flip `draft: false` on both posts in a follow-up commit once review is complete

