### PR TITLE
docs(accounting-db): fix README typos and leftover LDAP copy/paste

### DIFF
--- a/1.architectures/8.accounting-database/README.md
+++ b/1.architectures/8.accounting-database/README.md
@@ -25,17 +25,16 @@ In this section, you will retrieve the database parameter that are used by Slurm
 
 ### Get the Database URI
 
-Retrieve the `DatabaseHost` to connect to the LDAP User Interface.
+Retrieve the `DatabaseHost` to connect to the database.
 ```bash
 DATABASE_URI=$(aws cloudformation describe-stacks \
  --stack-name slurm-accounting-database \
  --query 'Stacks[0].Outputs[?OutputKey==`DatabaseHost`].OutputValue' \
  --output text)
 ```
-  Copy URL into a Web Browser.
 
 ### Get the Database Admin User
-The database admin user is by default `custeradmin` if you didn't change it on creation.
+The database admin user is by default `clusteradmin` if you didn't change it on creation.
 
 Get the Database admin user name
 ```bash
@@ -112,7 +111,7 @@ EOF
 
 Restart the slurmctld to pickup the configuration change.
 ```bash
-sudo systemctl restart slurmdctld
+sudo systemctl restart slurmctld
 sudo scontrol reconfigure
 ```
 


### PR DESCRIPTION
## Summary

Fixes #1094 — four small documentation flaws in `1.architectures/8.accounting-database/README.md`:

- **L28**: "Retrieve the `DatabaseHost` to connect to the LDAP User Interface." → "Retrieve the `DatabaseHost` to connect to the database." (leftover from LDAP boilerplate)
- **L33**: Removed orphan line "  Copy URL into a Web Browser." (also leftover LDAP boilerplate)
- **L38**: `custeradmin` → `clusteradmin` (matches the template default `DBAdminUserName` in `cf_database-accounting.yaml` L47)
- **L115**: `sudo systemctl restart slurmdctld` → `sudo systemctl restart slurmctld` (typo — the surrounding prose already says "Restart the slurmctld")

## Test plan

- [x] Documentation-only change — no code, no infra, no CI behavior affected
- [x] Re-read the rendered README on the branch to confirm wording and code blocks are intact
- [x] Verified `clusteradmin` matches the CloudFormation template default in `cf_database-accounting.yaml`