### PR TITLE
docs(accounting-db): add TLS config to HyperPod slurmdbd snippet

### DIFF
--- a/1.architectures/8.accounting-database/README.md
+++ b/1.architectures/8.accounting-database/README.md
@@ -78,7 +78,19 @@ There are two steps to setup Slurm with the accounting database:
 1. Configure Slurm accounting
 
 ### Add database configuration file
-You need to execute the following command on the controller node to configure the database connectivity for Slurm.
+You need to execute the following commands on the controller node to configure the database connectivity for Slurm.
+
+The Aurora cluster parameter group deployed by `cf_database-accounting.yaml` sets `require_secure_transport: ON`, so slurmdbd must connect over TLS and verify the RDS server certificate. The RDS public CA is not in the default OS trust store on Amazon Linux or Ubuntu, so first download the RDS global CA bundle and make it readable:
+
+```bash
+# Download the RDS public CA bundle so slurmdbd can verify the TLS server certificate
+# required by the cluster parameter group (require_secure_transport: ON).
+sudo curl -o /etc/ssl/certs/rds-global-bundle.pem \
+  https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+sudo chmod 644 /etc/ssl/certs/rds-global-bundle.pem
+```
+
+Then write the slurmdbd configuration. The `StorageParameters=SSL_CA=...` line points slurmdbd at the bundle you just downloaded; see the Slurm [`StorageParameters` documentation](https://slurm.schedmd.com/slurmdbd.conf.html#OPT_StorageParameters) for details.
 
 ```bash
 cat > /opt/slurm/etc/slurmdbd.conf << EOF
@@ -92,6 +104,7 @@ StorageUser=${DATABASE_ADMIN}
 StoragePass=$(aws secretsmanager get-secret-value --secret-id ${DATABASE_SECRET_ARN} --query SecretString --output text)
 StorageHost=${DATABASE_URI}
 StoragePort=3306
+StorageParameters=SSL_CA=/etc/ssl/certs/rds-global-bundle.pem
 EOF
 ```
 


### PR DESCRIPTION
## Summary

Fixes #1095.

The Aurora cluster parameter group deployed by `1.architectures/8.accounting-database/cf_database-accounting.yaml` sets `require_secure_transport: ON`, but the HyperPod section of the same directory's README built `/opt/slurm/etc/slurmdbd.conf` without any TLS configuration. Following the README verbatim produces a non-functional slurmdbd because the RDS public CA is not in the default OS trust store on Amazon Linux / Ubuntu.

## Changes

Scope is **HyperPod-only** (`### Add database configuration file` subsection):

- Add a step to download the RDS global CA bundle to `/etc/ssl/certs/rds-global-bundle.pem` before writing `slurmdbd.conf`.
- Add `StorageParameters=SSL_CA=/etc/ssl/certs/rds-global-bundle.pem` to the `slurmdbd.conf` heredoc.
- Add a sentence linking to the Slurm [`StorageParameters` docs](https://slurm.schedmd.com/slurmdbd.conf.html#OPT_StorageParameters) explaining why.

The ParallelCluster YAML snippet above (`SlurmSettings.Database`) is intentionally **not** modified — PC plumbs SSL automatically.

## Test plan

- [x] `git diff` is minimal and only touches the HyperPod subsection
- [ ] Reviewer: skim the rendered README on the PR page to confirm markdown reads cleanly