### PR TITLE
fix(parallelcluster-prereqs): default FSx OpenZFS to SINGLE_AZ_HA_2

### DIFF
--- a/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
+++ b/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
@@ -320,7 +320,7 @@ Resources:
         CopyTagsToBackups: Yes
         CopyTagsToVolumes: Yes
         DailyAutomaticBackupStartTime: '19:00'
-        DeploymentType: SINGLE_AZ_HA_1
+        DeploymentType: SINGLE_AZ_HA_2
         Options: 
           - DELETE_CHILD_VOLUMES_AND_SNAPSHOTS
         RootVolumeConfiguration: 


### PR DESCRIPTION
Fixes #1097.

`1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml` hard-coded `DeploymentType: SINGLE_AZ_HA_1` for the FSx OpenZFS file system backing `/home`. Per the official [FSx OpenZFS Availability by AWS Region table](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/available-aws-regions.html), `SINGLE_AZ_HA_1` is not offered in us-east-1, us-east-2, us-west-2, eu-central-1, eu-west-1, ap-northeast-1, ap-southeast-1, ap-southeast-2, ap-south-1, ca-central-1, and several other major regions — so the template fails out-of-the-box there.

This flips the default to `SINGLE_AZ_HA_2`, which is the newer generation and broadly available in all the regions where HA_1 is missing. Its 160 MB/s throughput minimum is below the template's existing `HomeThroughput` default of 512 MB/s, so no other parameters need to change. Minimal one-line fix; introducing a configurable `DeploymentType` parameter / Mappings / Rules was considered and explicitly deferred as a separate future enhancement.