### PR TITLE
fix(accounting-db): expose Aurora EngineVersion as parameter (default 3.12.0)

### DIFF
--- a/1.architectures/8.accounting-database/README.md
+++ b/1.architectures/8.accounting-database/README.md
@@ -20,6 +20,21 @@ Deploy the accounting database using the 1-click deploy:
   --parameter-overrides VpcId=XXX SubnetIds=XXX,XXX
   ```
 
+The template defaults the Aurora MySQL `EngineVersion` to the latest Serverless-v2-compatible
+release available at the time of the last template update. AWS retires Aurora MySQL minor
+versions on a rolling basis, so the pinned default may eventually become unavailable and
+stack creation will fail with `Cannot find version ... for aurora-mysql`. Check which
+versions are currently offered with:
+
+```bash
+aws rds describe-db-engine-versions --engine aurora-mysql \
+  --query 'DBEngineVersions[?Status==`available`].EngineVersion' --output text
+```
+
+Override the default by appending `EngineVersion=8.0.mysql_aurora.X.Y.Z` to
+`--parameter-overrides` (or `ParameterKey=EngineVersion,ParameterValue=8.0.mysql_aurora.X.Y.Z`
+when using `aws cloudformation create-stack`).
+
 ## Get database parameters
 In this section, you will retrieve the database parameter that are used by Slurm to connect to the accounting database.
 

--- a/1.architectures/8.accounting-database/cf_database-accounting.yaml
+++ b/1.architectures/8.accounting-database/cf_database-accounting.yaml
@@ -65,6 +65,14 @@ Parameters:
   SubnetIds:
     Description: Subnets in which database will be reachable.
     Type: List<AWS::EC2::Subnet::Id>
+  EngineVersion:
+    Description: >-
+      Aurora MySQL engine version. Verify the value is currently offered with
+      `aws rds describe-db-engine-versions --engine aurora-mysql --query 'DBEngineVersions[?Status==\`available\`].EngineVersion' --output text`.
+      Aurora retires minor versions on a rolling basis, so older pinned values will
+      eventually fail with "Cannot find version" at stack-create time.
+    Type: String
+    Default: "8.0.mysql_aurora.3.12.0"
 
 ############################
 ## Database Resources
@@ -141,7 +149,7 @@ Resources:
     Properties:
       DBClusterIdentifier: !Ref ClusterName
       Engine: "aurora-mysql"
-      EngineVersion: "8.0.mysql_aurora.3.07.1"
+      EngineVersion: !Ref EngineVersion
       CopyTagsToSnapshot: true
       DBClusterParameterGroupName: !Ref AccountingClusterParameterGroup
       DBSubnetGroupName: !Ref AccountingClusterSubnetGroup


### PR DESCRIPTION
## Summary

Fixes #1096.

`1.architectures/8.accounting-database/cf_database-accounting.yaml` pinned
`EngineVersion: "8.0.mysql_aurora.3.07.1"`, which AWS has rotated out of service.
Stack creation currently fails with:

```
Cannot find version 8.0.mysql_aurora.3.07.1 for aurora-mysql
```

AWS retires Aurora MySQL minor versions on a rolling basis, so any hardcoded pin
will eventually exhibit the same failure.

## Changes

- Expose `EngineVersion` as a CloudFormation parameter so users can override
  without forking the template.
- Default to `8.0.mysql_aurora.3.12.0` (latest Serverless-v2-compatible version
  as of 2026-05-16, verified live via `aws rds describe-db-engine-versions`).
- README: document how to verify the current default is still offered and how
  to override it at deploy time.

## Verification

Check the currently available Aurora MySQL engine versions:

```bash
aws rds describe-db-engine-versions --engine aurora-mysql \
  --query 'DBEngineVersions[?Status==`available`].EngineVersion' --output text
```

Override at deploy time:

```bash
aws cloudformation deploy --stack-name slurm-accounting-database \
  --template-file cf_database-accounting.yaml \
  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
  --parameter-overrides VpcId=XXX SubnetIds=XXX,XXX EngineVersion=8.0.mysql_aurora.3.12.0
```

## Test plan

- [ ] `aws cloudformation deploy` succeeds with default `EngineVersion`
- [ ] `aws cloudformation deploy` succeeds when `EngineVersion` is overridden via `--parameter-overrides`
- [ ] Stack output `DatabaseHost` resolves and is reachable from a ParallelCluster head node