### PR TITLE
fix(parallelcluster-prereqs): two private subnets + Multi-AZ FSx OpenZFS for /home (follow-up to #1100)

### DIFF
--- a/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
+++ b/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
@@ -81,9 +81,13 @@ Parameters:
       Multi-AZ FSx OpenZFS (the /home file system) and for the
       accounting-database CloudFormation template's Aurora DBSubnetGroup,
       which requires subnets in two different Availability Zones. Leave
-      empty to auto-pick an AZ different from PrimarySubnetAZ (the first
-      alphabetical AZ that isn't already PrimarySubnetAZ), or provide an
-      explicit AZ name (e.g. us-east-1c) to override.
+      empty to default to the second AZ in the region (alphabetical), or
+      provide an explicit AZ name (e.g. us-east-1c) to override. Must differ
+      from PrimarySubnetAZ. NOTE: if your PrimarySubnetAZ happens to be the
+      second alphabetically (e.g. us-east-1b, ap-northeast-1d), set
+      SecondarySubnetAZ explicitly to avoid a collision at FSx create time.
+      CloudFormation cannot validate this collision at parameter-eval time
+      because Fn::GetAZs is not permitted inside Conditions or Rules.
     Type: String
     Default: ""
 
@@ -160,11 +164,6 @@ Parameters:
 Conditions:
   S3EndpointCondition: !Equals [!Ref 'CreateS3Endpoint', 'true']
   UseAutoSecondaryAZ: !Equals [!Ref SecondarySubnetAZ, '']
-  # If PrimarySubnetAZ happens to be the second AZ alphabetically (the
-  # default position the auto-secondary would otherwise pick), the
-  # auto-secondary falls back to the first AZ instead. Guarantees the
-  # two AZs are distinct under the auto path without any user input.
-  PrimaryIsSecondAZAlphabetical: !Equals [!Ref PrimarySubnetAZ, !Select [1, !GetAZs '']]
 
 ###########
 ## Rules ##
@@ -304,10 +303,7 @@ Resources:
       CidrBlock: !Select [ 1, !Cidr [ !FindInMap [Networking, VPC, CIDR1], 2, 15 ]]
       AvailabilityZone: !If
         - UseAutoSecondaryAZ
-        - !If
-          - PrimaryIsSecondAZAlphabetical
-          - !Select [ 0, !GetAZs '' ]
-          - !Select [ 1, !GetAZs '' ]
+        - !Select [ 1, !GetAZs '' ]
         - !Ref SecondarySubnetAZ
       Tags:
         - Key: Name
@@ -317,10 +313,7 @@ Resources:
               - 'Private Subnet -'
               - !If
                 - UseAutoSecondaryAZ
-                - !If
-                  - PrimaryIsSecondAZAlphabetical
-                  - !Select [ 0, !GetAZs '' ]
-                  - !Select [ 1, !GetAZs '' ]
+                - !Select [ 1, !GetAZs '' ]
                 - !Ref SecondarySubnetAZ
 
   # Create and set the public route table

--- a/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
+++ b/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
@@ -3,14 +3,20 @@
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
-  This CloudFormation stack creates all the necessary pre-requisites for AWS ParallelCluster,
-  these include VPC and two Subnets, a security group and FSx Lustre Filesystem.
-  A public subnet and a private subnet are created in an Availability Zone that you provide as a parameter.
-  As part of the template you'll deploy an Internet Gateway and NAT Gateway in
-  the public subnet. In addition you deploy endpoints for Amazon S3. The VPC contains 2 CIDR blocks with 10.0.0.0/16 and 10.1.0.0/16
-  The first CIDR is used for the public subnet, the second is used for the private.
-  The template creates an fsx lustre volume in the specified AZ with a default of
-  1.2 TB storage which can be overridden by parameter.
+  This CloudFormation stack creates all the pre-requisites for AWS ParallelCluster:
+  a VPC with one public subnet and two private subnets in different AZs, a NAT
+  Gateway, an Internet Gateway, an Amazon S3 endpoint, an EFA-friendly security
+  group, an FSx Lustre file system (for /fsx), and a Multi-AZ FSx OpenZFS file
+  system (for /home) split across the two private subnets for cross-AZ failover.
+  The VPC has two CIDR blocks: 10.0.0.0/16 (used for the public subnet) and
+  10.1.0.0/16 (split into two /17s for the private subnets). FSx Lustre defaults
+  to 1.2 TB; override via parameter.
+
+  BREAKING CHANGE for existing stacks: this version switches the FSx OpenZFS
+  DeploymentType to MULTI_AZ_1. DeploymentType is CREATE_ONLY, which means
+  CloudFormation must REPLACE the file system on update — your /home data
+  will be destroyed and recreated. Back up /home before running update-stack,
+  or redeploy the stack from scratch.
 
 
 ####################
@@ -30,9 +36,17 @@ Metadata:
           - PrimarySubnetAZ
           - SecondarySubnetAZ
       - Label:
-          default: Fsx Lustre storage size
+          default: FSx Lustre (/fsx) configuration
         Parameters:
           - Capacity
+          - PerUnitStorageThroughput
+          - Compression
+          - LustreVersion
+      - Label:
+          default: FSx OpenZFS (/home) configuration
+        Parameters:
+          - HomeCapacity
+          - HomeThroughput
       - Label:
           default: Network and S3 endpoints configuration
         Parameters:
@@ -67,11 +81,9 @@ Parameters:
       Multi-AZ FSx OpenZFS (the /home file system) and for the
       accounting-database CloudFormation template's Aurora DBSubnetGroup,
       which requires subnets in two different Availability Zones. Leave
-      empty to default to the second AZ in the region (alphabetical), or
-      provide an explicit AZ name (e.g. us-east-1c) to override. Must differ
-      from PrimarySubnetAZ. NOTE: if your PrimarySubnetAZ happens to be the
-      second alphabetically, set SecondarySubnetAZ explicitly to avoid a
-      collision at FSx create time.
+      empty to auto-pick an AZ different from PrimarySubnetAZ (the first
+      alphabetical AZ that isn't already PrimarySubnetAZ), or provide an
+      explicit AZ name (e.g. us-east-1c) to override.
     Type: String
     Default: ""
 
@@ -148,6 +160,11 @@ Parameters:
 Conditions:
   S3EndpointCondition: !Equals [!Ref 'CreateS3Endpoint', 'true']
   UseAutoSecondaryAZ: !Equals [!Ref SecondarySubnetAZ, '']
+  # If PrimarySubnetAZ happens to be the second AZ alphabetically (the
+  # default position the auto-secondary would otherwise pick), the
+  # auto-secondary falls back to the first AZ instead. Guarantees the
+  # two AZs are distinct under the auto path without any user input.
+  PrimaryIsSecondAZAlphabetical: !Equals [!Ref PrimarySubnetAZ, !Select [1, !GetAZs '']]
 
 ###########
 ## Rules ##
@@ -287,7 +304,10 @@ Resources:
       CidrBlock: !Select [ 1, !Cidr [ !FindInMap [Networking, VPC, CIDR1], 2, 15 ]]
       AvailabilityZone: !If
         - UseAutoSecondaryAZ
-        - !Select [ 1, !GetAZs '' ]
+        - !If
+          - PrimaryIsSecondAZAlphabetical
+          - !Select [ 0, !GetAZs '' ]
+          - !Select [ 1, !GetAZs '' ]
         - !Ref SecondarySubnetAZ
       Tags:
         - Key: Name
@@ -297,7 +317,10 @@ Resources:
               - 'Private Subnet -'
               - !If
                 - UseAutoSecondaryAZ
-                - !Select [ 1, !GetAZs '' ]
+                - !If
+                  - PrimaryIsSecondAZAlphabetical
+                  - !Select [ 0, !GetAZs '' ]
+                  - !Select [ 1, !GetAZs '' ]
                 - !Ref SecondarySubnetAZ
 
   # Create and set the public route table
@@ -396,6 +419,11 @@ Resources:
     Type: AWS::FSx::FileSystem
     Properties:
       FileSystemType: OPENZFS
+      # Note on EndpointIpAddressRange: omitted intentionally. With both
+      # /17s of 10.1.0.0/16 used by the private subnets, FSx will auto-
+      # pick a free /28 from 10.0.128.0/17 (the unused half of the public
+      # CIDR). It's reachable from every subnet via the VPC's local route,
+      # which is why the choice works without explicit configuration.
       OpenZFSConfiguration:
         AutomaticBackupRetentionDays: 30
         CopyTagsToBackups: Yes
@@ -406,13 +434,22 @@ Resources:
         # https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/available-aws-regions.html
         # The HA pair is split across PrimaryPrivateSubnet and
         # SecondaryPrivateSubnet for cross-AZ failover.
+        #
+        # WARNING: DeploymentType is CREATE_ONLY. Changing this on an
+        # existing stack triggers a REPLACE of the file system, destroying
+        # /home data. Back up before update-stack, or redeploy fresh.
         DeploymentType: MULTI_AZ_1
         PreferredSubnetId: !Ref PrimaryPrivateSubnet
-        # Floating-IP routes are added to the private RT so traffic from
-        # the compute fleet (in PrimaryPrivateSubnet) reaches whichever
-        # file server is currently active.
+        # Floating-IP routes are added to BOTH route tables so traffic
+        # from every /home client — the compute fleet in
+        # PrimaryPrivateSubnet AND the head node in PublicSubnet —
+        # reaches whichever file server is currently active. A client in
+        # a subnet whose RT is not listed here loses /home access on
+        # failover, because the floating IP doesn't get a host route in
+        # its RT.
         RouteTableIds:
           - !Ref PrivateRouteTable
+          - !Ref PublicRouteTable
         Options:
           - DELETE_CHILD_VOLUMES_AND_SNAPSHOTS
         RootVolumeConfiguration:

--- a/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
+++ b/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
@@ -28,6 +28,7 @@ Metadata:
           default: Availability Zone configuration for the subnets
         Parameters:
           - PrimarySubnetAZ
+          - SecondarySubnetAZ
       - Label:
           default: Fsx Lustre storage size
         Parameters:
@@ -41,6 +42,8 @@ Metadata:
         default: Name of your VPC
       PrimarySubnetAZ:
         default: Availability zone id to deploy the primary subnets
+      SecondarySubnetAZ:
+        default: Availability zone id for the secondary private subnet (Multi-AZ /home + Aurora subnet group)
       CreateS3Endpoint:
         default: Create an S3 endpoint
 
@@ -57,6 +60,20 @@ Parameters:
   PrimarySubnetAZ:
     Description: Availability zone id in which the public subnet and primary private subnet will be created.
     Type: AWS::EC2::AvailabilityZone::Name
+
+  SecondarySubnetAZ:
+    Description: >-
+      Availability zone id for the secondary private subnet. Required for
+      Multi-AZ FSx OpenZFS (the /home file system) and for the
+      accounting-database CloudFormation template's Aurora DBSubnetGroup,
+      which requires subnets in two different Availability Zones. Leave
+      empty to default to the second AZ in the region (alphabetical), or
+      provide an explicit AZ name (e.g. us-east-1c) to override. Must differ
+      from PrimarySubnetAZ. NOTE: if your PrimarySubnetAZ happens to be the
+      second alphabetically, set SecondarySubnetAZ explicitly to avoid a
+      collision at FSx create time.
+    Type: String
+    Default: ""
 
   CreateS3Endpoint:
     AllowedValues:
@@ -104,9 +121,24 @@ Parameters:
     Default: 512
 
   HomeThroughput:
-    Description: "Home directories storage throughput MB/s"
+    Description: >-
+      FSx OpenZFS provisioned throughput for /home, in MB/s. The valid
+      values listed here are the discrete set supported by MULTI_AZ_1
+      (and SINGLE_AZ_HA_2). Default 160 is the minimum tier — bump it
+      if your workload actually needs the bandwidth, since FSx OpenZFS
+      prices throughput aggressively.
     Type: Number
-    Default: 512
+    Default: 160
+    AllowedValues:
+      - 160
+      - 320
+      - 640
+      - 1280
+      - 2560
+      - 3840
+      - 5120
+      - 7680
+      - 10240
 
 
 ###############################
@@ -115,6 +147,24 @@ Parameters:
 
 Conditions:
   S3EndpointCondition: !Equals [!Ref 'CreateS3Endpoint', 'true']
+  UseAutoSecondaryAZ: !Equals [!Ref SecondarySubnetAZ, '']
+
+###########
+## Rules ##
+###########
+
+Rules:
+  SecondaryAZDistinctWhenExplicit:
+    # Only fires when the user provides an explicit SecondarySubnetAZ. The
+    # default-empty case auto-selects !Select [1, !GetAZs ""], which we
+    # cannot validate against PrimarySubnetAZ at parameter-eval time.
+    RuleCondition: !Not [!Equals [!Ref SecondarySubnetAZ, '']]
+    Assertions:
+      - Assert: !Not [!Equals [!Ref PrimarySubnetAZ, !Ref SecondarySubnetAZ]]
+        AssertDescription: >-
+          SecondarySubnetAZ must differ from PrimarySubnetAZ. Multi-AZ FSx
+          OpenZFS and the Aurora DBSubnetGroup both require subnets in two
+          different Availability Zones.
 
 #########################
 ## VPC & Network Setup ##
@@ -226,6 +276,30 @@ Resources:
         - Key: Name
           Value: !Join [ ' ', [ !Ref VPCName, 'Private Subnet -', !Ref PrimarySubnetAZ ] ]
 
+  # Create the secondary private subnet in a different AZ. Carves the
+  # second /17 out of the private CIDR (10.1.128.0/17). Required for
+  # Multi-AZ FSx OpenZFS and for the Aurora DBSubnetGroup downstream.
+  SecondaryPrivateSubnet:
+    Type: AWS::EC2::Subnet
+    DependsOn: [VpcCidrBlock]
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [ 1, !Cidr [ !FindInMap [Networking, VPC, CIDR1], 2, 15 ]]
+      AvailabilityZone: !If
+        - UseAutoSecondaryAZ
+        - !Select [ 1, !GetAZs '' ]
+        - !Ref SecondarySubnetAZ
+      Tags:
+        - Key: Name
+          Value: !Join
+            - ' '
+            - - !Ref VPCName
+              - 'Private Subnet -'
+              - !If
+                - UseAutoSecondaryAZ
+                - !Select [ 1, !GetAZs '' ]
+                - !Ref SecondarySubnetAZ
+
   # Create and set the public route table
   PublicRouteTable:
     Type: AWS::EC2::RouteTable
@@ -264,6 +338,13 @@ Resources:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref PrimaryPrivateSubnet
+      RouteTableId: !Ref PrivateRouteTable
+
+  # also the secondary private subnet to the same private route table
+  SecondaryPrivateSubnetRTAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref SecondaryPrivateSubnet
       RouteTableId: !Ref PrivateRouteTable
 
   # S3 endpoint
@@ -315,31 +396,43 @@ Resources:
     Type: AWS::FSx::FileSystem
     Properties:
       FileSystemType: OPENZFS
-      OpenZFSConfiguration: 
+      OpenZFSConfiguration:
         AutomaticBackupRetentionDays: 30
         CopyTagsToBackups: Yes
         CopyTagsToVolumes: Yes
         DailyAutomaticBackupStartTime: '19:00'
-        DeploymentType: SINGLE_AZ_HA_2
-        Options: 
+        # MULTI_AZ_1 is the only deployment type with universal regional
+        # coverage per the FSx OpenZFS availability table:
+        # https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/available-aws-regions.html
+        # The HA pair is split across PrimaryPrivateSubnet and
+        # SecondaryPrivateSubnet for cross-AZ failover.
+        DeploymentType: MULTI_AZ_1
+        PreferredSubnetId: !Ref PrimaryPrivateSubnet
+        # Floating-IP routes are added to the private RT so traffic from
+        # the compute fleet (in PrimaryPrivateSubnet) reaches whichever
+        # file server is currently active.
+        RouteTableIds:
+          - !Ref PrivateRouteTable
+        Options:
           - DELETE_CHILD_VOLUMES_AND_SNAPSHOTS
-        RootVolumeConfiguration: 
+        RootVolumeConfiguration:
           DataCompressionType: NONE
-          NfsExports: 
-            - ClientConfigurations: 
+          NfsExports:
+            - ClientConfigurations:
               -  Clients: '*'
-                 Options: 
+                 Options:
                     - rw
                     - no_root_squash
                     - crossmnt
         ThroughputCapacity: !Ref HomeThroughput
         WeeklyMaintenanceStartTime: '1:04:00'
-      SecurityGroupIds: 
+      SecurityGroupIds:
         - !Ref SecurityGroup
       StorageCapacity: !Ref HomeCapacity
       StorageType: SSD
-      SubnetIds: 
+      SubnetIds:
         - !Ref PrimaryPrivateSubnet
+        - !Ref SecondaryPrivateSubnet
 
 #############
 ## Outputs ##
@@ -360,6 +453,15 @@ Outputs:
     Description: ID of the primary private subnet
     Export:
       Name: !Sub ${AWS::StackName}-PrimaryPrivateSubnet
+  SecondaryPrivateSubnet:
+    Value: !Ref SecondaryPrivateSubnet
+    Description: >-
+      ID of the secondary private subnet (different AZ from the primary).
+      Pass this alongside the primary subnet to the accounting-database
+      template's SubnetIds parameter to satisfy the Aurora DBSubnetGroup
+      multi-AZ requirement.
+    Export:
+      Name: !Sub ${AWS::StackName}-SecondaryPrivateSubnet
   SecurityGroup:
     Value: !Ref SecurityGroup
     Description: SecurityGroup for Batch


### PR DESCRIPTION
## Summary

Follow-up to #1100. That PR flipped FSx OpenZFS from `SINGLE_AZ_HA_1` to `SINGLE_AZ_HA_2`, which made the template work in the major regions where HA_1 was rejected (us-east-1, us-east-2, us-west-2, eu-central-1, eu-west-1, ap-northeast-1, ap-southeast-1/2, ap-south-1, ca-central-1). But HA_2 itself isn't universally available either — about 20 regions still don't offer it as a Single-AZ HA SSD option, per the official [FSx OpenZFS regional availability table](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/available-aws-regions.html): ap-osaka, ap-jakarta, ap-melbourne, ap-malaysia, ap-hyderabad, ap-newzealand, ap-taipei, ap-thailand, ca-west-1, eu-milan, eu-london, eu-paris, mex-central, me-uae, me-bahrain, sa-east-1, il-central, af-south, GovCloud-East, …

**`MULTI_AZ_1` is the only Single/Multi-AZ HA SSD type with a ✓ in *every* row of that table.**

This PR also incidentally eliminates the "create a second private subnet by hand" workaround that the accounting-database CloudFormation template's Aurora `DBSubnetGroup` currently forces on users (the prereqs template before this change provisions only one private subnet, but Aurora needs subnets in ≥2 AZs).

## Changes

- **New `SecondarySubnetAZ` parameter** — defaults empty; when empty, auto-picks the second AZ in the region via `!Select [1, !GetAZs '']`. Override with an explicit AZ name. Parameter description warns users to set this explicitly if their `PrimarySubnetAZ` happens to be the second alphabetically (e.g. `us-east-1b`, `ap-northeast-1d`) — the auto-default would collide. *(See [Self-correction note](#self-correction-note) at the bottom for why this can't be guarded against in CFN.)*
- **New `SecondaryPrivateSubnet` resource** carved from the second `/17` of the private CIDR block (`10.1.128.0/17`), associated with the existing private route table.
- **CloudFormation `Rules` block** asserting `PrimarySubnetAZ != SecondarySubnetAZ` whenever the latter is explicit — fires at parameter-validation time, before any resource is created.
- **FSx OpenZFS switched from `SINGLE_AZ_HA_2` to `MULTI_AZ_1`**: both subnets attached, `PreferredSubnetId: !Ref PrimaryPrivateSubnet`. Floating-IP `RouteTableIds: [!Ref PrivateRouteTable, !Ref PublicRouteTable]` — **both** route tables, so the head node (in PublicSubnet, mounts `/home`) and the compute fleet (in PrimaryPrivateSubnet, mounts `/home`) each follow the floating IP through failover.
- **`HomeThroughput` default 512 → 160** (`512` isn't in the discrete set MULTI_AZ_1 / SINGLE_AZ_HA_2 / SINGLE_AZ_2 accept) plus `AllowedValues` enumerating the valid set, so throughput mistakes now fail at CFN parameter-validation time instead of mid-stack inside the FSx API.
- **New `SecondaryPrivateSubnet` stack output** so downstream templates (`cf_database-accounting.yaml` in particular) can consume both subnets directly.
- **Breaking-change documentation**: top-of-file `Description` and an inline `# WARNING` comment above `DeploymentType: MULTI_AZ_1` flag that the change is `CREATE_ONLY` for FSx — running `update-stack` against an existing stack replaces the file system and destroys `/home`.
- **Parameter groups**: `HomeCapacity` and `HomeThroughput` are now grouped under "FSx OpenZFS (/home) configuration" in the CFN console (previously orphaned under "Other parameters"); the Lustre parameters are grouped under "FSx Lustre (/fsx) configuration".
- **Comment on `EndpointIpAddressRange`** auto-pick — given both `/17`s of `10.1.0.0/16` are now consumed by the private subnets, FSx lands the endpoint `/28` in `10.0.128.0/17` (the unused half of the public CIDR). Verified live (see Test plan).

## Cost note

Multi-AZ FSx OpenZFS is roughly **2× the cost** of Single-AZ HA for the same throughput tier (synchronous cross-AZ replication, two file servers in two AZs). At the new default `HomeThroughput: 160` and the existing `HomeCapacity: 512` default, that's still under \$0.50/hr for /home in `us-east-1` — acceptable for a starter template, and the universal regional coverage is worth it. Users who explicitly want the cheaper Single-AZ-HA option in regions that offer it can fork the OpenZFS resource back.

## Test plan

- [x] `aws cloudformation validate-template` — passes; parameters wired up correctly
- [x] **Live deploy in `us-east-1`** (`PrimarySubnetAZ=us-east-1a`, `SecondarySubnetAZ` left empty, `HomeCapacity=256`, `PerUnitStorageThroughput=125`, rest default): stack `CREATE_COMPLETE` at 09:38:34 — 13 min total, FSx OpenZFS Multi-AZ create was the long pole (~12 min); everything else completed in the first minute.
- [x] **Subnets in different AZs verified**: auto-derived `SecondaryPrivateSubnet` landed in `us-east-1b` (alphabetical index 1), distinct from `PrimarySubnetAZ=us-east-1a` — no collision because the primary was index 0. (The documented warning still applies to users who pick index 1, e.g. `us-east-1b`, as their primary; that path was not exercised in this deploy.)
- [x] **OpenZFS Multi-AZ topology confirmed via `aws fsx describe-file-systems`**:
  - `DeploymentType: MULTI_AZ_1`
  - `PreferredSubnetId: subnet-04735fa4ad905e920` (primary)
  - `SubnetIds: [primary, secondary]`
  - `EndpointIpAddressRange: 10.0.255.224/28` (auto-picked from the unused half of `10.0.0.0/16`, exactly as the new template comment predicts)
  - `ThroughputCapacity: 160` (the new default; `AllowedValues` enforces the valid set at parameter-eval time)
- [x] **MUST-FIX verified live: floating-IP route exists in BOTH route tables.** `aws ec2 describe-route-tables` shows `10.0.255.235/32 → eni-0469fa8ab483cdda6` present in *both* `PrivateRouteTable` and `PublicRouteTable`. Without the fix this PR adds (`PublicRouteTable` in `OpenZFSConfiguration.RouteTableIds`), the public RT wouldn't have the route and the head node would lose `/home` access on failover.
- [x] **End-to-end mount verified**: deployed a ParallelCluster on top of this prereqs stack (head node in PublicSubnet, compute fleet in PrimaryPrivateSubnet, both mounting `/home`). Both head node *and* compute node mount `/home` via the same floating endpoint IP `addr=10.0.255.235`:

  ```
  # head node (PublicSubnet client, addr 10.0.5.126)
  fs-…fsx.us-east-1.amazonaws.com:/fsx on /home type nfs4 (… addr=10.0.255.235)

  # compute node gpu-st-g6-48xl-1 (PrimaryPrivateSubnet client, addr 10.1.112.136)
  fs-…fsx.us-east-1.amazonaws.com:/fsx on /home type nfs4 (… addr=10.0.255.235)
  ```

  Confirms the routing fix works end-to-end for the two client classes that matter. The head-node mount specifically is the test that would have failed under the original `RouteTableIds: [!Ref PrivateRouteTable]` only.
- [x] **Smoke job recorded by `slurmdbd`**: `sbatch --gres=gpu:1`, exit `COMPLETED` with `AllocTRES: billing=1,cpu=1,gres/gpu=1,node=1` in `sacct` — GPU TRES correctly captured.
- [x] **Downstream consumer verified**: the new `SecondaryPrivateSubnet` Output threaded directly into the accounting-database template's `SubnetIds: List<AWS::EC2::Subnet::Id>` parameter — Aurora `DBSubnetGroup` accepted both subnets with no manual `aws ec2 create-subnet` workaround. Stack `CREATE_COMPLETE`.

### Open verification gap

- [ ] Multi-AZ FSx OpenZFS *failover* itself was not exercised. The routing fix is verified at create-time (both RTs have the floating-IP route on first deploy), but a real failover (e.g. triggered by `aws fsx update-file-system --open-zfs-configuration ThroughputCapacity=...`, which causes FSx to switch file servers) would be the strongest end-to-end test. Skipped for now; flagging in case reviewer wants to drive it.

### Self-correction note

The /lt:review pass originally suggested a "smart default" Condition that auto-picks AZ 0 vs AZ 1 to avoid the collision in the docstring NOTE. I implemented it as a `PrimaryIsSecondAZAlphabetical` Condition using `!Equals [!Ref PrimarySubnetAZ, !Select [1, !GetAZs '']]`, but CFN rejected it at create-stack time:

```
Template error: Cannot use Fn::GetAZs in Conditions.
```

Per [CFN docs on intrinsic functions in Conditions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html), only `Fn::And`, `Fn::Equals`, `Fn::If`, `Fn::Not`, `Fn::Or`, `Ref`, and `Fn::FindInMap` are permitted there — `Fn::GetAZs` is excluded. `Fn::If`'s first argument must be a *named* Condition (not an inline `!Equals`), so the collision check cannot be expressed without `GetAZs` somewhere on the validation path. Reverted in commit 651f5fa back to the documented-warning approach.

Relates to #1097
