### PR TITLE
Publish Slurm series: flip draft: false on both posts

### DIFF
--- a/content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
+++ b/content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-Tenant Slurm on AWS ParallelCluster, Part 1: Accounting Database + Multi-User Setup"
 date: 2026-05-16
-draft: true
+draft: false
 author: ["Keita Watanabe"]
 description: "Stand up a Slurm accounting database on Aurora Serverless v2, wire it into AWS ParallelCluster, and onboard multiple users without LDAP. Part 1 of a two-post series; Part 2 adds QoS on top."
 tags: ["slurm", "accounting", "parallelcluster", "aurora", "rds", "multi-tenant", "aws", "multi-user"]

--- a/content/posts/slurm-qos-on-parallelcluster/index.md
+++ b/content/posts/slurm-qos-on-parallelcluster/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-Tenant Slurm on AWS ParallelCluster, Part 2: QoS Deep Dive"
 date: 2026-05-17
-draft: true
+draft: false
 author: ["Keita Watanabe"]
 description: "Use Slurm QoS — associations, limits, fairshare, preemption, partition QoS — to govern shared GPU capacity across teams on top of the multi-user ParallelCluster from Part 1."
 tags: ["slurm", "qos", "parallelcluster", "multi-tenant", "scheduling", "fairshare", "preemption", "aws"]


### PR DESCRIPTION
## Summary

PR #1093 merged the Slurm series into the `content` branch, but both posts shipped with `draft: true` in the front matter. The Hugo deploy workflow (`.github/workflows/hugo-deploy.yml`) runs `hugo --minify` *without* `--buildDrafts`, so drafts are excluded from the published site — the posts never appeared at https://awslabs.github.io/awsome-distributed-ai/.

This PR flips `draft: false` on both posts so the next deploy picks them up.

## Diff

```diff
 # content/posts/slurm-accounting-multi-user-on-parallelcluster/index.md
 date: 2026-05-16
-draft: true
+draft: false

 # content/posts/slurm-qos-on-parallelcluster/index.md
 date: 2026-05-17
-draft: true
+draft: false
```

Two-line change. Content of both posts is unchanged from what was reviewed and merged in #1093.

## Test plan

- [x] Both posts already build clean locally with `hugo --buildDrafts --minify` at v0.161.1 (matches the deploy workflow) — confirmed during #1093 review
- [ ] After merge, watch the deploy workflow run and confirm the posts appear at:
  - https://awslabs.github.io/awsome-distributed-ai/posts/slurm-accounting-multi-user-on-parallelcluster/
  - https://awslabs.github.io/awsome-distributed-ai/posts/slurm-qos-on-parallelcluster/