### PR TITLE
site: rename title to Awsome-Distributed-AI Deep Dives

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = "https://awslabs.github.io/awsome-distributed/"
 languageCode = "en-us"
-title = "Awsome-Distributed Deep Dives by the AWS Frameworks Team"
+title = "Awsome-Distributed-AI Deep Dives by the AWS Frameworks Team"
 theme = "PaperMod"
 
 [params]


### PR DESCRIPTION
## Summary

Updates the site title in `hugo.toml` to match the repo's current name (`awsome-distributed-ai`).

```diff
-title = "Awsome-Distributed Deep Dives by the AWS Frameworks Team"
+title = "Awsome-Distributed-AI Deep Dives by the AWS Frameworks Team"
```

One-line change; affects the header, browser tab title, RSS feed `<title>`, and OpenGraph title across all pages.

## Test plan

- [ ] After merge, the deploy workflow rebuilds and the new title appears at https://awslabs.github.io/awsome-distributed-ai/

## Related stale references (not in this PR)

Two other lines in `hugo.toml` still reference the old `awsome-distributed` name. They're left alone here so this PR stays a one-line title change. Worth a follow-up PR:

- L1: `baseURL = "https://awslabs.github.io/awsome-distributed/"` — Hugo uses this for absolute URLs in the sitemap, RSS feed, and any `absURL`-using template. GitHub Pages serves the redirect so visitors aren't affected, but external tools (RSS readers, OG-card crawlers) see URLs pointing at the old path.
- L7: `description = "...companion to awslabs/awsome-distributed."` — same naming inconsistency.