### PR TITLE
site: update baseURL + description + home-page link to awsome-distributed-ai

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,10 +1,10 @@
-baseURL = "https://awslabs.github.io/awsome-distributed/"
+baseURL = "https://awslabs.github.io/awsome-distributed-ai/"
 languageCode = "en-us"
 title = "Awsome-Distributed-AI Deep Dives by the AWS Frameworks Team"
 theme = "PaperMod"
 
 [params]
-  description = "Posts about distributed ML training on AWS — companion to awslabs/awsome-distributed."
+  description = "Posts about distributed ML training on AWS — companion to awslabs/awsome-distributed-ai."
   ShowReadingTime = true
   ShowShareButtons = false
   ShowPostNavLinks = true
@@ -14,7 +14,7 @@ theme = "PaperMod"
   Content = """
 Posts on distributed training and inference — infrastructure, frameworks, and observability — from the AWS Frameworks Team.
 
-Companion to [`awslabs/awsome-distributed`](https://github.com/awslabs/awsome-distributed).
+Companion to [`awslabs/awsome-distributed-ai`](https://github.com/awslabs/awsome-distributed-ai).
 """
 
 [[menu.main]]


### PR DESCRIPTION
## Summary

Follow-up to #1104. The repo was renamed from `awsome-distributed` to `awsome-distributed-ai` earlier in 2026 — #1104 fixed the site title; this PR clears the three remaining stale references in `hugo.toml`:

```diff
-baseURL = "https://awslabs.github.io/awsome-distributed/"
+baseURL = "https://awslabs.github.io/awsome-distributed-ai/"

-  description = "Posts about distributed ML training on AWS — companion to awslabs/awsome-distributed."
+  description = "Posts about distributed ML training on AWS — companion to awslabs/awsome-distributed-ai."

-Companion to [`awslabs/awsome-distributed`](https://github.com/awslabs/awsome-distributed).
+Companion to [`awslabs/awsome-distributed-ai`](https://github.com/awslabs/awsome-distributed-ai).
```

### Why each one matters

| Line | Surface area |
|---|---|
| `baseURL` | Hugo uses this for absolute URLs in `sitemap.xml`, the RSS feed, and any template using `absURL`. GitHub Pages handles the redirect for human visitors, so the site was reachable, but external tools (RSS readers, OG-card crawlers, search engines) saw URLs pointing at the old repo path. |
| `[params].description` | Surfaces in the `<meta name="description">` tag on every page — the snippet search engines and link-previewers display. |
| `[params.homeInfoParams].Content` | The home-page byline under "Distributed ML on AWS" — both the visible link text and the GitHub URL it points at. |

After edit, `grep -E 'awsome-distributed[^-]' hugo.toml` returns no matches.

## Test plan

- [ ] After merge, the deploy workflow rebuilds and:
  - The home page byline says `awslabs/awsome-distributed-ai` and the link target is `https://github.com/awslabs/awsome-distributed-ai`
  - The deployed sitemap at `/sitemap.xml` shows post URLs under `awsome-distributed-ai`, not `awsome-distributed`
  - The RSS feed at `/index.xml` matches