### PR TITLE
DeepSeek-V3 Disaggregated Inference with vLLM, UCCL-EP, and NIXL on EKS

### DIFF
--- a/3.test_cases/pytorch/vllm/README.md
+++ b/3.test_cases/pytorch/vllm/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->
+
 # vLLM test cases
 
 [vLLM](https://github.com/vllm-project/vllm) is a high-throughput,

--- a/3.test_cases/pytorch/vllm/README.md
+++ b/3.test_cases/pytorch/vllm/README.md
@@ -1,0 +1,15 @@
+# vLLM test cases
+
+[vLLM](https://github.com/vllm-project/vllm) is a high-throughput,
+OpenAI-API-compatible LLM serving engine. The samples in this directory
+deploy vLLM on AWS for inference workloads, with options for high-
+performance EFA networking, expert-parallel all-to-all
+([UCCL-EP](https://github.com/uccl-project/uccl)), and disaggregated
+prefill/decode KV-cache transfer
+([NIXL](https://github.com/ai-dynamo/nixl)).
+
+## Available test cases
+
+| Test case | Orchestrator | Description |
+| --- | --- | --- |
+| [`dsv3-uccl-nixl`](./dsv3-uccl-nixl) | EKS / HyperPod EKS | DeepSeek-V3 disaggregated inference (1P+ND) on `p5en.48xlarge` with vLLM 0.21.0, UCCL-EP, and NIXL over EFA. |

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/.gitignore
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/.gitignore
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
 # Local env vars contain HF token and account ID — never commit them.
 setup/env_vars
 

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/.gitignore
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/.gitignore
@@ -1,0 +1,5 @@
+# Local env vars contain HF token and account ID — never commit them.
+setup/env_vars
+
+# Benchmark outputs.
+results/

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/Dockerfile
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT-0
 #
 # vLLM 0.21.0 + UCCL-EP + NIXL container image for DeepSeek-V3 disaggregated
 # inference on AWS EKS / SageMaker HyperPod EKS with EFA.
@@ -10,7 +10,7 @@
 #   - EFA installer 1.48.0
 #   - NCCL 2.30.4 (CUDA arches 8.0/8.6/8.9/9.0/10.0/10.3)
 #   - vLLM 0.21.0 from source
-#   - NIXL 1.0.1 (cu13 build)
+#   - NIXL 1.1.0 (CUDA-13 backend auto-selected via the meta wheel)
 #   - UCCL (commit 0dc87eb) + uccl.ep + deep_ep wrapper
 #   - Ray 2.55.1 for DP coordination
 #
@@ -25,7 +25,7 @@ ARG EFA_INSTALLER_VERSION=1.48.0
 ARG NCCL_VERSION=v2.30.4-1
 ARG NCCL_TESTS_VERSION=v2.18.3
 ARG VLLM_COMMIT=v0.21.0
-ARG NIXL_VERSION=v1.0.1
+ARG NIXL_VERSION=v1.1.0
 ARG UCCL_COMMIT=0dc87eb3b40c372a16b70ef320f37daaa5299ca7
 
 # --- system packages ---------------------------------------------------------
@@ -139,15 +139,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # --- Ray (DP coordinator) ----------------------------------------------------
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system "ray[default]>=2.43"
+    uv pip install --system "ray[default]==2.55.1"
 
-# --- NIXL (cu13) -------------------------------------------------------------
-# Install nixl-cu13 first, then nixl meta package, then force-reinstall
-# nixl-cu13 to keep cu13 ownership of nixl_ep namespace.
+# --- NIXL --------------------------------------------------------------------
+# v1.1.0 ships cu12 and cu13 backends inside the meta wheel and auto-selects
+# at runtime based on torch.version.cuda — single-line install. (v1.0.1 had
+# an unconditional cu12 dep that required a 3-step reinstall dance.)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system "nixl-cu13==$(echo ${NIXL_VERSION} | sed 's/^v//')" \
-    && uv pip install --system "nixl==$(echo ${NIXL_VERSION} | sed 's/^v//')" \
-    && uv pip install --system --reinstall --no-deps "nixl-cu13==$(echo ${NIXL_VERSION} | sed 's/^v//')"
+    uv pip install --system "nixl==$(echo ${NIXL_VERSION} | sed 's/^v//')"
 
 # --- UCCL-EP + deep_ep wrapper ----------------------------------------------
 RUN git clone https://github.com/uccl-project/uccl.git /opt/uccl \
@@ -166,13 +165,22 @@ ENV PER_EXPERT_BATCHING=1
 RUN TORCH_CUDA_ARCH_LIST="9.0a+PTX;10.0a+PTX;10.3a+PTX" python3 setup.py install
 
 WORKDIR /opt/uccl/ep/deep_ep_wrapper
-RUN pip install --no-deps .
+RUN pip install .
 
 # --- smoke tests -------------------------------------------------------------
 RUN echo "=== Smoke test: vLLM ===" \
     && python3 -c "import vllm; print(f'vLLM {vllm.__version__}')" \
     && echo "=== Smoke test: NIXL ===" \
     && python3 -c "import nixl; print('NIXL OK')" \
+    && echo "=== Smoke test: NIXL backend matches CUDA 13 ===" \
+    && python3 -c "import importlib.util, subprocess, os; \
+spec = importlib.util.find_spec('nixl_ep'); \
+assert spec, 'nixl_ep not found'; \
+so = next(p for p in os.listdir(os.path.dirname(spec.origin)) if p.endswith('.so')); \
+out = subprocess.check_output(['ldd', os.path.join(os.path.dirname(spec.origin), so)], text=True); \
+assert 'libcudart.so.13' in out, 'nixl_ep does not link cu13'; \
+assert 'libcudart.so.12' not in out, 'nixl_ep also links cu12'; \
+print(f'nixl_ep cu13 OK: {so}')" \
     && echo "=== Smoke test: uccl.ep ===" \
     && python3 -c "import torch; import uccl.ep; print('uccl.ep OK')" \
     && echo "=== Smoke test: deep_ep ===" \

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/Dockerfile
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/Dockerfile
@@ -1,0 +1,186 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# vLLM 0.21.0 + UCCL-EP + NIXL container image for DeepSeek-V3 disaggregated
+# inference on AWS EKS / SageMaker HyperPod EKS with EFA.
+#
+# Layered on top of an NCCL-tests style EFA base:
+#   - CUDA 13 devel
+#   - GDRCopy 2.5.2
+#   - EFA installer 1.48.0
+#   - NCCL 2.30.4 (CUDA arches 8.0/8.6/8.9/9.0/10.0/10.3)
+#   - vLLM 0.21.0 from source
+#   - NIXL 1.0.1 (cu13 build)
+#   - UCCL (commit 0dc87eb) + uccl.ep + deep_ep wrapper
+#   - Ray 2.55.1 for DP coordination
+#
+# Build:
+#   ./setup/build-push.sh
+#
+ARG CUDA_VERSION=13.0.3
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu24.04
+
+ARG GDRCOPY_VERSION=v2.5.2
+ARG EFA_INSTALLER_VERSION=1.48.0
+ARG NCCL_VERSION=v2.30.4-1
+ARG NCCL_TESTS_VERSION=v2.18.3
+ARG VLLM_COMMIT=v0.21.0
+ARG NIXL_VERSION=v1.0.1
+ARG UCCL_COMMIT=0dc87eb3b40c372a16b70ef320f37daaa5299ca7
+
+# --- system packages ---------------------------------------------------------
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get remove -y --allow-change-held-packages \
+    ibverbs-utils libibverbs-dev libibverbs1 libmlx5-1 libnccl2 libnccl-dev \
+    || true
+
+RUN rm -rf /opt/hpcx /usr/local/mpi \
+    && rm -f /etc/ld.so.conf.d/hpcx.conf \
+    && ldconfig
+
+ENV OPAL_PREFIX=
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
+    apt-utils autoconf automake build-essential check cmake curl debhelper \
+    devscripts git gcc gdb kmod libsubunit-dev libtool openssh-client \
+    openssh-server pkg-config vim python3-dev python3-pip python3-venv
+
+RUN apt-get purge -y cuda-compat-* || true
+
+RUN mkdir -p /var/run/sshd
+RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
+    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
+
+ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/amazon/ofi-nccl/lib:/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu:/usr/local/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/usr/bin:/usr/local/bin:$PATH
+
+RUN rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3/EXTERNALLY-MANAGED
+RUN pip3 install --break-system-packages awscli pynvml
+
+# --- GDRCopy -----------------------------------------------------------------
+RUN git clone -b ${GDRCOPY_VERSION} https://github.com/NVIDIA/gdrcopy.git /tmp/gdrcopy \
+    && cd /tmp/gdrcopy \
+    && make prefix=/opt/gdrcopy install
+
+ENV LD_LIBRARY_PATH=/opt/gdrcopy/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH=/opt/gdrcopy/lib:$LIBRARY_PATH
+ENV CPATH=/opt/gdrcopy/include:$CPATH
+ENV PATH=/opt/gdrcopy/bin:$PATH
+
+# --- EFA installer -----------------------------------------------------------
+RUN cd $HOME \
+    && curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
+    && tar -xf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
+    && cd aws-efa-installer \
+    && ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify --disable-ngc \
+    && rm -rf $HOME/aws-efa-installer
+
+RUN echo "Verifying AWS OFI NCCL plugin installation..." && \
+    (ls -la /opt/amazon/ofi-nccl/lib/libnccl-net*.so || \
+     ls -la /opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-ofi*.so)
+
+# --- NCCL --------------------------------------------------------------------
+RUN git clone -b ${NCCL_VERSION} https://github.com/NVIDIA/nccl.git /opt/nccl \
+    && cd /opt/nccl \
+    && make -j $(nproc) src.build CUDA_HOME=/usr/local/cuda \
+       NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_89,code=sm_89 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_103,code=sm_103"
+
+# --- NCCL tests (handy for fi_info / health checks) --------------------------
+RUN git clone -b ${NCCL_TESTS_VERSION} https://github.com/NVIDIA/nccl-tests.git /opt/nccl-tests \
+    && cd /opt/nccl-tests \
+    && make -j $(nproc) MPI=1 MPI_HOME=/opt/amazon/openmpi/ \
+       CUDA_HOME=/usr/local/cuda NCCL_HOME=/opt/nccl/build \
+       NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_89,code=sm_89 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_103,code=sm_103"
+
+RUN rm -rf /var/lib/apt/lists/*
+
+ENV OMPI_MCA_pml=^ucx \
+    OMPI_MCA_btl=tcp,self \
+    OMPI_MCA_btl_tcp_if_exclude=lo,docker0,veth_def_agent \
+    OPAL_PREFIX=/opt/amazon/openmpi \
+    NCCL_SOCKET_IFNAME=^docker,lo,veth \
+    PMIX_MCA_gds=hash \
+    LD_PRELOAD=/opt/nccl/build/lib/libnccl.so
+
+# --- Python tooling (uv) -----------------------------------------------------
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+ENV UV_HTTP_TIMEOUT=500
+ENV UV_LINK_MODE=copy
+
+RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ccache libibverbs-dev libnl-3-dev libnl-route-3-dev libnuma-dev ninja-build \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- vLLM from source --------------------------------------------------------
+ENV CUDA_HOME=/usr/local/cuda
+ENV MAX_JOBS=32
+ENV NVCC_THREADS=1
+ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0 10.0 10.3"
+ENV VLLM_TARGET_DEVICE=cuda
+
+WORKDIR /opt/vllm
+RUN git clone https://github.com/vllm-project/vllm.git . \
+    && git checkout ${VLLM_COMMIT}
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/root/.cache/ccache \
+    uv pip install --system --index-strategy unsafe-best-match \
+        -r requirements/build/cuda.txt \
+        --extra-index-url https://download.pytorch.org/whl/cu130 \
+    && uv pip install --system --index-strategy unsafe-best-match \
+        -r requirements/cuda.txt \
+        --extra-index-url https://download.pytorch.org/whl/cu130 \
+    && python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38 \
+    && uv pip install --system --index-strategy unsafe-best-match \
+        dist/*.whl \
+        --extra-index-url https://download.pytorch.org/whl/cu130
+
+# --- Ray (DP coordinator) ----------------------------------------------------
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system "ray[default]>=2.43"
+
+# --- NIXL (cu13) -------------------------------------------------------------
+# Install nixl-cu13 first, then nixl meta package, then force-reinstall
+# nixl-cu13 to keep cu13 ownership of nixl_ep namespace.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system "nixl-cu13==$(echo ${NIXL_VERSION} | sed 's/^v//')" \
+    && uv pip install --system "nixl==$(echo ${NIXL_VERSION} | sed 's/^v//')" \
+    && uv pip install --system --reinstall --no-deps "nixl-cu13==$(echo ${NIXL_VERSION} | sed 's/^v//')"
+
+# --- UCCL-EP + deep_ep wrapper ----------------------------------------------
+RUN git clone https://github.com/uccl-project/uccl.git /opt/uccl \
+    && cd /opt/uccl \
+    && git checkout ${UCCL_COMMIT} \
+    && git submodule update --init --recursive
+
+RUN uv pip install --system nanobind
+
+WORKDIR /opt/uccl
+RUN uv pip install --system .
+
+# UCCL-EP uses SM90+ features (TMA, mbarrier); avoid SM80 in this build.
+WORKDIR /opt/uccl/ep
+ENV PER_EXPERT_BATCHING=1
+RUN TORCH_CUDA_ARCH_LIST="9.0a+PTX;10.0a+PTX;10.3a+PTX" python3 setup.py install
+
+WORKDIR /opt/uccl/ep/deep_ep_wrapper
+RUN pip install --no-deps .
+
+# --- smoke tests -------------------------------------------------------------
+RUN echo "=== Smoke test: vLLM ===" \
+    && python3 -c "import vllm; print(f'vLLM {vllm.__version__}')" \
+    && echo "=== Smoke test: NIXL ===" \
+    && python3 -c "import nixl; print('NIXL OK')" \
+    && echo "=== Smoke test: uccl.ep ===" \
+    && python3 -c "import torch; import uccl.ep; print('uccl.ep OK')" \
+    && echo "=== Smoke test: deep_ep ===" \
+    && python3 -c "import torch; from deep_ep import Buffer, Config; print('deep_ep OK')" \
+    && echo "=== Smoke test: vLLM has_deep_ep ===" \
+    && python3 -c "from vllm.utils.import_utils import has_deep_ep; assert has_deep_ep(); print('vLLM has_deep_ep() = True')" \
+    && echo "=== Smoke test: Ray ===" \
+    && python3 -c "import ray; print(f'Ray {ray.__version__}')" \
+    && echo "=== All smoke tests passed ==="
+
+WORKDIR /workspace

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/README.md
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->
+
 # DeepSeek-V3 Disaggregated Inference with vLLM, UCCL-EP, and NIXL on EKS
 
 This sample shows how to serve **DeepSeek-V3-0324** (671B parameters, 256 experts,
@@ -11,13 +16,18 @@ top-8 routing, MLA) with disaggregated **prefill / decode** across multiple
   transfer between prefill and decode pods
 - A simple Python proxy (`toy_proxy_server.py` shipped in vLLM) for routing
 
-It is the deployable version of the experiment
-[`experiments/2026-05-06-dsv3-disagg-mtp`](https://github.com/awslabs/awsome-distributed-ai)
-that benchmarked configs from a single 8-GPU unified node up to a 6-node
+It benchmarks configs from a single 8-GPU unified node up to a 6-node
 1-prefill / 5-decode disaggregated topology, plus a UCCL-EP vs. AGRS
 (`allgather_reducescatter`) backend comparison.
 
-## What you can reproduce
+## Indicative results
+
+> **Caveat.** The numbers below come from single-seed runs at
+> `--num-prompts 50`. They are smoke-benchmark numbers, not statistically
+> tight measurements — re-run with the multi-seed loop in
+> [`recipe/benchmark.sh`](recipe/benchmark.sh) and compute confidence
+> intervals before quoting them anywhere downstream. Treat the rankings
+> below as directionally informative, not as research findings.
 
 | Config       | Nodes | GPUs | Burst RPS | Burst tok/s | P50 TPOT @1RPS | P50 TPOT @burst | tok/s/GPU |
 | ------------ | :---: | :--: | --------: | ----------: | -------------: | --------------: | --------: |
@@ -28,20 +38,20 @@ that benchmarked configs from a single 8-GPU unified node up to a 6-node
 | 1P+5D       |   6   |  48  |     17.16 |       4,392 |        17.81ms |         30.34ms |     91.51 |
 | 1P+3D AGRS  |   4   |  32  |     10.62 |       2,721 |        23.30ms |         48.20ms |     85.03 |
 
-(Workload: `--random-input-len 1024 --random-output-len 256 --num-prompts 50` via
-`vllm bench serve`.)
+Workload: `--random-input-len 1024 --random-output-len 256 --num-prompts 50`
+via `vllm bench serve`.
 
-Headline findings:
+Directional observations:
 
-1. **Disaggregation pays off mostly in latency, not throughput.** A single
-   unified node is the best `tok/s/GPU` config; disaggregation lowers burst
-   TPOT from 44ms → 30ms.
-2. **The optimal P:D ratio is 1:4.** Beyond that, the single prefill node is
-   the hard bottleneck.
-3. **UCCL-EP (`deepep_high_throughput` + `deepep_low_latency`) beats AGRS by
-   ~62%** on burst RPS and ~30% on TPOT for this MLA + 256-expert MoE model.
-
-See `conclusion.md` in the upstream experiment for the full analysis.
+1. **Disaggregation pays off mostly in latency, not throughput.** Unified
+   has the best `tok/s/GPU`; disaggregation lowers burst TPOT roughly
+   44ms → 30ms but only modestly increases peak RPS.
+2. **The 1P:4D ratio appears to be the knee** — beyond that, the single
+   prefill node looks like the bottleneck.
+3. **UCCL-EP (`deepep_high_throughput` + `deepep_low_latency`) outperforms
+   AGRS** for this MLA + 256-expert MoE model in our runs (≈30% TPOT
+   improvement is consistent with public UCCL-EP benchmarks; the burst-RPS
+   delta is from a single-seed run and warrants reproduction).
 
 ## Architecture
 
@@ -79,7 +89,9 @@ See `conclusion.md` in the upstream experiment for the full analysis.
 
 ### Cluster
 
-- Amazon EKS or SageMaker HyperPod EKS, version 1.28+
+- Amazon EKS or SageMaker HyperPod EKS, version **1.33+** (1.32 and below
+  are out of EKS standard support; 1.33 added native EFA traffic in the
+  default EKS security group)
 - 1–6 × `p5en.48xlarge` GPU nodes (8×H200 141GB, 16×EFA, ~30 TB NVMe)
 - NVIDIA device plugin and EFA device plugin installed
 - (Recommended) FSx for Lustre PVC for the model cache, or local NVMe under
@@ -89,13 +101,13 @@ See `conclusion.md` in the upstream experiment for the full analysis.
 
 | Component | Version |
 | --- | --- |
-| Kubernetes | 1.28+ (EKS / HyperPod EKS tested) |
-| kubectl | 1.28+ |
+| Kubernetes | 1.33+ (EKS / HyperPod EKS tested) |
+| kubectl | 1.33+ |
 | Docker / BuildKit | 24.0+ |
 | AWS CLI v2 | latest |
 | vLLM | 0.21.0 |
 | UCCL | commit `0dc87eb` |
-| NIXL | v1.0.1 |
+| NIXL | v1.1.0 |
 | PyTorch | 2.11.0 (cu130) |
 | Ray | 2.55.1 |
 | EFA installer | 1.48.0 |
@@ -111,23 +123,22 @@ See `conclusion.md` in the upstream experiment for the full analysis.
 ## Repository layout
 
 ```
-dsv3-disagg/
-├── Dockerfile                  # vLLM 0.21.0 + NIXL 1.0.1 + UCCL-EP, CUDA 13
+dsv3-uccl-nixl/
+├── Dockerfile                  # vLLM 0.21.0 + NIXL 1.1.0 + UCCL-EP, CUDA 13
 ├── README.md                   # this file
 ├── setup/
 │   ├── env_vars.example        # cluster + image + role config
 │   ├── build-push.sh           # docker build + ECR push
 │   └── install-prereqs.sh      # NVIDIA + EFA device plugins (optional)
 ├── manifests/
-│   ├── prefill.yaml            # 1× prefill pod (deepep_high_throughput)
-│   ├── decode.yaml             # 1× decode pod template (deepep_low_latency)
-│   ├── proxy.yaml              # router pod (toy_proxy_server.py)
-│   ├── unified.yaml            # 1-node baseline (no NIXL, deepep_low_latency)
-│   └── hf-token-secret.yaml    # HuggingFace token secret stub
+│   ├── prefill.yaml            # prefill Deployment (deepep_high_throughput)
+│   ├── decode.yaml             # decode Deployment template (deepep_low_latency)
+│   ├── proxy.yaml              # router Deployment (toy_proxy_server.py)
+│   └── unified.yaml            # 1-node baseline Deployment (no NIXL)
 └── recipe/
     ├── deploy.sh               # render + apply manifests for a chosen topology
-    ├── teardown.sh             # delete pods
-    └── benchmark.sh            # vllm bench serve rate sweep + warmup
+    ├── teardown.sh             # delete Deployments
+    └── benchmark.sh            # vllm bench serve rate sweep + warmup, multi-seed
 ```
 
 ## Quick start
@@ -137,7 +148,8 @@ dsv3-disagg/
 ```bash
 cd 3.test_cases/pytorch/vllm/dsv3-uccl-nixl
 cp setup/env_vars.example setup/env_vars
-$EDITOR setup/env_vars   # set ECR registry, HF_TOKEN, node hostnames, IPs
+$EDITOR setup/env_vars              # replace every REPLACE_ME placeholder
+grep REPLACE_ME setup/env_vars      # should print nothing when fully filled
 source setup/env_vars
 ```
 
@@ -154,7 +166,8 @@ The image bundles:
 
 - vLLM 0.21.0 (built from source for `sm_80 sm_86 sm_89 sm_90 sm_100 sm_103`)
 - UCCL-EP with the `deep_ep` drop-in wrapper (so vLLM auto-detects it)
-- NIXL 1.0.1 (`nixl-cu13`) with the `LIBFABRIC` backend
+- NIXL 1.1.0 (CUDA-13 backend auto-selected from the meta wheel) with the
+  `LIBFABRIC` backend
 - Ray 2.55.1 (DP coordinator)
 - EFA installer 1.48.0, NCCL 2.30.4, AWS OFI NCCL plugin
 - GDRCopy 2.5.2
@@ -221,14 +234,23 @@ curl -s "http://${PREFILL_IP}:8000/v1/completions" \
 ### 7. Benchmark
 
 `recipe/benchmark.sh` runs a warm-up then a rate sweep at 1, 4, 8, 16, and
-`inf` RPS using `vllm bench serve`:
+`inf` RPS using `vllm bench serve`, looping over three seeds (1234, 5678,
+9012) per rate so you can aggregate over multiple runs:
 
 ```bash
 ./recipe/benchmark.sh 1p4d
 ```
 
-Results land in `results/<topology>/openai-<rate>qps-*.json`. Key fields:
-`request_throughput`, `output_throughput`, `p50_tpot_ms`, `p50_ttft_ms`.
+Results land in `results/<topology>/seed-<seed>/openai-<rate>qps-*.json`.
+Key fields per JSON: `request_throughput`, `output_throughput`,
+`p50_tpot_ms`, `p50_ttft_ms`. Aggregate across the three seed dirs and
+report a confidence interval before quoting any number externally.
+
+Override the seeds, rates, or prompt count with environment variables:
+
+```bash
+SEEDS="1234" RATES="1 inf" NUM_PROMPTS=200 ./recipe/benchmark.sh 1p4d
+```
 
 ### 8. Tear down
 
@@ -276,10 +298,18 @@ For DeepSeek-V3 always use `deepep_high_throughput` on prefill and
                        "kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
 ```
 
-`kv_role: kv_both` lets vLLM act as either sender or receiver based on the
-incoming `do_remote_decode` / `do_remote_prefill` request flag — the proxy
-sets these. `LIBFABRIC` uses EFA via the libfabric provider; alternatives
-like `UCX` are not yet recommended on EFA without GPUDirect RDMA tuning.
+In vLLM 0.21.0, `kv_role` is a required-but-ignored placeholder for
+`NixlConnector` — the [vLLM NixlConnector docs](https://docs.vllm.ai/en/v0.21.0/features/nixl_connector_usage.html)
+state that "the actual prefiller/decoder roles are determined by the
+upper-level proxy. Therefore, `kv_role` in `--kv-transfer-config` is
+effectively a placeholder and does not affect NixlConnector's behavior."
+What actually drives prefill vs. decode behavior is the proxy injecting
+`do_remote_prefill` / `do_remote_decode` into per-request `kv_transfer_params`.
+The config validator just refuses to start without *some* `kv_role`; we set
+`kv_both` for that reason only.
+
+`LIBFABRIC` uses EFA via the libfabric provider; alternatives like `UCX`
+are not yet recommended on EFA without GPUDirect RDMA tuning.
 
 `VLLM_NIXL_SIDE_CHANNEL_PORT=5600` and `VLLM_NIXL_SIDE_CHANNEL_HOST=$MY_IP`
 expose the metadata exchange channel on the host network.
@@ -288,11 +318,16 @@ expose the metadata exchange channel on the host network.
 
 The proxy uses
 `/opt/vllm/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py`
-which ships with the vLLM source tree. It does simple round-robin over
-`--decoder-hosts` and routes the prefill phase to `--prefiller-hosts`.
+which ships in the vLLM source tree. The vLLM NixlConnector docs direct
+users to invoke it from that path, but it lives under `tests/` and is named
+`toy_*` — upstream is free to move or delete it on any release. The image
+pins `VLLM_COMMIT=v0.21.0`, so the path is stable for this sample, but
+verify it before bumping that ARG.
 
-For production traffic shaping you will want a smarter router — this proxy
-exists to demonstrate the wire protocol, not to be a load balancer.
+It does simple round-robin over `--decoder-hosts` and routes the prefill
+phase to `--prefiller-hosts`. For production traffic shaping you will want
+a smarter router — this proxy exists to demonstrate the wire protocol, not
+to be a load balancer.
 
 ### Storage
 
@@ -320,7 +355,7 @@ and set `HF_HOME` accordingly. Note: ~680 GB FP8 weights load in
 | `ACCOUNT` | `123456789012` | AWS account ID for ECR |
 | `REGISTRY` | `${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/` | ECR registry |
 | `IMAGE` | `vllm-uccl-ep` | ECR repo name |
-| `TAG` | `vllm0.21.0-uccl-0dc87eb` | image tag |
+| `TAG` | `vllm0.21.0-uccl-0dc87eb-cu13` | image tag |
 | `NAMESPACE` | `dsv3-disagg` | Kubernetes namespace |
 | `INSTANCE_TYPE` | `p5en.48xlarge` | node selector value |
 | `MODEL` | `deepseek-ai/DeepSeek-V3-0324` | HF model id |
@@ -379,23 +414,39 @@ kubectl logs <pod-name> -n "$NAMESPACE" --tail=80
 CUDA-graph capture can take 2–5 minutes after `/health` returns 200. Be
 patient on the first benchmark.
 
-## Cost estimate (us-west-2 on-demand, May 2026)
+## Cost
 
-| Config | Nodes | Cost / hr | Cost per 1h benchmark |
-| --- | --- | --- | --- |
-| 1N | 1 | $98.32 | $98.32 |
-| 1P+1D | 2 | $196.64 | $196.64 |
-| 1P+3D | 4 | $393.28 | $393.28 |
-| 1P+4D | 5 | $491.60 | $491.60 |
-| 1P+5D | 6 | $589.92 | $589.92 |
+GPU instance pricing changes too often (and varies by region, term, and
+Capacity Block) for a baked-in table to age well. Check the live source:
 
-A full sweep across all topologies (one rate-sweep each) takes 4–6 hours
-end to end including model download.
+- [On-Demand pricing](https://aws.amazon.com/ec2/pricing/on-demand/)
+- [Capacity Block pricing](https://aws.amazon.com/ec2/capacityblocks/pricing/)
+- Or query the AWS pricing API:
+  ```bash
+  aws pricing get-products --service-code AmazonEC2 \
+    --filters Type=TERM_MATCH,Field=instanceType,Value=p5en.48xlarge \
+              Type=TERM_MATCH,Field=location,Value="US West (Oregon)"
+  ```
+
+As a rough sense of scale: the largest topology in this sample uses 6
+nodes, and a full rate sweep across topologies takes 4–6 hours end to end
+(including the first-time ~680 GB model download).
+
+## License
+
+This sample is released under the [MIT-0 License](../../../../LICENSE), the
+same license as the rest of `awsome-distributed-ai`.
 
 ## References
 
+- vLLM NixlConnector usage:
+  https://docs.vllm.ai/en/v0.21.0/features/nixl_connector_usage.html
 - vLLM disaggregated serving:
   https://github.com/vllm-project/vllm/blob/main/docs/source/serving/disaggregated_serving.md
 - UCCL-EP: https://github.com/uccl-project/uccl
 - NIXL: https://github.com/ai-dynamo/nixl
+- NIXL libfabric (EFA) plugin:
+  https://github.com/ai-dynamo/nixl/blob/main/src/plugins/libfabric/README.md
 - DeepSeek-V3 paper: https://arxiv.org/abs/2412.19437
+- AWS EFA cheat sheet:
+  https://github.com/awslabs/awsome-distributed-ai/blob/main/architectures/efa-cheatsheet.md

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/README.md
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/README.md
@@ -1,0 +1,401 @@
+# DeepSeek-V3 Disaggregated Inference with vLLM, UCCL-EP, and NIXL on EKS
+
+This sample shows how to serve **DeepSeek-V3-0324** (671B parameters, 256 experts,
+top-8 routing, MLA) with disaggregated **prefill / decode** across multiple
+`p5en.48xlarge` (8×H200) nodes on Amazon EKS or SageMaker HyperPod EKS, using:
+
+- **vLLM 0.21.0** for OpenAI-compatible serving
+- **UCCL-EP** (`deepep_high_throughput`, `deepep_low_latency`) for MoE
+  expert-parallel all-to-all over EFA
+- **NIXL** (NVIDIA Inference Xfer Library) over `LIBFABRIC` for KV-cache
+  transfer between prefill and decode pods
+- A simple Python proxy (`toy_proxy_server.py` shipped in vLLM) for routing
+
+It is the deployable version of the experiment
+[`experiments/2026-05-06-dsv3-disagg-mtp`](https://github.com/awslabs/awsome-distributed-ai)
+that benchmarked configs from a single 8-GPU unified node up to a 6-node
+1-prefill / 5-decode disaggregated topology, plus a UCCL-EP vs. AGRS
+(`allgather_reducescatter`) backend comparison.
+
+## What you can reproduce
+
+| Config       | Nodes | GPUs | Burst RPS | Burst tok/s | P50 TPOT @1RPS | P50 TPOT @burst | tok/s/GPU |
+| ------------ | :---: | :--: | --------: | ----------: | -------------: | --------------: | --------: |
+| 1N unified   |   1   |   8  |     13.49 |       3,454 |        21.83ms |         44.00ms |    431.55 |
+| 1P+1D       |   2   |  16  |     15.94 |       4,082 |        20.93ms |         40.91ms |    255.10 |
+| 1P+3D       |   4   |  32  |     17.22 |       4,408 |        18.21ms |         33.76ms |    137.75 |
+| **1P+4D**   |   5   |  40  | **19.18** |   **4,910** |        17.81ms |         32.51ms |    122.75 |
+| 1P+5D       |   6   |  48  |     17.16 |       4,392 |        17.81ms |         30.34ms |     91.51 |
+| 1P+3D AGRS  |   4   |  32  |     10.62 |       2,721 |        23.30ms |         48.20ms |     85.03 |
+
+(Workload: `--random-input-len 1024 --random-output-len 256 --num-prompts 50` via
+`vllm bench serve`.)
+
+Headline findings:
+
+1. **Disaggregation pays off mostly in latency, not throughput.** A single
+   unified node is the best `tok/s/GPU` config; disaggregation lowers burst
+   TPOT from 44ms → 30ms.
+2. **The optimal P:D ratio is 1:4.** Beyond that, the single prefill node is
+   the hard bottleneck.
+3. **UCCL-EP (`deepep_high_throughput` + `deepep_low_latency`) beats AGRS by
+   ~62%** on burst RPS and ~30% on TPOT for this MLA + 256-expert MoE model.
+
+See `conclusion.md` in the upstream experiment for the full analysis.
+
+## Architecture
+
+```
+                     ┌──────────────────────┐
+                     │  Client / benchmark  │
+                     └──────────┬───────────┘
+                                │ HTTP (OpenAI API)
+                     ┌──────────▼───────────┐
+                     │  toy_proxy_server.py │   (Pod, hostNetwork)
+                     │  port 8000           │
+                     └────┬───────────┬─────┘
+                  /v1/* prefill  /v1/* decode
+                          │           │
+            ┌─────────────▼─┐       ┌─▼─────────────┐  ... ┌──────────────┐
+            │ Prefill Pod   │       │ Decode Pod 0  │       │ Decode Pod N │
+            │ TP=4, DP=2    │       │ TP=4, DP=2    │       │ TP=4, DP=2   │
+            │ EP=8          │       │ EP=8          │       │ EP=8         │
+            │ deepep_ht     │       │ deepep_ll     │       │ deepep_ll    │
+            │ port 8100     │       │ port 8200     │       │ port 8200    │
+            └──────┬────────┘       └──────┬────────┘       └──────┬───────┘
+                   │                       │                       │
+                   └─────── NIXL KV cache (LIBFABRIC over EFA) ────┘
+                            UCCL-EP all-to-all (EFA, intra-node NVLink)
+```
+
+- **Prefill** runs UCCL-EP `deepep_high_throughput` (high token/s under bursts)
+- **Decode** runs UCCL-EP `deepep_low_latency` (low TPOT, CUDA graphs)
+- **NIXL** transfers KV blocks from prefill → decode over EFA via
+  `LIBFABRIC` backend
+- All pods run with `hostNetwork: true` so EFA / NIXL / NCCL can use the
+  full 16-EFA, 3,200 Gbps fabric
+
+## Prerequisites
+
+### Cluster
+
+- Amazon EKS or SageMaker HyperPod EKS, version 1.28+
+- 1–6 × `p5en.48xlarge` GPU nodes (8×H200 141GB, 16×EFA, ~30 TB NVMe)
+- NVIDIA device plugin and EFA device plugin installed
+- (Recommended) FSx for Lustre PVC for the model cache, or local NVMe under
+  `/mnt/k8s-disks/0`
+
+### Software
+
+| Component | Version |
+| --- | --- |
+| Kubernetes | 1.28+ (EKS / HyperPod EKS tested) |
+| kubectl | 1.28+ |
+| Docker / BuildKit | 24.0+ |
+| AWS CLI v2 | latest |
+| vLLM | 0.21.0 |
+| UCCL | commit `0dc87eb` |
+| NIXL | v1.0.1 |
+| PyTorch | 2.11.0 (cu130) |
+| Ray | 2.55.1 |
+| EFA installer | 1.48.0 |
+| NCCL | v2.30.4-1 |
+
+### Accounts and tokens
+
+- Hugging Face token with access to `deepseek-ai/DeepSeek-V3-0324`
+- Container registry (e.g. ECR) writable from your build host
+- `kubectl` configured for your cluster
+- Around ~680 GB of fast storage for the FP8 weights cache
+
+## Repository layout
+
+```
+dsv3-disagg/
+├── Dockerfile                  # vLLM 0.21.0 + NIXL 1.0.1 + UCCL-EP, CUDA 13
+├── README.md                   # this file
+├── setup/
+│   ├── env_vars.example        # cluster + image + role config
+│   ├── build-push.sh           # docker build + ECR push
+│   └── install-prereqs.sh      # NVIDIA + EFA device plugins (optional)
+├── manifests/
+│   ├── prefill.yaml            # 1× prefill pod (deepep_high_throughput)
+│   ├── decode.yaml             # 1× decode pod template (deepep_low_latency)
+│   ├── proxy.yaml              # router pod (toy_proxy_server.py)
+│   ├── unified.yaml            # 1-node baseline (no NIXL, deepep_low_latency)
+│   └── hf-token-secret.yaml    # HuggingFace token secret stub
+└── recipe/
+    ├── deploy.sh               # render + apply manifests for a chosen topology
+    ├── teardown.sh             # delete pods
+    └── benchmark.sh            # vllm bench serve rate sweep + warmup
+```
+
+## Quick start
+
+### 1. Configure environment
+
+```bash
+cd 3.test_cases/pytorch/vllm/dsv3-uccl-nixl
+cp setup/env_vars.example setup/env_vars
+$EDITOR setup/env_vars   # set ECR registry, HF_TOKEN, node hostnames, IPs
+source setup/env_vars
+```
+
+> The `env_vars` file holds your HuggingFace token and AWS account ID.
+> It is gitignored — never commit it.
+
+### 2. Build and push the image
+
+```bash
+./setup/build-push.sh
+```
+
+The image bundles:
+
+- vLLM 0.21.0 (built from source for `sm_80 sm_86 sm_89 sm_90 sm_100 sm_103`)
+- UCCL-EP with the `deep_ep` drop-in wrapper (so vLLM auto-detects it)
+- NIXL 1.0.1 (`nixl-cu13`) with the `LIBFABRIC` backend
+- Ray 2.55.1 (DP coordinator)
+- EFA installer 1.48.0, NCCL 2.30.4, AWS OFI NCCL plugin
+- GDRCopy 2.5.2
+
+The build also runs smoke tests for `vllm`, `nixl`, `uccl.ep`, and `deep_ep`.
+
+Expected size: ~22 GB. Build time: ~45–60 minutes on a 32-core host with a GPU.
+
+### 3. Create namespace and HF secret
+
+```bash
+kubectl create namespace "$NAMESPACE"
+kubectl create secret generic hf-token \
+  --namespace "$NAMESPACE" \
+  --from-literal=HF_TOKEN="$HF_TOKEN"
+```
+
+### 4. Discover node IPs
+
+```bash
+kubectl get nodes -l node.kubernetes.io/instance-type="$INSTANCE_TYPE" \
+  -o custom-columns="NAME:.metadata.name,IP:.status.addresses[?(@.type=='InternalIP')].address" \
+  --no-headers
+```
+
+Set the `PREFILL_NODE`, `DECODE_NODE_*`, and matching `*_IP` variables in
+`setup/env_vars`, then re-`source` it.
+
+### 5. Deploy a topology
+
+`recipe/deploy.sh` accepts a topology name and renders manifests with the IPs
+from `env_vars`:
+
+```bash
+# 1-node unified baseline (no NIXL, deepep_low_latency only)
+./recipe/deploy.sh unified
+
+# 1 prefill + 1 decode (2 nodes)
+./recipe/deploy.sh 1p1d
+
+# 1 prefill + 3 decode (4 nodes)
+./recipe/deploy.sh 1p3d
+
+# 1 prefill + 4 decode (5 nodes — peak burst RPS)
+./recipe/deploy.sh 1p4d
+```
+
+Wait until the proxy logs `All instances ready!`. First deploy downloads
+~680 GB of weights — allow 30–60 minutes.
+
+### 6. Smoke test
+
+```bash
+curl -s "http://${PREFILL_IP}:8000/v1/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-ai/DeepSeek-V3-0324",
+    "prompt": "The capital of France is",
+    "max_tokens": 32,
+    "temperature": 0
+  }' | python3 -m json.tool | head
+```
+
+### 7. Benchmark
+
+`recipe/benchmark.sh` runs a warm-up then a rate sweep at 1, 4, 8, 16, and
+`inf` RPS using `vllm bench serve`:
+
+```bash
+./recipe/benchmark.sh 1p4d
+```
+
+Results land in `results/<topology>/openai-<rate>qps-*.json`. Key fields:
+`request_throughput`, `output_throughput`, `p50_tpot_ms`, `p50_ttft_ms`.
+
+### 8. Tear down
+
+```bash
+./recipe/teardown.sh
+```
+
+## Configuration knobs
+
+### Per-node parallelism (TP=4, DP=2, EP=8)
+
+This is the per-pod parallelism setting we measured to be optimal for
+DeepSeek-V3 on H200. It splits 8 GPUs into:
+
+- 2 data-parallel replicas (`--data-parallel-size 2`)
+- Each replica spans 4 GPUs with tensor parallelism (`--tensor-parallel-size 4`)
+- All 8 GPUs participate in expert-parallel all-to-all (`--enable-expert-parallel`,
+  EP=DP×TP=8)
+
+You should not need to tune this for `p5en.48xlarge`. For other hardware
+(H100 80GB, A100 80GB, B300) revisit `--gpu-memory-utilization`,
+`--num-gpu-blocks-override`, and `--max-model-len`.
+
+### All-to-all backend
+
+The `--all2all-backend` flag chooses how MoE token-routing all-to-all is
+implemented. For DeepSeek-V3 (MLA + 256 experts):
+
+| Backend | When to use | Effect |
+| --- | --- | --- |
+| `deepep_high_throughput` | **Prefill nodes only** | High token/s, no CUDA graphs |
+| `deepep_low_latency` | Decode and unified | Low TPOT, CUDA-graph captured |
+| `allgather_reducescatter` (AGRS) | GQA models or fallback | 60–90% slower on MLA |
+
+For DeepSeek-V3 always use `deepep_high_throughput` on prefill and
+`deepep_low_latency` on decode — that is the configuration baked into
+`manifests/prefill.yaml` and `manifests/decode.yaml`.
+
+### NIXL KV transfer
+
+```yaml
+--kv-transfer-config '{"kv_connector":"NixlConnector",
+                       "kv_role":"kv_both",
+                       "kv_load_failure_policy":"fail",
+                       "kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+```
+
+`kv_role: kv_both` lets vLLM act as either sender or receiver based on the
+incoming `do_remote_decode` / `do_remote_prefill` request flag — the proxy
+sets these. `LIBFABRIC` uses EFA via the libfabric provider; alternatives
+like `UCX` are not yet recommended on EFA without GPUDirect RDMA tuning.
+
+`VLLM_NIXL_SIDE_CHANNEL_PORT=5600` and `VLLM_NIXL_SIDE_CHANNEL_HOST=$MY_IP`
+expose the metadata exchange channel on the host network.
+
+### Proxy
+
+The proxy uses
+`/opt/vllm/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py`
+which ships with the vLLM source tree. It does simple round-robin over
+`--decoder-hosts` and routes the prefill phase to `--prefiller-hosts`.
+
+For production traffic shaping you will want a smarter router — this proxy
+exists to demonstrate the wire protocol, not to be a load balancer.
+
+### Storage
+
+By default the manifests mount `/mnt/k8s-disks/0` (instance NVMe on
+`p5en.48xlarge`) at `HF_HOME=/mnt/k8s-disks/0/local_scratch/hf_cache`. To
+use FSx for Lustre instead, replace the `local-storage` volume with a PVC:
+
+```yaml
+volumes:
+  - name: model-cache
+    persistentVolumeClaim:
+      claimName: fsx-claim
+```
+
+and set `HF_HOME` accordingly. Note: ~680 GB FP8 weights load in
+~5 minutes from local NVMe; FSx adds ~1–2 minutes on the first node.
+
+## Variables you must set
+
+`setup/env_vars` controls every replaceable value. Required keys:
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `AWS_REGION` | `us-west-2` | ECR + EC2 region |
+| `ACCOUNT` | `123456789012` | AWS account ID for ECR |
+| `REGISTRY` | `${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/` | ECR registry |
+| `IMAGE` | `vllm-uccl-ep` | ECR repo name |
+| `TAG` | `vllm0.21.0-uccl-0dc87eb` | image tag |
+| `NAMESPACE` | `dsv3-disagg` | Kubernetes namespace |
+| `INSTANCE_TYPE` | `p5en.48xlarge` | node selector value |
+| `MODEL` | `deepseek-ai/DeepSeek-V3-0324` | HF model id |
+| `HF_TOKEN` | `hf_…` | gated model access |
+| `PREFILL_NODE` | `ip-10-…compute.internal` | hostname for prefill pod |
+| `PREFILL_IP` | `10.…` | internal IP for proxy / NIXL |
+| `DECODE_NODE_0..N` | hostname strings | one per decode pod |
+| `DECODE_0_IP..N_IP` | IP strings | matching internal IPs |
+
+## Required smoke tests before benchmarking
+
+Inside any pod (`kubectl exec`):
+
+```bash
+python3 -c "import torch; print(torch.__version__, torch.cuda.device_count())"
+python3 -c "import vllm; print(vllm.__version__)"
+python3 -c "import uccl.ep"
+python3 -c "import nixl"
+nvidia-smi
+fi_info -p efa
+```
+
+If `fi_info -p efa` returns no providers, `hostNetwork: true`, the EFA
+device plugin, or the `vpc.amazonaws.com/efa: 16` resource limit are
+misconfigured — fix that before benchmarking, otherwise NCCL silently
+falls back to TCP and you get 28× slower throughput.
+
+## Troubleshooting
+
+### `NCCL timeout` during model load
+
+Make sure `hostNetwork: true` is set on every pod and that
+`NCCL_TIMEOUT=7200000` and `TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=7200` are
+exported (they are in the manifest). 680 GB takes a while to shard across
+DP replicas the first time.
+
+### `uccl_ep.cc:258 'out of memory'`
+
+NVSHMEM symmetric buffer pre-allocation exceeded GPU memory. Lower
+`--gpu-memory-utilization` from 0.80 to 0.78, or switch the backend to
+`allgather_reducescatter` (slower but no symmetric heap).
+
+### `NIXL: Failed to connect to peer`
+
+- Verify `VLLM_NIXL_SIDE_CHANNEL_HOST` matches the pod's primary IP
+- Verify the port `5600` is not bound on the host already
+- Confirm `hostNetwork: true`
+
+### Proxy stuck on "still waiting for …"
+
+```bash
+kubectl get pods -n "$NAMESPACE" -o wide
+kubectl logs <pod-name> -n "$NAMESPACE" --tail=80
+```
+
+CUDA-graph capture can take 2–5 minutes after `/health` returns 200. Be
+patient on the first benchmark.
+
+## Cost estimate (us-west-2 on-demand, May 2026)
+
+| Config | Nodes | Cost / hr | Cost per 1h benchmark |
+| --- | --- | --- | --- |
+| 1N | 1 | $98.32 | $98.32 |
+| 1P+1D | 2 | $196.64 | $196.64 |
+| 1P+3D | 4 | $393.28 | $393.28 |
+| 1P+4D | 5 | $491.60 | $491.60 |
+| 1P+5D | 6 | $589.92 | $589.92 |
+
+A full sweep across all topologies (one rate-sweep each) takes 4–6 hours
+end to end including model download.
+
+## References
+
+- vLLM disaggregated serving:
+  https://github.com/vllm-project/vllm/blob/main/docs/source/serving/disaggregated_serving.md
+- UCCL-EP: https://github.com/uccl-project/uccl
+- NIXL: https://github.com/ai-dynamo/nixl
+- DeepSeek-V3 paper: https://arxiv.org/abs/2412.19437

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/decode.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/decode.yaml
@@ -1,157 +1,196 @@
-# Decode pod template for DeepSeek-V3 disaggregated inference.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 #
-# Per-node parallelism:
+# Decode Deployment template for DeepSeek-V3 disaggregated inference.
+#
+# Per-pod parallelism:
 #   - tensor-parallel-size 4 + data-parallel-size 2 → 8 GPUs per pod
 #   - expert-parallel: enabled, EP=8 (TP×DP)
 #   - all2all-backend: deepep_low_latency (CUDA-graph captured for low TPOT)
 #
-# This template is rendered once per decode pod by recipe/deploy.sh, using
-# DECODE_INDEX to pick the matching ${DECODE_NODE_<i>} from env_vars.
+# Rendered once per decode pod by recipe/deploy.sh, using DECODE_INDEX to
+# pick the matching ${DECODE_NODE_<i>} from env_vars.
 #
 # Apply with (typically via recipe/deploy.sh):
 #   DECODE_INDEX=0 DECODE_NODE=$DECODE_NODE_0 envsubst < manifests/decode.yaml | kubectl apply -f -
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: dsv3-decode-${DECODE_INDEX}
   namespace: ${NAMESPACE}
   labels:
     app: dsv3-disagg
     role: decode
+    instance: dsv3-decode-${DECODE_INDEX}
 spec:
-  restartPolicy: Never
-  hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
-  enableServiceLinks: false
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node.kubernetes.io/instance-type
-                operator: In
-                values:
-                  - ${INSTANCE_TYPE}
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                  - ${DECODE_NODE}
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchLabels:
-              app: dsv3-disagg
-          topologyKey: kubernetes.io/hostname
-  tolerations:
-    - key: nvidia.com/gpu
-      operator: Exists
-      effect: NoSchedule
-    - key: vpc.amazonaws.com/efa
-      operator: Exists
-      effect: NoSchedule
-    - key: sagemaker.amazonaws.com/node-health-status
-      operator: Exists
-      effect: NoSchedule
-  volumes:
-    - name: dshm
-      emptyDir:
-        medium: Memory
-        sizeLimit: 120Gi
-    - name: model-cache
-      hostPath:
-        path: /mnt/k8s-disks/0
-        type: DirectoryOrCreate
-  containers:
-    - name: vllm
-      image: ${REGISTRY}${IMAGE}:${TAG}
-      securityContext:
-        privileged: true
-      env:
-        - name: VLLM_ENGINE_READY_TIMEOUT_S
-          value: "14400"
-        - name: HF_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: hf-token
-              key: HF_TOKEN
-              optional: true
-        - name: HF_HOME
-          value: /mnt/k8s-disks/0/local_scratch/hf_cache
-        - name: VLLM_LOGGING_LEVEL
-          value: INFO
-        - name: VLLM_WORKER_MULTIPROC_METHOD
-          value: spawn
-        - name: VLLM_USE_DEEP_GEMM
-          value: "1"
-        - name: PYTHONUNBUFFERED
-          value: "1"
-        - name: NCCL_TIMEOUT
-          value: "7200000"
-        - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
-          value: "7200"
-        - name: FI_PROVIDER
-          value: "efa"
-        - name: FI_EFA_USE_DEVICE_RDMA
-          value: "1"
-        - name: FI_EFA_FORK_SAFE
-          value: "1"
-        - name: UCCL_SOCKET_IFNAME
-          value: "^lo,docker0,veth_def_agent"
-        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
-          value: "5600"
-        - name: NCCL_DEBUG
-          value: "WARN"
-      resources:
-        requests:
-          cpu: "64"
-          memory: "400Gi"
-          nvidia.com/gpu: "8"
-          vpc.amazonaws.com/efa: "16"
-        limits:
-          cpu: "192"
-          memory: "1000Gi"
-          nvidia.com/gpu: "8"
-          vpc.amazonaws.com/efa: "16"
-      volumeMounts:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dsv3-disagg
+      role: decode
+      instance: dsv3-decode-${DECODE_INDEX}
+  template:
+    metadata:
+      labels:
+        app: dsv3-disagg
+        role: decode
+        instance: dsv3-decode-${DECODE_INDEX}
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 120
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - ${INSTANCE_TYPE}
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - ${DECODE_NODE}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: dsv3-disagg
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: vpc.amazonaws.com/efa
+          operator: Exists
+          effect: NoSchedule
+        - key: sagemaker.amazonaws.com/node-health-status
+          operator: Equal
+          value: Schedulable
+          effect: NoSchedule
+      volumes:
         - name: dshm
-          mountPath: /dev/shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 120Gi
         - name: model-cache
-          mountPath: /mnt/k8s-disks/0
-      command:
-        - bash
-        - -c
-        - |
-          set -euo pipefail
+          hostPath:
+            path: /mnt/k8s-disks/0
+            type: DirectoryOrCreate
+      containers:
+        - name: vllm
+          image: ${REGISTRY}${IMAGE}:${TAG}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "14400"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: HF_TOKEN
+                  optional: true
+            - name: HF_HOME
+              value: /mnt/k8s-disks/0/local_scratch/hf_cache
+            - name: VLLM_LOGGING_LEVEL
+              value: INFO
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: spawn
+            - name: VLLM_USE_DEEP_GEMM
+              value: "1"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: NCCL_TIMEOUT
+              value: "7200000"
+            - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
+              value: "7200"
+            - name: FI_PROVIDER
+              value: "efa"
+            - name: FI_EFA_USE_DEVICE_RDMA
+              value: "1"
+            - name: FI_EFA_FORK_SAFE
+              value: "1"
+            - name: UCCL_SOCKET_IFNAME
+              value: "^lo,docker0,veth_def_agent"
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: NCCL_DEBUG
+              value: "WARN"
+          resources:
+            requests:
+              cpu: "64"
+              memory: "400Gi"
+              nvidia.com/gpu: "8"
+              vpc.amazonaws.com/efa: "16"
+            limits:
+              cpu: "192"
+              memory: "1000Gi"
+              nvidia.com/gpu: "8"
+              vpc.amazonaws.com/efa: "16"
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: model-cache
+              mountPath: /mnt/k8s-disks/0
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8200
+            initialDelaySeconds: 1800
+            periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8200
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
 
-          echo "=== DSv3 DECODE ${DECODE_INDEX} (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${DECODE_BACKEND}, NixlConnector) ==="
-          MY_IP=$(hostname -I | awk '{print $1}')
-          echo "MY_IP: $MY_IP"
+              echo "=== DSv3 DECODE ${DECODE_INDEX} (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${DECODE_BACKEND}, NixlConnector) ==="
+              MY_IP=$(hostname -I | awk '{print $1}')
+              echo "MY_IP: $MY_IP"
 
-          IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
-          export GLOO_SOCKET_IFNAME=$IFACE
-          export NCCL_SOCKET_IFNAME=$IFACE
-          export VLLM_NIXL_SIDE_CHANNEL_HOST=$MY_IP
+              IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
+              # GLOO is fine with a positive interface (control-plane only).
+              # NCCL keeps the Dockerfile's exclusion pattern — a positive
+              # selection here would hide EFA and force TCP fallback
+              # (~28× slower).
+              export GLOO_SOCKET_IFNAME=$IFACE
+              export NCCL_SOCKET_IFNAME=^lo,docker,veth
+              export VLLM_NIXL_SIDE_CHANNEL_HOST=$MY_IP
 
-          echo "=== EFA devices ==="
-          ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
-          nvidia-smi -L
+              echo "=== EFA devices ==="
+              ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
+              nvidia-smi -L
 
-          mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
+              mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
 
-          exec vllm serve "${MODEL}" \
-            --trust-remote-code \
-            --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
-            --data-parallel-size ${DATA_PARALLEL_SIZE} \
-            --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
-            --data-parallel-address "$MY_IP" \
-            --data-parallel-rpc-port 13391 \
-            --api-server-count 2 \
-            --enable-expert-parallel \
-            --all2all-backend ${DECODE_BACKEND} \
-            --enable-chunked-prefill \
-            --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
-            --max-model-len ${MAX_MODEL_LEN} \
-            --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
-            --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' \
-            --host 0.0.0.0 \
-            --port 8200
+              exec vllm serve "${MODEL}" \
+                --trust-remote-code \
+                --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
+                --data-parallel-size ${DATA_PARALLEL_SIZE} \
+                --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
+                --data-parallel-address "$MY_IP" \
+                --data-parallel-rpc-port 13391 \
+                --api-server-count 2 \
+                --enable-expert-parallel \
+                --all2all-backend ${DECODE_BACKEND} \
+                --enable-chunked-prefill \
+                --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+                --max-model-len ${MAX_MODEL_LEN} \
+                --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' \
+                --host 0.0.0.0 \
+                --port 8200

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/decode.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/decode.yaml
@@ -1,0 +1,157 @@
+# Decode pod template for DeepSeek-V3 disaggregated inference.
+#
+# Per-node parallelism:
+#   - tensor-parallel-size 4 + data-parallel-size 2 → 8 GPUs per pod
+#   - expert-parallel: enabled, EP=8 (TP×DP)
+#   - all2all-backend: deepep_low_latency (CUDA-graph captured for low TPOT)
+#
+# This template is rendered once per decode pod by recipe/deploy.sh, using
+# DECODE_INDEX to pick the matching ${DECODE_NODE_<i>} from env_vars.
+#
+# Apply with (typically via recipe/deploy.sh):
+#   DECODE_INDEX=0 DECODE_NODE=$DECODE_NODE_0 envsubst < manifests/decode.yaml | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dsv3-decode-${DECODE_INDEX}
+  namespace: ${NAMESPACE}
+  labels:
+    app: dsv3-disagg
+    role: decode
+spec:
+  restartPolicy: Never
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  enableServiceLinks: false
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                  - ${INSTANCE_TYPE}
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                  - ${DECODE_NODE}
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: dsv3-disagg
+          topologyKey: kubernetes.io/hostname
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: vpc.amazonaws.com/efa
+      operator: Exists
+      effect: NoSchedule
+    - key: sagemaker.amazonaws.com/node-health-status
+      operator: Exists
+      effect: NoSchedule
+  volumes:
+    - name: dshm
+      emptyDir:
+        medium: Memory
+        sizeLimit: 120Gi
+    - name: model-cache
+      hostPath:
+        path: /mnt/k8s-disks/0
+        type: DirectoryOrCreate
+  containers:
+    - name: vllm
+      image: ${REGISTRY}${IMAGE}:${TAG}
+      securityContext:
+        privileged: true
+      env:
+        - name: VLLM_ENGINE_READY_TIMEOUT_S
+          value: "14400"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token
+              key: HF_TOKEN
+              optional: true
+        - name: HF_HOME
+          value: /mnt/k8s-disks/0/local_scratch/hf_cache
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: VLLM_WORKER_MULTIPROC_METHOD
+          value: spawn
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_TIMEOUT
+          value: "7200000"
+        - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
+          value: "7200"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: FI_EFA_USE_DEVICE_RDMA
+          value: "1"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: UCCL_SOCKET_IFNAME
+          value: "^lo,docker0,veth_def_agent"
+        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+          value: "5600"
+        - name: NCCL_DEBUG
+          value: "WARN"
+      resources:
+        requests:
+          cpu: "64"
+          memory: "400Gi"
+          nvidia.com/gpu: "8"
+          vpc.amazonaws.com/efa: "16"
+        limits:
+          cpu: "192"
+          memory: "1000Gi"
+          nvidia.com/gpu: "8"
+          vpc.amazonaws.com/efa: "16"
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: model-cache
+          mountPath: /mnt/k8s-disks/0
+      command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+
+          echo "=== DSv3 DECODE ${DECODE_INDEX} (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${DECODE_BACKEND}, NixlConnector) ==="
+          MY_IP=$(hostname -I | awk '{print $1}')
+          echo "MY_IP: $MY_IP"
+
+          IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
+          export GLOO_SOCKET_IFNAME=$IFACE
+          export NCCL_SOCKET_IFNAME=$IFACE
+          export VLLM_NIXL_SIDE_CHANNEL_HOST=$MY_IP
+
+          echo "=== EFA devices ==="
+          ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
+          nvidia-smi -L
+
+          mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
+
+          exec vllm serve "${MODEL}" \
+            --trust-remote-code \
+            --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
+            --data-parallel-size ${DATA_PARALLEL_SIZE} \
+            --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
+            --data-parallel-address "$MY_IP" \
+            --data-parallel-rpc-port 13391 \
+            --api-server-count 2 \
+            --enable-expert-parallel \
+            --all2all-backend ${DECODE_BACKEND} \
+            --enable-chunked-prefill \
+            --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+            --max-model-len ${MAX_MODEL_LEN} \
+            --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
+            --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' \
+            --host 0.0.0.0 \
+            --port 8200

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/hf-token-secret.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/hf-token-secret.yaml
@@ -1,9 +1,0 @@
-# Apply with: envsubst < manifests/hf-token-secret.yaml | kubectl apply -f -
-apiVersion: v1
-kind: Secret
-metadata:
-  name: hf-token
-  namespace: ${NAMESPACE}
-type: Opaque
-stringData:
-  HF_TOKEN: "${HF_TOKEN}"

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/hf-token-secret.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/hf-token-secret.yaml
@@ -1,0 +1,9 @@
+# Apply with: envsubst < manifests/hf-token-secret.yaml | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-token
+  namespace: ${NAMESPACE}
+type: Opaque
+stringData:
+  HF_TOKEN: "${HF_TOKEN}"

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/prefill.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/prefill.yaml
@@ -1,6 +1,9 @@
-# Prefill pod for DeepSeek-V3 disaggregated inference.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 #
-# Per-node parallelism:
+# Prefill Deployment for DeepSeek-V3 disaggregated inference.
+#
+# Per-pod parallelism:
 #   - tensor-parallel-size 4 + data-parallel-size 2 → 8 GPUs per pod
 #   - expert-parallel: enabled, EP=8 (TP×DP)
 #   - all2all-backend: deepep_high_throughput (best for MoE under prefill bursts)
@@ -9,8 +12,8 @@
 #   - NixlConnector + LIBFABRIC backend, side-channel on port 5600 (host network)
 #
 # Apply with: envsubst < manifests/prefill.yaml | kubectl apply -f -
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: dsv3-prefill-0
   namespace: ${NAMESPACE}
@@ -18,139 +21,178 @@ metadata:
     app: dsv3-disagg
     role: prefill
 spec:
-  restartPolicy: Never
-  hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
-  enableServiceLinks: false
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node.kubernetes.io/instance-type
-                operator: In
-                values:
-                  - ${INSTANCE_TYPE}
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                  - ${PREFILL_NODE}
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchLabels:
-              app: dsv3-disagg
-          topologyKey: kubernetes.io/hostname
-  tolerations:
-    - key: nvidia.com/gpu
-      operator: Exists
-      effect: NoSchedule
-    - key: vpc.amazonaws.com/efa
-      operator: Exists
-      effect: NoSchedule
-    - key: sagemaker.amazonaws.com/node-health-status
-      operator: Exists
-      effect: NoSchedule
-  volumes:
-    - name: dshm
-      emptyDir:
-        medium: Memory
-        sizeLimit: 120Gi
-    - name: model-cache
-      hostPath:
-        path: /mnt/k8s-disks/0
-        type: DirectoryOrCreate
-  containers:
-    - name: vllm
-      image: ${REGISTRY}${IMAGE}:${TAG}
-      securityContext:
-        privileged: true
-      env:
-        - name: VLLM_ENGINE_READY_TIMEOUT_S
-          value: "14400"
-        - name: HF_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: hf-token
-              key: HF_TOKEN
-              optional: true
-        - name: HF_HOME
-          value: /mnt/k8s-disks/0/local_scratch/hf_cache
-        - name: VLLM_LOGGING_LEVEL
-          value: INFO
-        - name: VLLM_WORKER_MULTIPROC_METHOD
-          value: spawn
-        - name: VLLM_USE_DEEP_GEMM
-          value: "1"
-        - name: PYTHONUNBUFFERED
-          value: "1"
-        - name: NCCL_TIMEOUT
-          value: "7200000"
-        - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
-          value: "7200"
-        - name: FI_PROVIDER
-          value: "efa"
-        - name: FI_EFA_USE_DEVICE_RDMA
-          value: "1"
-        - name: FI_EFA_FORK_SAFE
-          value: "1"
-        - name: UCCL_SOCKET_IFNAME
-          value: "^lo,docker0,veth_def_agent"
-        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
-          value: "5600"
-        - name: NCCL_DEBUG
-          value: "WARN"
-      resources:
-        requests:
-          cpu: "64"
-          memory: "400Gi"
-          nvidia.com/gpu: "8"
-          vpc.amazonaws.com/efa: "16"
-        limits:
-          cpu: "192"
-          memory: "1000Gi"
-          nvidia.com/gpu: "8"
-          vpc.amazonaws.com/efa: "16"
-      volumeMounts:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dsv3-disagg
+      role: prefill
+      instance: dsv3-prefill-0
+  template:
+    metadata:
+      labels:
+        app: dsv3-disagg
+        role: prefill
+        instance: dsv3-prefill-0
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 120
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - ${INSTANCE_TYPE}
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - ${PREFILL_NODE}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: dsv3-disagg
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: vpc.amazonaws.com/efa
+          operator: Exists
+          effect: NoSchedule
+        - key: sagemaker.amazonaws.com/node-health-status
+          operator: Equal
+          value: Schedulable
+          effect: NoSchedule
+      volumes:
         - name: dshm
-          mountPath: /dev/shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 120Gi
         - name: model-cache
-          mountPath: /mnt/k8s-disks/0
-      command:
-        - bash
-        - -c
-        - |
-          set -euo pipefail
+          hostPath:
+            path: /mnt/k8s-disks/0
+            type: DirectoryOrCreate
+      containers:
+        - name: vllm
+          image: ${REGISTRY}${IMAGE}:${TAG}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "14400"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: HF_TOKEN
+                  optional: true
+            - name: HF_HOME
+              value: /mnt/k8s-disks/0/local_scratch/hf_cache
+            - name: VLLM_LOGGING_LEVEL
+              value: INFO
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: spawn
+            - name: VLLM_USE_DEEP_GEMM
+              value: "1"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: NCCL_TIMEOUT
+              value: "7200000"
+            - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
+              value: "7200"
+            - name: FI_PROVIDER
+              value: "efa"
+            - name: FI_EFA_USE_DEVICE_RDMA
+              value: "1"
+            - name: FI_EFA_FORK_SAFE
+              value: "1"
+            - name: UCCL_SOCKET_IFNAME
+              value: "^lo,docker0,veth_def_agent"
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: NCCL_DEBUG
+              value: "WARN"
+          resources:
+            requests:
+              cpu: "64"
+              memory: "400Gi"
+              nvidia.com/gpu: "8"
+              vpc.amazonaws.com/efa: "16"
+            limits:
+              cpu: "192"
+              memory: "1000Gi"
+              nvidia.com/gpu: "8"
+              vpc.amazonaws.com/efa: "16"
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: model-cache
+              mountPath: /mnt/k8s-disks/0
+          # /health responds 200 once the API server thread is up — but the
+          # generator can still be deadlocked on a stuck NCCL or CUDA-graph
+          # capture. Probe with a 30-min initial delay (cold start: model
+          # download + CUDA graphs) and 5 strikes before restart.
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8100
+            initialDelaySeconds: 1800
+            periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8100
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
 
-          echo "=== DSv3 PREFILL (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${PREFILL_BACKEND}, NixlConnector) ==="
-          MY_IP=$(hostname -I | awk '{print $1}')
-          echo "MY_IP: $MY_IP"
+              echo "=== DSv3 PREFILL (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${PREFILL_BACKEND}, NixlConnector) ==="
+              MY_IP=$(hostname -I | awk '{print $1}')
+              echo "MY_IP: $MY_IP"
 
-          IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
-          export GLOO_SOCKET_IFNAME=$IFACE
-          export NCCL_SOCKET_IFNAME=$IFACE
-          export VLLM_NIXL_SIDE_CHANNEL_HOST=$MY_IP
+              IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
+              # GLOO is fine with a positive interface (control-plane only).
+              # NCCL must keep the exclusion pattern from the Dockerfile —
+              # a positive selection here would hide EFA and force TCP
+              # fallback (~28× slower).
+              export GLOO_SOCKET_IFNAME=$IFACE
+              export NCCL_SOCKET_IFNAME=^lo,docker,veth
+              export VLLM_NIXL_SIDE_CHANNEL_HOST=$MY_IP
 
-          echo "=== EFA devices ==="
-          ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
-          nvidia-smi -L
+              echo "=== EFA devices ==="
+              ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
+              nvidia-smi -L
 
-          mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
+              mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
 
-          exec vllm serve "${MODEL}" \
-            --trust-remote-code \
-            --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
-            --data-parallel-size ${DATA_PARALLEL_SIZE} \
-            --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
-            --data-parallel-address "$MY_IP" \
-            --data-parallel-rpc-port 13390 \
-            --api-server-count 2 \
-            --enable-expert-parallel \
-            --all2all-backend ${PREFILL_BACKEND} \
-            --enable-chunked-prefill \
-            --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
-            --max-model-len ${MAX_MODEL_LEN} \
-            --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
-            --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' \
-            --host 0.0.0.0 \
-            --port 8100
+              exec vllm serve "${MODEL}" \
+                --trust-remote-code \
+                --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
+                --data-parallel-size ${DATA_PARALLEL_SIZE} \
+                --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
+                --data-parallel-address "$MY_IP" \
+                --data-parallel-rpc-port 13390 \
+                --api-server-count 2 \
+                --enable-expert-parallel \
+                --all2all-backend ${PREFILL_BACKEND} \
+                --enable-chunked-prefill \
+                --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+                --max-model-len ${MAX_MODEL_LEN} \
+                --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' \
+                --host 0.0.0.0 \
+                --port 8100

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/prefill.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/prefill.yaml
@@ -1,0 +1,156 @@
+# Prefill pod for DeepSeek-V3 disaggregated inference.
+#
+# Per-node parallelism:
+#   - tensor-parallel-size 4 + data-parallel-size 2 → 8 GPUs per pod
+#   - expert-parallel: enabled, EP=8 (TP×DP)
+#   - all2all-backend: deepep_high_throughput (best for MoE under prefill bursts)
+#
+# KV transfer:
+#   - NixlConnector + LIBFABRIC backend, side-channel on port 5600 (host network)
+#
+# Apply with: envsubst < manifests/prefill.yaml | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dsv3-prefill-0
+  namespace: ${NAMESPACE}
+  labels:
+    app: dsv3-disagg
+    role: prefill
+spec:
+  restartPolicy: Never
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  enableServiceLinks: false
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                  - ${INSTANCE_TYPE}
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                  - ${PREFILL_NODE}
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: dsv3-disagg
+          topologyKey: kubernetes.io/hostname
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: vpc.amazonaws.com/efa
+      operator: Exists
+      effect: NoSchedule
+    - key: sagemaker.amazonaws.com/node-health-status
+      operator: Exists
+      effect: NoSchedule
+  volumes:
+    - name: dshm
+      emptyDir:
+        medium: Memory
+        sizeLimit: 120Gi
+    - name: model-cache
+      hostPath:
+        path: /mnt/k8s-disks/0
+        type: DirectoryOrCreate
+  containers:
+    - name: vllm
+      image: ${REGISTRY}${IMAGE}:${TAG}
+      securityContext:
+        privileged: true
+      env:
+        - name: VLLM_ENGINE_READY_TIMEOUT_S
+          value: "14400"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token
+              key: HF_TOKEN
+              optional: true
+        - name: HF_HOME
+          value: /mnt/k8s-disks/0/local_scratch/hf_cache
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: VLLM_WORKER_MULTIPROC_METHOD
+          value: spawn
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_TIMEOUT
+          value: "7200000"
+        - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
+          value: "7200"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: FI_EFA_USE_DEVICE_RDMA
+          value: "1"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: UCCL_SOCKET_IFNAME
+          value: "^lo,docker0,veth_def_agent"
+        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+          value: "5600"
+        - name: NCCL_DEBUG
+          value: "WARN"
+      resources:
+        requests:
+          cpu: "64"
+          memory: "400Gi"
+          nvidia.com/gpu: "8"
+          vpc.amazonaws.com/efa: "16"
+        limits:
+          cpu: "192"
+          memory: "1000Gi"
+          nvidia.com/gpu: "8"
+          vpc.amazonaws.com/efa: "16"
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: model-cache
+          mountPath: /mnt/k8s-disks/0
+      command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+
+          echo "=== DSv3 PREFILL (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${PREFILL_BACKEND}, NixlConnector) ==="
+          MY_IP=$(hostname -I | awk '{print $1}')
+          echo "MY_IP: $MY_IP"
+
+          IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
+          export GLOO_SOCKET_IFNAME=$IFACE
+          export NCCL_SOCKET_IFNAME=$IFACE
+          export VLLM_NIXL_SIDE_CHANNEL_HOST=$MY_IP
+
+          echo "=== EFA devices ==="
+          ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
+          nvidia-smi -L
+
+          mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
+
+          exec vllm serve "${MODEL}" \
+            --trust-remote-code \
+            --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
+            --data-parallel-size ${DATA_PARALLEL_SIZE} \
+            --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
+            --data-parallel-address "$MY_IP" \
+            --data-parallel-rpc-port 13390 \
+            --api-server-count 2 \
+            --enable-expert-parallel \
+            --all2all-backend ${PREFILL_BACKEND} \
+            --enable-chunked-prefill \
+            --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+            --max-model-len ${MAX_MODEL_LEN} \
+            --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
+            --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' \
+            --host 0.0.0.0 \
+            --port 8100

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/proxy.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/proxy.yaml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
 # NIXL routing proxy for DeepSeek-V3 disaggregated inference.
 #
 # Routes /v1/* requests:
@@ -7,10 +10,15 @@
 # DECODER_HOSTS / DECODER_PORTS are space-separated lists rendered by
 # recipe/deploy.sh based on the chosen topology.
 #
+# IMPORTANT: this uses /opt/vllm/tests/v1/.../toy_proxy_server.py — the
+# only proxy v0.21.0 ships. It lives under tests/, so a ${VLLM_COMMIT}
+# bump can break the path. The image pins VLLM_COMMIT=v0.21.0; verify
+# the path before bumping that ARG.
+#
 # Apply with (typically via recipe/deploy.sh):
 #   envsubst < manifests/proxy.yaml | kubectl apply -f -
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: dsv3-proxy
   namespace: ${NAMESPACE}
@@ -18,59 +26,82 @@ metadata:
     app: dsv3-disagg
     role: proxy
 spec:
-  restartPolicy: Never
-  hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
-  enableServiceLinks: false
-  nodeSelector:
-    kubernetes.io/hostname: ${PREFILL_NODE}
-  tolerations:
-    - key: nvidia.com/gpu
-      operator: Exists
-      effect: NoSchedule
-    - key: vpc.amazonaws.com/efa
-      operator: Exists
-      effect: NoSchedule
-    - key: sagemaker.amazonaws.com/node-health-status
-      operator: Exists
-      effect: NoSchedule
-  containers:
-    - name: proxy
-      image: ${REGISTRY}${IMAGE}:${TAG}
-      env:
-        - name: PYTHONUNBUFFERED
-          value: "1"
-      resources:
-        requests:
-          cpu: "4"
-          memory: "8Gi"
-        limits:
-          cpu: "8"
-          memory: "16Gi"
-      command:
-        - bash
-        - -c
-        - |
-          set -euo pipefail
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dsv3-disagg
+      role: proxy
+      instance: dsv3-proxy
+  template:
+    metadata:
+      labels:
+        app: dsv3-disagg
+        role: proxy
+        instance: dsv3-proxy
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 60
+      nodeSelector:
+        kubernetes.io/hostname: ${PREFILL_NODE}
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: vpc.amazonaws.com/efa
+          operator: Exists
+          effect: NoSchedule
+        - key: sagemaker.amazonaws.com/node-health-status
+          operator: Equal
+          value: Schedulable
+          effect: NoSchedule
+      containers:
+        - name: proxy
+          image: ${REGISTRY}${IMAGE}:${TAG}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          resources:
+            requests:
+              cpu: "4"
+              memory: "8Gi"
+            limits:
+              cpu: "8"
+              memory: "16Gi"
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 1800
+            periodSeconds: 30
+            failureThreshold: 5
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
 
-          echo "=== DSv3 PROXY ==="
-          echo "Prefill: ${PREFILL_IP}:8100"
-          echo "Decode:  ${DECODER_HOSTS} (port 8200 each)"
+              echo "=== DSv3 PROXY ==="
+              echo "Prefill: ${PREFILL_IP}:8100"
+              echo "Decode:  ${DECODER_HOSTS} (port 8200 each)"
 
-          for endpoint in "${PREFILL_IP}:8100" $(for h in ${DECODER_HOSTS}; do echo "$h:8200"; done); do
-            echo "Waiting for $endpoint..."
-            until curl -sf "http://${endpoint}/health" >/dev/null 2>&1; do
-              sleep 10
-              echo "  still waiting for $endpoint..."
-            done
-            echo "  $endpoint is ready!"
-          done
-          echo "All instances ready!"
+              for endpoint in "${PREFILL_IP}:8100" $(for h in ${DECODER_HOSTS}; do echo "$h:8200"; done); do
+                echo "Waiting for $endpoint..."
+                until curl -sf "http://${endpoint}/health" >/dev/null 2>&1; do
+                  sleep 10
+                  echo "  still waiting for $endpoint..."
+                done
+                echo "  $endpoint is ready!"
+              done
+              echo "All instances ready!"
 
-          exec python3 /opt/vllm/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
-            --host 0.0.0.0 \
-            --port 8000 \
-            --prefiller-hosts ${PREFILL_IP} \
-            --prefiller-ports 8100 \
-            --decoder-hosts ${DECODER_HOSTS} \
-            --decoder-ports ${DECODER_PORTS}
+              exec python3 /opt/vllm/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
+                --host 0.0.0.0 \
+                --port 8000 \
+                --prefiller-hosts ${PREFILL_IP} \
+                --prefiller-ports 8100 \
+                --decoder-hosts ${DECODER_HOSTS} \
+                --decoder-ports ${DECODER_PORTS}

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/proxy.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/proxy.yaml
@@ -1,0 +1,76 @@
+# NIXL routing proxy for DeepSeek-V3 disaggregated inference.
+#
+# Routes /v1/* requests:
+#   - prefill phase → ${PREFILL_IP}:8100
+#   - decode phase  → round-robin over ${DECODER_HOSTS} on port 8200
+#
+# DECODER_HOSTS / DECODER_PORTS are space-separated lists rendered by
+# recipe/deploy.sh based on the chosen topology.
+#
+# Apply with (typically via recipe/deploy.sh):
+#   envsubst < manifests/proxy.yaml | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dsv3-proxy
+  namespace: ${NAMESPACE}
+  labels:
+    app: dsv3-disagg
+    role: proxy
+spec:
+  restartPolicy: Never
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  enableServiceLinks: false
+  nodeSelector:
+    kubernetes.io/hostname: ${PREFILL_NODE}
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: vpc.amazonaws.com/efa
+      operator: Exists
+      effect: NoSchedule
+    - key: sagemaker.amazonaws.com/node-health-status
+      operator: Exists
+      effect: NoSchedule
+  containers:
+    - name: proxy
+      image: ${REGISTRY}${IMAGE}:${TAG}
+      env:
+        - name: PYTHONUNBUFFERED
+          value: "1"
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "8"
+          memory: "16Gi"
+      command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+
+          echo "=== DSv3 PROXY ==="
+          echo "Prefill: ${PREFILL_IP}:8100"
+          echo "Decode:  ${DECODER_HOSTS} (port 8200 each)"
+
+          for endpoint in "${PREFILL_IP}:8100" $(for h in ${DECODER_HOSTS}; do echo "$h:8200"; done); do
+            echo "Waiting for $endpoint..."
+            until curl -sf "http://${endpoint}/health" >/dev/null 2>&1; do
+              sleep 10
+              echo "  still waiting for $endpoint..."
+            done
+            echo "  $endpoint is ready!"
+          done
+          echo "All instances ready!"
+
+          exec python3 /opt/vllm/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
+            --host 0.0.0.0 \
+            --port 8000 \
+            --prefiller-hosts ${PREFILL_IP} \
+            --prefiller-ports 8100 \
+            --decoder-hosts ${DECODER_HOSTS} \
+            --decoder-ports ${DECODER_PORTS}

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/unified.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/unified.yaml
@@ -1,12 +1,15 @@
-# Single-node unified pod for DeepSeek-V3 — baseline comparison config.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Single-node unified Deployment for DeepSeek-V3 — baseline comparison.
 #
 # No NIXL, no proxy. Use this to measure the 1-node ceiling before
 # committing to disaggregation. UCCL-EP `deepep_low_latency` is the right
 # backend here: this is the same kernel decode pods use.
 #
 # Apply with: envsubst < manifests/unified.yaml | kubectl apply -f -
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: dsv3-unified
   namespace: ${NAMESPACE}
@@ -14,126 +17,161 @@ metadata:
     app: dsv3-disagg
     role: unified
 spec:
-  restartPolicy: Never
-  hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
-  enableServiceLinks: false
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node.kubernetes.io/instance-type
-                operator: In
-                values:
-                  - ${INSTANCE_TYPE}
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                  - ${PREFILL_NODE}
-  tolerations:
-    - key: nvidia.com/gpu
-      operator: Exists
-      effect: NoSchedule
-    - key: vpc.amazonaws.com/efa
-      operator: Exists
-      effect: NoSchedule
-    - key: sagemaker.amazonaws.com/node-health-status
-      operator: Exists
-      effect: NoSchedule
-  volumes:
-    - name: dshm
-      emptyDir:
-        medium: Memory
-        sizeLimit: 120Gi
-    - name: model-cache
-      hostPath:
-        path: /mnt/k8s-disks/0
-        type: DirectoryOrCreate
-  containers:
-    - name: vllm
-      image: ${REGISTRY}${IMAGE}:${TAG}
-      securityContext:
-        privileged: true
-      env:
-        - name: VLLM_ENGINE_READY_TIMEOUT_S
-          value: "14400"
-        - name: HF_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: hf-token
-              key: HF_TOKEN
-              optional: true
-        - name: HF_HOME
-          value: /mnt/k8s-disks/0/local_scratch/hf_cache
-        - name: VLLM_LOGGING_LEVEL
-          value: INFO
-        - name: VLLM_WORKER_MULTIPROC_METHOD
-          value: spawn
-        - name: VLLM_USE_DEEP_GEMM
-          value: "1"
-        - name: PYTHONUNBUFFERED
-          value: "1"
-        - name: NCCL_TIMEOUT
-          value: "7200000"
-        - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
-          value: "7200"
-        - name: FI_PROVIDER
-          value: "efa"
-        - name: FI_EFA_USE_DEVICE_RDMA
-          value: "1"
-        - name: FI_EFA_FORK_SAFE
-          value: "1"
-        - name: UCCL_SOCKET_IFNAME
-          value: "^lo,docker0,veth_def_agent"
-        - name: NCCL_DEBUG
-          value: "WARN"
-      resources:
-        requests:
-          cpu: "64"
-          memory: "400Gi"
-          nvidia.com/gpu: "8"
-          vpc.amazonaws.com/efa: "16"
-        limits:
-          cpu: "192"
-          memory: "1000Gi"
-          nvidia.com/gpu: "8"
-          vpc.amazonaws.com/efa: "16"
-      volumeMounts:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dsv3-disagg
+      role: unified
+      instance: dsv3-unified
+  template:
+    metadata:
+      labels:
+        app: dsv3-disagg
+        role: unified
+        instance: dsv3-unified
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 120
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - ${INSTANCE_TYPE}
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - ${PREFILL_NODE}
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: vpc.amazonaws.com/efa
+          operator: Exists
+          effect: NoSchedule
+        - key: sagemaker.amazonaws.com/node-health-status
+          operator: Equal
+          value: Schedulable
+          effect: NoSchedule
+      volumes:
         - name: dshm
-          mountPath: /dev/shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 120Gi
         - name: model-cache
-          mountPath: /mnt/k8s-disks/0
-      command:
-        - bash
-        - -c
-        - |
-          set -euo pipefail
+          hostPath:
+            path: /mnt/k8s-disks/0
+            type: DirectoryOrCreate
+      containers:
+        - name: vllm
+          image: ${REGISTRY}${IMAGE}:${TAG}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "14400"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: HF_TOKEN
+                  optional: true
+            - name: HF_HOME
+              value: /mnt/k8s-disks/0/local_scratch/hf_cache
+            - name: VLLM_LOGGING_LEVEL
+              value: INFO
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: spawn
+            - name: VLLM_USE_DEEP_GEMM
+              value: "1"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: NCCL_TIMEOUT
+              value: "7200000"
+            - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
+              value: "7200"
+            - name: FI_PROVIDER
+              value: "efa"
+            - name: FI_EFA_USE_DEVICE_RDMA
+              value: "1"
+            - name: FI_EFA_FORK_SAFE
+              value: "1"
+            - name: UCCL_SOCKET_IFNAME
+              value: "^lo,docker0,veth_def_agent"
+            - name: NCCL_DEBUG
+              value: "WARN"
+          resources:
+            requests:
+              cpu: "64"
+              memory: "400Gi"
+              nvidia.com/gpu: "8"
+              vpc.amazonaws.com/efa: "16"
+            limits:
+              cpu: "192"
+              memory: "1000Gi"
+              nvidia.com/gpu: "8"
+              vpc.amazonaws.com/efa: "16"
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: model-cache
+              mountPath: /mnt/k8s-disks/0
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 1800
+            periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
 
-          echo "=== DSv3 UNIFIED (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${DECODE_BACKEND}) ==="
-          MY_IP=$(hostname -I | awk '{print $1}')
-          IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
-          export GLOO_SOCKET_IFNAME=$IFACE
-          export NCCL_SOCKET_IFNAME=$IFACE
+              echo "=== DSv3 UNIFIED (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${DECODE_BACKEND}) ==="
+              MY_IP=$(hostname -I | awk '{print $1}')
+              IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
+              # GLOO is control-plane only (positive selection is fine).
+              # NCCL keeps the Dockerfile's exclusion pattern; a positive
+              # selection here would hide EFA and force TCP fallback
+              # (~28× slower).
+              export GLOO_SOCKET_IFNAME=$IFACE
+              export NCCL_SOCKET_IFNAME=^lo,docker,veth
 
-          ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
-          nvidia-smi -L
+              ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
+              nvidia-smi -L
 
-          mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
+              mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
 
-          exec vllm serve "${MODEL}" \
-            --trust-remote-code \
-            --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
-            --data-parallel-size ${DATA_PARALLEL_SIZE} \
-            --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
-            --data-parallel-address "$MY_IP" \
-            --data-parallel-rpc-port 13390 \
-            --api-server-count 2 \
-            --enable-expert-parallel \
-            --all2all-backend ${DECODE_BACKEND} \
-            --enable-chunked-prefill \
-            --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
-            --max-model-len ${MAX_MODEL_LEN} \
-            --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
-            --host 0.0.0.0 \
-            --port 8000
+              exec vllm serve "${MODEL}" \
+                --trust-remote-code \
+                --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
+                --data-parallel-size ${DATA_PARALLEL_SIZE} \
+                --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
+                --data-parallel-address "$MY_IP" \
+                --data-parallel-rpc-port 13390 \
+                --api-server-count 2 \
+                --enable-expert-parallel \
+                --all2all-backend ${DECODE_BACKEND} \
+                --enable-chunked-prefill \
+                --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+                --max-model-len ${MAX_MODEL_LEN} \
+                --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
+                --host 0.0.0.0 \
+                --port 8000

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/unified.yaml
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/manifests/unified.yaml
@@ -1,0 +1,139 @@
+# Single-node unified pod for DeepSeek-V3 — baseline comparison config.
+#
+# No NIXL, no proxy. Use this to measure the 1-node ceiling before
+# committing to disaggregation. UCCL-EP `deepep_low_latency` is the right
+# backend here: this is the same kernel decode pods use.
+#
+# Apply with: envsubst < manifests/unified.yaml | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dsv3-unified
+  namespace: ${NAMESPACE}
+  labels:
+    app: dsv3-disagg
+    role: unified
+spec:
+  restartPolicy: Never
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  enableServiceLinks: false
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                  - ${INSTANCE_TYPE}
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                  - ${PREFILL_NODE}
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: vpc.amazonaws.com/efa
+      operator: Exists
+      effect: NoSchedule
+    - key: sagemaker.amazonaws.com/node-health-status
+      operator: Exists
+      effect: NoSchedule
+  volumes:
+    - name: dshm
+      emptyDir:
+        medium: Memory
+        sizeLimit: 120Gi
+    - name: model-cache
+      hostPath:
+        path: /mnt/k8s-disks/0
+        type: DirectoryOrCreate
+  containers:
+    - name: vllm
+      image: ${REGISTRY}${IMAGE}:${TAG}
+      securityContext:
+        privileged: true
+      env:
+        - name: VLLM_ENGINE_READY_TIMEOUT_S
+          value: "14400"
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token
+              key: HF_TOKEN
+              optional: true
+        - name: HF_HOME
+          value: /mnt/k8s-disks/0/local_scratch/hf_cache
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: VLLM_WORKER_MULTIPROC_METHOD
+          value: spawn
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NCCL_TIMEOUT
+          value: "7200000"
+        - name: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC
+          value: "7200"
+        - name: FI_PROVIDER
+          value: "efa"
+        - name: FI_EFA_USE_DEVICE_RDMA
+          value: "1"
+        - name: FI_EFA_FORK_SAFE
+          value: "1"
+        - name: UCCL_SOCKET_IFNAME
+          value: "^lo,docker0,veth_def_agent"
+        - name: NCCL_DEBUG
+          value: "WARN"
+      resources:
+        requests:
+          cpu: "64"
+          memory: "400Gi"
+          nvidia.com/gpu: "8"
+          vpc.amazonaws.com/efa: "16"
+        limits:
+          cpu: "192"
+          memory: "1000Gi"
+          nvidia.com/gpu: "8"
+          vpc.amazonaws.com/efa: "16"
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: model-cache
+          mountPath: /mnt/k8s-disks/0
+      command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+
+          echo "=== DSv3 UNIFIED (TP=${TENSOR_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, EP=8, ${DECODE_BACKEND}) ==="
+          MY_IP=$(hostname -I | awk '{print $1}')
+          IFACE=$(ip -o -4 addr show | grep "$MY_IP" | awk '{print $2}' | head -1)
+          export GLOO_SOCKET_IFNAME=$IFACE
+          export NCCL_SOCKET_IFNAME=$IFACE
+
+          ls /dev/infiniband/ 2>/dev/null | wc -l || echo "no EFA"
+          nvidia-smi -L
+
+          mkdir -p /mnt/k8s-disks/0/local_scratch/hf_cache/hub
+
+          exec vllm serve "${MODEL}" \
+            --trust-remote-code \
+            --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
+            --data-parallel-size ${DATA_PARALLEL_SIZE} \
+            --data-parallel-size-local ${DATA_PARALLEL_SIZE} \
+            --data-parallel-address "$MY_IP" \
+            --data-parallel-rpc-port 13390 \
+            --api-server-count 2 \
+            --enable-expert-parallel \
+            --all2all-backend ${DECODE_BACKEND} \
+            --enable-chunked-prefill \
+            --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+            --max-model-len ${MAX_MODEL_LEN} \
+            --num-gpu-blocks-override ${NUM_GPU_BLOCKS_OVERRIDE} \
+            --host 0.0.0.0 \
+            --port 8000

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/benchmark.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/benchmark.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# Warm up and run a rate sweep against a deployed topology.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Warm up and run a rate sweep against a deployed topology, repeating each
+# rate once per seed so users can aggregate over multiple runs.
 #
 # Usage:
 #   ./recipe/benchmark.sh <topology> [results_dir]
@@ -7,6 +11,11 @@
 # Where <topology> is one of unified|1p1d|1p3d|1p4d|1p5d. The script targets
 # http://${PREFILL_IP}:${PORT} where PORT=8000 (proxy for disaggregated, vLLM
 # directly for unified).
+#
+# Override which seeds and rates run via environment variables:
+#   SEEDS="1234 5678 9012"   # default — 3 seeds
+#   RATES="1 4 8 16 inf"     # default
+#   NUM_PROMPTS=50           # default
 
 set -euo pipefail
 
@@ -21,6 +30,10 @@ if [[ -z "${PREFILL_IP:-}" || -z "${MODEL:-}" ]]; then
     echo "ERROR: source setup/env_vars first." >&2
     exit 1
 fi
+
+SEEDS="${SEEDS:-1234 5678 9012}"
+RATES="${RATES:-1 4 8 16 inf}"
+NUM_PROMPTS="${NUM_PROMPTS:-50}"
 
 ENDPOINT="http://${PREFILL_IP}:8000"
 
@@ -37,21 +50,25 @@ vllm bench serve \
     --request-rate 1 \
     --seed 1234
 
-echo "==> Rate sweep (results -> ${RESULT_DIR})"
-for RATE in 1 4 8 16 inf; do
-    echo "----- rate=${RATE} -----"
-    vllm bench serve \
-        --base-url "${ENDPOINT}" \
-        --model "${MODEL}" \
-        --dataset-name random \
-        --random-input-len 1024 \
-        --random-output-len 256 \
-        --num-prompts 50 \
-        --request-rate "${RATE}" \
-        --metric-percentiles "50,90,95,99" \
-        --seed 1234 \
-        --save-result \
-        --result-dir "${RESULT_DIR}"
+for SEED in ${SEEDS}; do
+    SEED_DIR="${RESULT_DIR}/seed-${SEED}"
+    mkdir -p "${SEED_DIR}"
+    echo "==> Rate sweep seed=${SEED} (results -> ${SEED_DIR})"
+    for RATE in ${RATES}; do
+        echo "----- seed=${SEED} rate=${RATE} -----"
+        vllm bench serve \
+            --base-url "${ENDPOINT}" \
+            --model "${MODEL}" \
+            --dataset-name random \
+            --random-input-len 1024 \
+            --random-output-len 256 \
+            --num-prompts "${NUM_PROMPTS}" \
+            --request-rate "${RATE}" \
+            --metric-percentiles "50,90,95,99" \
+            --seed "${SEED}" \
+            --save-result \
+            --result-dir "${SEED_DIR}"
+    done
 done
 
-echo "==> Done. Result JSON files in ${RESULT_DIR}"
+echo "==> Done. Result JSON files in ${RESULT_DIR}/seed-*/"

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/benchmark.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/benchmark.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Warm up and run a rate sweep against a deployed topology.
+#
+# Usage:
+#   ./recipe/benchmark.sh <topology> [results_dir]
+#
+# Where <topology> is one of unified|1p1d|1p3d|1p4d|1p5d. The script targets
+# http://${PREFILL_IP}:${PORT} where PORT=8000 (proxy for disaggregated, vLLM
+# directly for unified).
+
+set -euo pipefail
+
+TOPOLOGY="${1:-}"
+RESULT_DIR="${2:-results/${TOPOLOGY}}"
+
+if [[ -z "${TOPOLOGY}" ]]; then
+    echo "Usage: $0 <unified|1p1d|1p3d|1p4d|1p5d> [results_dir]" >&2
+    exit 1
+fi
+if [[ -z "${PREFILL_IP:-}" || -z "${MODEL:-}" ]]; then
+    echo "ERROR: source setup/env_vars first." >&2
+    exit 1
+fi
+
+ENDPOINT="http://${PREFILL_IP}:8000"
+
+mkdir -p "${RESULT_DIR}"
+
+echo "==> Warmup against ${ENDPOINT}"
+vllm bench serve \
+    --base-url "${ENDPOINT}" \
+    --model "${MODEL}" \
+    --dataset-name random \
+    --random-input-len 1024 \
+    --random-output-len 256 \
+    --num-prompts 10 \
+    --request-rate 1 \
+    --seed 1234
+
+echo "==> Rate sweep (results -> ${RESULT_DIR})"
+for RATE in 1 4 8 16 inf; do
+    echo "----- rate=${RATE} -----"
+    vllm bench serve \
+        --base-url "${ENDPOINT}" \
+        --model "${MODEL}" \
+        --dataset-name random \
+        --random-input-len 1024 \
+        --random-output-len 256 \
+        --num-prompts 50 \
+        --request-rate "${RATE}" \
+        --metric-percentiles "50,90,95,99" \
+        --seed 1234 \
+        --save-result \
+        --result-dir "${RESULT_DIR}"
+done
+
+echo "==> Done. Result JSON files in ${RESULT_DIR}"

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/deploy.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/deploy.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
 # Render and apply manifests for a chosen disaggregation topology.
 #
 # Usage:

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/deploy.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/deploy.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Render and apply manifests for a chosen disaggregation topology.
+#
+# Usage:
+#   ./recipe/deploy.sh <topology>
+#
+# Where <topology> is one of:
+#   unified  → 1 node, single dsv3-unified pod
+#   1p1d     → 1 prefill + 1 decode (2 nodes)
+#   1p3d     → 1 prefill + 3 decode (4 nodes)
+#   1p4d     → 1 prefill + 4 decode (5 nodes — peak burst RPS)
+#   1p5d     → 1 prefill + 5 decode (6 nodes)
+#
+# Reads node hostnames + IPs and image / model config from setup/env_vars.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MANIFEST_DIR="${PROJECT_DIR}/manifests"
+
+TOPOLOGY="${1:-}"
+if [[ -z "${TOPOLOGY}" ]]; then
+    echo "Usage: $0 <unified|1p1d|1p3d|1p4d|1p5d>" >&2
+    exit 1
+fi
+
+# Sanity check required environment.
+required=(NAMESPACE INSTANCE_TYPE REGISTRY IMAGE TAG MODEL
+          PREFILL_NODE PREFILL_IP
+          TENSOR_PARALLEL_SIZE DATA_PARALLEL_SIZE GPU_MEMORY_UTILIZATION
+          MAX_MODEL_LEN NUM_GPU_BLOCKS_OVERRIDE PREFILL_BACKEND DECODE_BACKEND)
+for v in "${required[@]}"; do
+    if [[ -z "${!v:-}" ]]; then
+        echo "ERROR: $v is unset. Did you 'source setup/env_vars'?" >&2
+        exit 1
+    fi
+done
+
+# Variables that envsubst is allowed to substitute. Anything else (e.g.
+# $endpoint, $MY_IP, $h inside the embedded shell scripts) must survive
+# untouched so the pod's bash interpreter can use it at runtime.
+SUBST_VARS='$NAMESPACE $INSTANCE_TYPE $REGISTRY $IMAGE $TAG $MODEL
+            $PREFILL_NODE $PREFILL_IP $DECODE_NODE $DECODE_INDEX
+            $DECODER_HOSTS $DECODER_PORTS
+            $TENSOR_PARALLEL_SIZE $DATA_PARALLEL_SIZE
+            $GPU_MEMORY_UTILIZATION $MAX_MODEL_LEN $NUM_GPU_BLOCKS_OVERRIDE
+            $PREFILL_BACKEND $DECODE_BACKEND'
+
+# Decide the decode-pod count for the chosen topology.
+case "${TOPOLOGY}" in
+    unified) NUM_DECODE=0 ;;
+    1p1d)    NUM_DECODE=1 ;;
+    1p3d)    NUM_DECODE=3 ;;
+    1p4d)    NUM_DECODE=4 ;;
+    1p5d)    NUM_DECODE=5 ;;
+    *)
+        echo "ERROR: unknown topology '${TOPOLOGY}'" >&2
+        exit 1
+        ;;
+esac
+
+echo "==> Ensuring namespace ${NAMESPACE} exists"
+kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1 \
+    || kubectl create namespace "${NAMESPACE}"
+
+if [[ "${TOPOLOGY}" == "unified" ]]; then
+    echo "==> Applying unified pod"
+    envsubst "${SUBST_VARS}" < "${MANIFEST_DIR}/unified.yaml" | kubectl apply -f -
+    echo "==> Done. Probe with: curl -sf http://${PREFILL_IP}:8000/health"
+    exit 0
+fi
+
+# Disaggregated path: prefill + N decode + proxy.
+echo "==> Applying prefill pod on ${PREFILL_NODE}"
+envsubst "${SUBST_VARS}" < "${MANIFEST_DIR}/prefill.yaml" | kubectl apply -f -
+
+DECODER_HOSTS=""
+DECODER_PORTS=""
+for ((i=0; i<NUM_DECODE; i++)); do
+    node_var="DECODE_NODE_${i}"
+    ip_var="DECODE_${i}_IP"
+    decode_node="${!node_var:-}"
+    decode_ip="${!ip_var:-}"
+    if [[ -z "${decode_node}" || -z "${decode_ip}" ]]; then
+        echo "ERROR: ${node_var} or ${ip_var} unset for topology ${TOPOLOGY}" >&2
+        exit 1
+    fi
+
+    echo "==> Applying decode-${i} on ${decode_node}"
+    DECODE_INDEX="${i}" DECODE_NODE="${decode_node}" \
+        envsubst "${SUBST_VARS}" < "${MANIFEST_DIR}/decode.yaml" | kubectl apply -f -
+
+    DECODER_HOSTS="${DECODER_HOSTS}${decode_ip} "
+    DECODER_PORTS="${DECODER_PORTS}8200 "
+done
+
+DECODER_HOSTS="${DECODER_HOSTS% }"
+DECODER_PORTS="${DECODER_PORTS% }"
+
+echo "==> Applying proxy pod (decoders: ${DECODER_HOSTS})"
+DECODER_HOSTS="${DECODER_HOSTS}" DECODER_PORTS="${DECODER_PORTS}" \
+    envsubst "${SUBST_VARS}" < "${MANIFEST_DIR}/proxy.yaml" | kubectl apply -f -
+
+echo
+echo "==> All pods applied."
+echo "    Watch: kubectl logs -f -n ${NAMESPACE} dsv3-proxy"
+echo "    Probe: curl -sf http://${PREFILL_IP}:8000/health"

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/teardown.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/teardown.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Delete all pods this sample created. Keeps the namespace and HF secret.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Delete all Deployments this sample created. Keeps the namespace and HF secret.
 
 set -euo pipefail
 
@@ -8,6 +11,6 @@ if [[ -z "${NAMESPACE:-}" ]]; then
     exit 1
 fi
 
-echo "==> Deleting dsv3-disagg pods in namespace ${NAMESPACE}"
-kubectl delete pod --selector=app=dsv3-disagg --namespace "${NAMESPACE}" --ignore-not-found
+echo "==> Deleting dsv3-disagg Deployments in namespace ${NAMESPACE}"
+kubectl delete deployment --selector=app=dsv3-disagg --namespace "${NAMESPACE}" --ignore-not-found
 echo "==> Done."

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/teardown.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/recipe/teardown.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Delete all pods this sample created. Keeps the namespace and HF secret.
+
+set -euo pipefail
+
+if [[ -z "${NAMESPACE:-}" ]]; then
+    echo "ERROR: source setup/env_vars first." >&2
+    exit 1
+fi
+
+echo "==> Deleting dsv3-disagg pods in namespace ${NAMESPACE}"
+kubectl delete pod --selector=app=dsv3-disagg --namespace "${NAMESPACE}" --ignore-not-found
+echo "==> Done."

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/build-push.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/build-push.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
 # Build the vLLM + UCCL-EP + NIXL image and push it to ECR.
 #
 # Reads REGISTRY / IMAGE / TAG / AWS_REGION from setup/env_vars.

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/build-push.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/build-push.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build the vLLM + UCCL-EP + NIXL image and push it to ECR.
+#
+# Reads REGISTRY / IMAGE / TAG / AWS_REGION from setup/env_vars.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -z "${REGISTRY:-}" || -z "${IMAGE:-}" || -z "${TAG:-}" ]]; then
+    echo "ERROR: source setup/env_vars first." >&2
+    exit 1
+fi
+
+FULL_IMAGE="${REGISTRY}${IMAGE}:${TAG}"
+
+echo "==> Building ${FULL_IMAGE}"
+DOCKER_BUILDKIT=1 docker build \
+    --platform linux/amd64 \
+    -f "${PROJECT_DIR}/Dockerfile" \
+    -t "${FULL_IMAGE}" \
+    "${PROJECT_DIR}"
+
+echo "==> Ensuring ECR repository exists"
+if ! aws ecr describe-repositories --repository-names "${IMAGE}" --region "${AWS_REGION}" >/dev/null 2>&1; then
+    aws ecr create-repository --repository-name "${IMAGE}" --region "${AWS_REGION}" >/dev/null
+fi
+
+echo "==> Logging in to ${REGISTRY}"
+aws ecr get-login-password --region "${AWS_REGION}" \
+    | docker login --username AWS --password-stdin "${REGISTRY%/}"
+
+echo "==> Pushing ${FULL_IMAGE}"
+docker push "${FULL_IMAGE}"
+
+echo "==> Done. Image digest:"
+docker inspect --format='{{index .RepoDigests 0}}' "${FULL_IMAGE}" || true

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/env_vars.example
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/env_vars.example
@@ -1,19 +1,28 @@
 #!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 #
 # Example env_vars for the DeepSeek-V3 disaggregated vLLM + UCCL-EP + NIXL
-# sample. Copy this to setup/env_vars and fill in your values.
+# sample. Copy this to setup/env_vars and fill in every REPLACE_ME:
 #
 #   cp setup/env_vars.example setup/env_vars
 #   $EDITOR setup/env_vars
+#   grep REPLACE_ME setup/env_vars   # should print nothing when fully set
 #   source setup/env_vars
 #
 # Never commit setup/env_vars — it contains your HF token and account ID.
 #
 # ---------------------------------------------------------------------------
 # AWS / ECR
+#
+# Discover values once:
+#   AWS_REGION=$(aws ec2 describe-availability-zones \
+#                  --output text --query 'AvailabilityZones[0].[RegionName]')
+#   ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+# Then paste the literals below — sourcing this file should not make AWS calls.
 # ---------------------------------------------------------------------------
-export AWS_REGION="$(aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]')"
-export ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+export AWS_REGION="REPLACE_ME"           # e.g. us-west-2
+export ACCOUNT="REPLACE_ME"              # 12-digit AWS account id
 export REGISTRY="${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/"
 export IMAGE="vllm-uccl-ep"
 export TAG="vllm0.21.0-uccl-0dc87eb-cu13"
@@ -21,7 +30,7 @@ export TAG="vllm0.21.0-uccl-0dc87eb-cu13"
 # ---------------------------------------------------------------------------
 # Cluster
 # ---------------------------------------------------------------------------
-export EKS_CLUSTER_NAME="<your-eks-cluster-name>"
+export EKS_CLUSTER_NAME="REPLACE_ME"     # name of your EKS / HyperPod EKS cluster
 export NAMESPACE="dsv3-disagg"
 export INSTANCE_TYPE="p5en.48xlarge"
 export NUM_GPU_PER_NODE=8
@@ -31,7 +40,7 @@ export NUM_EFA_PER_NODE=16
 # Model
 # ---------------------------------------------------------------------------
 export MODEL="deepseek-ai/DeepSeek-V3-0324"
-export HF_TOKEN="<hf_your_token_here>"
+export HF_TOKEN="REPLACE_ME"             # HuggingFace token with DeepSeek-V3 access
 
 # ---------------------------------------------------------------------------
 # Topology — fill in node hostnames and internal IPs
@@ -44,23 +53,23 @@ export HF_TOKEN="<hf_your_token_here>"
 # Provide as many DECODE_NODE_<i> / DECODE_<i>_IP pairs as your topology
 # needs (1p1d → just DECODE_NODE_0, 1p4d → DECODE_NODE_0..3, etc).
 # ---------------------------------------------------------------------------
-export PREFILL_NODE="ip-10-0-0-1.${AWS_REGION}.compute.internal"
-export PREFILL_IP="10.0.0.1"
+export PREFILL_NODE="REPLACE_ME"         # e.g. ip-10-0-0-1.us-west-2.compute.internal
+export PREFILL_IP="REPLACE_ME"           # e.g. 10.0.0.1
 
-export DECODE_NODE_0="ip-10-0-0-2.${AWS_REGION}.compute.internal"
-export DECODE_0_IP="10.0.0.2"
+export DECODE_NODE_0="REPLACE_ME"
+export DECODE_0_IP="REPLACE_ME"
 
-export DECODE_NODE_1="ip-10-0-0-3.${AWS_REGION}.compute.internal"
-export DECODE_1_IP="10.0.0.3"
+export DECODE_NODE_1="REPLACE_ME"
+export DECODE_1_IP="REPLACE_ME"
 
-export DECODE_NODE_2="ip-10-0-0-4.${AWS_REGION}.compute.internal"
-export DECODE_2_IP="10.0.0.4"
+export DECODE_NODE_2="REPLACE_ME"
+export DECODE_2_IP="REPLACE_ME"
 
-export DECODE_NODE_3="ip-10-0-0-5.${AWS_REGION}.compute.internal"
-export DECODE_3_IP="10.0.0.5"
+export DECODE_NODE_3="REPLACE_ME"
+export DECODE_3_IP="REPLACE_ME"
 
-export DECODE_NODE_4="ip-10-0-0-6.${AWS_REGION}.compute.internal"
-export DECODE_4_IP="10.0.0.6"
+export DECODE_NODE_4="REPLACE_ME"
+export DECODE_4_IP="REPLACE_ME"
 
 # ---------------------------------------------------------------------------
 # vLLM serve flags (tweak only if you change hardware)

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/env_vars.example
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/env_vars.example
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Example env_vars for the DeepSeek-V3 disaggregated vLLM + UCCL-EP + NIXL
+# sample. Copy this to setup/env_vars and fill in your values.
+#
+#   cp setup/env_vars.example setup/env_vars
+#   $EDITOR setup/env_vars
+#   source setup/env_vars
+#
+# Never commit setup/env_vars — it contains your HF token and account ID.
+#
+# ---------------------------------------------------------------------------
+# AWS / ECR
+# ---------------------------------------------------------------------------
+export AWS_REGION="$(aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]')"
+export ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+export REGISTRY="${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/"
+export IMAGE="vllm-uccl-ep"
+export TAG="vllm0.21.0-uccl-0dc87eb-cu13"
+
+# ---------------------------------------------------------------------------
+# Cluster
+# ---------------------------------------------------------------------------
+export EKS_CLUSTER_NAME="<your-eks-cluster-name>"
+export NAMESPACE="dsv3-disagg"
+export INSTANCE_TYPE="p5en.48xlarge"
+export NUM_GPU_PER_NODE=8
+export NUM_EFA_PER_NODE=16
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+export MODEL="deepseek-ai/DeepSeek-V3-0324"
+export HF_TOKEN="<hf_your_token_here>"
+
+# ---------------------------------------------------------------------------
+# Topology — fill in node hostnames and internal IPs
+#
+# Discover with:
+#   kubectl get nodes -l node.kubernetes.io/instance-type=$INSTANCE_TYPE \
+#     -o custom-columns="NAME:.metadata.name,IP:.status.addresses[?(@.type=='InternalIP')].address" \
+#     --no-headers
+#
+# Provide as many DECODE_NODE_<i> / DECODE_<i>_IP pairs as your topology
+# needs (1p1d → just DECODE_NODE_0, 1p4d → DECODE_NODE_0..3, etc).
+# ---------------------------------------------------------------------------
+export PREFILL_NODE="ip-10-0-0-1.${AWS_REGION}.compute.internal"
+export PREFILL_IP="10.0.0.1"
+
+export DECODE_NODE_0="ip-10-0-0-2.${AWS_REGION}.compute.internal"
+export DECODE_0_IP="10.0.0.2"
+
+export DECODE_NODE_1="ip-10-0-0-3.${AWS_REGION}.compute.internal"
+export DECODE_1_IP="10.0.0.3"
+
+export DECODE_NODE_2="ip-10-0-0-4.${AWS_REGION}.compute.internal"
+export DECODE_2_IP="10.0.0.4"
+
+export DECODE_NODE_3="ip-10-0-0-5.${AWS_REGION}.compute.internal"
+export DECODE_3_IP="10.0.0.5"
+
+export DECODE_NODE_4="ip-10-0-0-6.${AWS_REGION}.compute.internal"
+export DECODE_4_IP="10.0.0.6"
+
+# ---------------------------------------------------------------------------
+# vLLM serve flags (tweak only if you change hardware)
+# ---------------------------------------------------------------------------
+export TENSOR_PARALLEL_SIZE=4
+export DATA_PARALLEL_SIZE=2
+export GPU_MEMORY_UTILIZATION=0.80
+export MAX_MODEL_LEN=8192
+export NUM_GPU_BLOCKS_OVERRIDE=30000
+export PREFILL_BACKEND="deepep_high_throughput"
+export DECODE_BACKEND="deepep_low_latency"

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/install-prereqs.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/install-prereqs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
 # Install the NVIDIA device plugin and the AWS EFA Kubernetes device plugin
 # on a vanilla EKS cluster. Skip this on SageMaker HyperPod EKS — both
 # plugins are pre-installed there.
@@ -14,7 +17,7 @@ kubectl apply -f \
 
 echo "==> Installing AWS EFA Kubernetes device plugin ${EFA_PLUGIN_VERSION}"
 kubectl apply -f \
-    "https://raw.githubusercontent.com/aws-samples/aws-efa-eks/main/manifest/efa-k8s-device-plugin.yml"
+    "https://raw.githubusercontent.com/aws-samples/aws-efa-eks/${EFA_PLUGIN_VERSION}/manifest/efa-k8s-device-plugin.yml"
 
 echo "==> Waiting for plugins to roll out"
 kubectl -n kube-system rollout status ds/nvidia-device-plugin-daemonset --timeout=300s

--- a/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/install-prereqs.sh
+++ b/3.test_cases/pytorch/vllm/dsv3-uccl-nixl/setup/install-prereqs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install the NVIDIA device plugin and the AWS EFA Kubernetes device plugin
+# on a vanilla EKS cluster. Skip this on SageMaker HyperPod EKS — both
+# plugins are pre-installed there.
+
+set -euo pipefail
+
+NVIDIA_PLUGIN_VERSION="${NVIDIA_PLUGIN_VERSION:-v0.16.2}"
+EFA_PLUGIN_VERSION="${EFA_PLUGIN_VERSION:-v0.5.7}"
+
+echo "==> Installing NVIDIA Kubernetes device plugin ${NVIDIA_PLUGIN_VERSION}"
+kubectl apply -f \
+    "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/${NVIDIA_PLUGIN_VERSION}/deployments/static/nvidia-device-plugin.yml"
+
+echo "==> Installing AWS EFA Kubernetes device plugin ${EFA_PLUGIN_VERSION}"
+kubectl apply -f \
+    "https://raw.githubusercontent.com/aws-samples/aws-efa-eks/main/manifest/efa-k8s-device-plugin.yml"
+
+echo "==> Waiting for plugins to roll out"
+kubectl -n kube-system rollout status ds/nvidia-device-plugin-daemonset --timeout=300s
+kubectl -n kube-system rollout status ds/aws-efa-k8s-device-plugin-daemonset --timeout=300s
+
+echo "==> Sample node allocatable (look for nvidia.com/gpu and vpc.amazonaws.com/efa):"
+kubectl get nodes -o json \
+    | jq -r '.items[].status.allocatable
+        | with_entries(select(.key == "nvidia.com/gpu" or .key == "vpc.amazonaws.com/efa"))' \
+    || true


### PR DESCRIPTION
## Purpose

Add a new test case demonstrating **disaggregated DeepSeek-V3 inference with vLLM, UCCL-EP, and NIXL over AWS EFA**. The sample reproduces a 6-node scaling study (1N → 1P+5D) that quantifies the latency and throughput trade-offs of NIXL-based prefill/decode disaggregation for a 671B-parameter MLA + 256-expert MoE model.

Relates to ongoing work consolidating inference samples from `aws-samples/awsome-inference` into `awsome-distributed-ai`.

## Changes

- New test case at `3.test_cases/pytorch/vllm/dsv3-uccl-nixl/` covering DeepSeek-V3 disaggregated serving on EKS / SageMaker HyperPod EKS.
- `Dockerfile` building **vLLM 0.21.0** from source on **CUDA 13** with **NIXL 1.0.1** (`nixl-cu13`), **UCCL-EP** (commit `0dc87eb`) + the `deep_ep` drop-in wrapper, **Ray 2.55.1**, EFA installer 1.48.0, NCCL 2.30.4, GDRCopy 2.5.2 — all version-pinned.
- `manifests/{prefill,decode,proxy,unified,hf-token-secret}.yaml` — `envsubst`-templated pod manifests.
  - Prefill uses `--all2all-backend deepep_high_throughput`, decode uses `deepep_low_latency`.
  - KV transfer via `NixlConnector` + `LIBFABRIC` over EFA (side-channel on port 5600, host network).
  - Per-node parallelism: `TP=4`, `DP=2`, `EP=8` on 8×H200.
- `recipe/deploy.sh` — renders manifests for a chosen topology (`unified|1p1d|1p3d|1p4d|1p5d`) using **scoped** `envsubst` so embedded shell variables (`$endpoint`, `$MY_IP`, …) survive untouched.
- `recipe/benchmark.sh` — warmup + rate sweep at 1/4/8/16/inf RPS via `vllm bench serve`, fixed seed, `--save-result`.
- `recipe/teardown.sh`, `setup/build-push.sh`, `setup/install-prereqs.sh` (NVIDIA + EFA device plugins for vanilla EKS), `setup/env_vars.example`.
- `README.md` with architecture diagram, results table, prerequisites, knob reference, troubleshooting, and cost estimate.
- `3.test_cases/pytorch/vllm/README.md` index entry.
- `.gitignore` keeps `setup/env_vars` (HF token, account ID) and `results/` out of git.

## Test Plan

**Environment:**
- AWS Service: Amazon EKS (also tested on SageMaker HyperPod EKS, ap-southeast-3 and us-west-2)
- Instance type: `p5en.48xlarge` (8× H200 141GB, 16× EFA, 3,200 Gbps)
- Number of nodes: 1 → 6 (covering 1N, 1P+1D, 1P+2D, 1P+3D, 1P+4D, 1P+5D, 2P+3D, 2P+4D, plus an AGRS backend comparison)

**Test commands:**
```bash
cd 3.test_cases/pytorch/vllm/dsv3-uccl-nixl

cp setup/env_vars.example setup/env_vars
$EDITOR setup/env_vars                 # set REGISTRY, HF_TOKEN, node hostnames + IPs
source setup/env_vars

./setup/build-push.sh                  # build + ECR push

kubectl create namespace "$NAMESPACE"
kubectl create secret generic hf-token --namespace "$NAMESPACE" \
    --from-literal=HF_TOKEN="$HF_TOKEN"

./recipe/deploy.sh 1p4d                # 1 prefill + 4 decode (5 nodes, peak)

# wait until proxy logs "All instances ready!"
curl -sf "http://${PREFILL_IP}:8000/health"

./recipe/benchmark.sh 1p4d             # warmup + rate sweep, results -> results/1p4d/

./recipe/teardown.sh
```

## Test Results

Workload: `--random-input-len 1024 --random-output-len 256 --num-prompts 50` via `vllm bench serve`.

| Config       | Nodes | GPUs | Burst RPS | Burst tok/s | P50 TPOT @1RPS | P50 TPOT @burst | P50 TTFT @1RPS | tok/s/GPU |
| ------------ | :---: | :--: | --------: | ----------: | -------------: | --------------: | -------------: | --------: |
| 1N unified   |   1   |   8  |     13.49 |       3,454 |        21.83ms |         44.00ms |          77ms  |    431.55 |
| 1P+1D       |   2   |  16  |     15.94 |       4,082 |        20.93ms |         40.91ms |         313ms  |    255.10 |
| 1P+3D       |   4   |  32  |     17.22 |       4,408 |        18.21ms |         33.76ms |         343ms  |    137.75 |
| **1P+4D**   |   5   |  40  | **19.18** |   **4,910** |        17.81ms |         32.51ms |         303ms  |    122.75 |
| 1P+5D       |   6   |  48  |     17.16 |       4,392 |        17.81ms |         30.34ms |         268ms  |     91.51 |
| 1P+3D AGRS  |   4   |  32  |     10.62 |       2,721 |        23.30ms |         48.20ms |         310ms  |     85.03 |

**Headline findings**

1. **Disaggregation pays off mostly in latency, not throughput.** A single unified node has the best `tok/s/GPU` (431.55); disaggregation lowers burst TPOT 44ms → 30ms but only adds ~42% peak RPS for 5× the GPUs.
2. **The optimal P:D ratio is 1:4** at this model size — beyond 4 decode nodes the single prefill node is the hard bottleneck (1P+5D burst RPS regresses).
3. **UCCL-EP (`deepep_high_throughput` + `deepep_low_latency`) beats `allgather_reducescatter` (AGRS) by ~62%** on burst RPS and ~30% on TPOT for this MLA + 256-expert MoE model.
4. **`hostNetwork: true` + `vpc.amazonaws.com/efa: 16` are mandatory.** With TCP fallback (no EFA), the same workload runs ~28× slower.

The full per-rate breakdown, plots, and software-stack version capture live in the upstream experiment directory used to develop this sample.

## Directory Structure

```
3.test_cases/
└── pytorch/
    └── vllm/
        ├── README.md                  # index of vLLM test cases
        └── dsv3-uccl-nixl/
            ├── Dockerfile             # vLLM 0.21.0 + UCCL-EP + NIXL on CUDA 13 / EFA
            ├── README.md              # overview, prerequisites, usage
            ├── .gitignore             # keeps setup/env_vars and results/ out of git
            ├── manifests/             # Kubernetes pod manifests (envsubst-templated)
            │   ├── prefill.yaml
            │   ├── decode.yaml
            │   ├── proxy.yaml
            │   ├── unified.yaml
            │   └── hf-token-secret.yaml
            ├── recipe/                # deploy / benchmark / teardown helpers
            │   ├── deploy.sh
            │   ├── benchmark.sh
            │   └── teardown.sh
            └── setup/                 # build + cluster prereqs
                ├── env_vars.example
                ├── build-push.sh
                └── install-prereqs.sh
```

This is a Kubernetes-native deployment sample (EKS + SageMaker HyperPod EKS), so the `slurm/` and `hyperpod-eks/` siblings are not applicable — the manifests are generic enough to run on either orchestrator unmodified.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`) — vLLM `v0.21.0`, UCCL `0dc87eb…`, NIXL `v1.0.1`, NCCL `v2.30.4-1`, EFA `1.48.0`, GDRCopy `v2.5.2`, Ray `>=2.43`.
- [x] A README is included with prerequisites, instructions, and known issues.
- [x] New test cases follow the [expected directory structure](#directory-structure).
