### PR TITLE
CI: build & publish hpc-cloud images via GitHub Actions (nccl-tests first)

### DIFF
--- a/.github/image-manifest.yaml
+++ b/.github/image-manifest.yaml
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Image manifest consumed by .github/workflows/build-image.yml.
+#
+# Schema (per image, keyed by `key`):
+#   key:         logical image name (must match the top-level map key)
+#   context:     Docker build context, relative to repo root
+#   dockerfile:  Dockerfile path, relative to `context`
+#   ecr_repo:    ECR Public repository name (pushed under public.ecr.aws/hpc-cloud/<ecr_repo>)
+#   platforms:   list of CPU arches to build (amd64 | arm64); each maps to a native runner fleet
+#   build_args:  map of Docker build args -> values (passed verbatim as --build-arg KEY=VALUE)
+#
+# The image tag is derived by build-image.yml from build_args, NOT stored here, so that
+# a single source of truth (this map) drives both the build args and the tag.
+#
+# SOURCE-OF-TRUTH COUPLING (D1): the build_args versions below are intentionally
+# duplicated in micro-benchmarks/nccl-tests/buildspec.yaml, which remains the
+# documented manual fallback (DESIGN section 6, Rollback). To prevent silent
+# drift, release-images.yml runs a `manifest-buildspec-parity` check that asserts
+# all six versions (CUDA, GDRCOPY, EFA, OFI, NCCL, NCCL_TESTS) in this manifest
+# equal the buildspec values. A PR that bumps one file but not the other FAILS
+# that check. If you bump a version here, bump it in buildspec.yaml too (and vice
+# versa).
+
+images:
+  nccl-tests:
+    key: nccl-tests
+    context: micro-benchmarks/nccl-tests
+    dockerfile: nccl-tests.Dockerfile
+    ecr_repo: nccl-tests
+    platforms:
+      - amd64
+      - arm64
+    build_args:
+      CUDA_VERSION: "13.0.2"
+      GDRCOPY_VERSION: "v2.5.2"
+      EFA_INSTALLER_VERSION: "1.48.0"
+      AWS_OFI_NCCL_VERSION: "v1.19.0"
+      NCCL_VERSION: "v2.30.4-1"
+      NCCL_TESTS_VERSION: "v2.18.3"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,235 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Reusable workflow: build + (optionally) publish a single multi-arch container image
+# defined in .github/image-manifest.yaml to ECR Public (public.ecr.aws/hpc-cloud).
+#
+# Strategy:
+#   prepare  -> read the manifest entry for `image`, derive TAG and the --build-arg list
+#   build    -> matrix over arch, each on its native CodeBuild-hosted runner fleet,
+#               build + push-by-digest (push only on non-PR events), export the digest
+#   merge    -> assemble the multi-arch manifest list from the per-arch digests and
+#               tag it :<TAG> and :latest (skipped on pull_request)
+#
+# On pull_request the image is built for validation only and never pushed.
+
+name: build-image
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Image key in .github/image-manifest.yaml (e.g. nccl-tests)"
+        required: true
+        type: string
+
+# Reusable workflows run with the CALLER's permissions; these are restated in
+# release-images.yml. id-token is required for GitHub OIDC -> assume the existing
+# ECR-publish role (awslabs-AOSH-GitHubActionsRole). The job runs on a
+# CodeBuild-hosted runner, but the OIDC token still comes from GitHub, so this
+# works regardless of where the job executes.
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ECR_PUBLIC_REGISTRY: public.ecr.aws
+  ECR_PUBLIC_NAMESPACE: hpc-cloud
+  AWS_REGION: us-east-1
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      context: ${{ steps.manifest.outputs.context }}
+      dockerfile: ${{ steps.manifest.outputs.dockerfile }}
+      ecr_repo: ${{ steps.manifest.outputs.ecr_repo }}
+      platforms: ${{ steps.manifest.outputs.platforms }}
+      build_arg_flags: ${{ steps.manifest.outputs.build_arg_flags }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read manifest entry
+        id: manifest
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          MANIFEST=.github/image-manifest.yaml
+          if ! yq -e ".images.\"${IMAGE}\"" "${MANIFEST}" >/dev/null 2>&1; then
+            echo "::error::Image key '${IMAGE}' not found in ${MANIFEST}"
+            exit 1
+          fi
+          CONTEXT=$(yq -r ".images.\"${IMAGE}\".context" "${MANIFEST}")
+          DOCKERFILE=$(yq -r ".images.\"${IMAGE}\".dockerfile" "${MANIFEST}")
+          ECR_REPO=$(yq -r ".images.\"${IMAGE}\".ecr_repo" "${MANIFEST}")
+          # platforms -> compact JSON array consumed by the matrix via fromJSON()
+          PLATFORMS=$(yq -o=json -I=0 ".images.\"${IMAGE}\".platforms" "${MANIFEST}")
+          # build_args map -> "--build-arg K=V --build-arg ..." (image-agnostic; passes every arg)
+          BUILD_ARG_FLAGS=$(yq -r \
+            ".images.\"${IMAGE}\".build_args | to_entries | map(\"--build-arg \" + .key + \"=\" + .value) | join(\" \")" \
+            "${MANIFEST}")
+          {
+            echo "context=${CONTEXT}"
+            echo "dockerfile=${DOCKERFILE}"
+            echo "ecr_repo=${ECR_REPO}"
+            echo "platforms=${PLATFORMS}"
+            echo "build_arg_flags=${BUILD_ARG_FLAGS}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Derive image tag
+        id: tag
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          MANIFEST=.github/image-manifest.yaml
+          # Tag formula MUST match micro-benchmarks/nccl-tests/buildspec.yaml exactly:
+          #   cuda<CUDA>-efa<EFA>-ofi<OFI>-nccl<NCCL>-tests<TESTS>
+          # (GDRCOPY_VERSION is a build arg but is intentionally NOT part of the tag.)
+          CUDA=$(yq -r ".images.\"${IMAGE}\".build_args.CUDA_VERSION" "${MANIFEST}")
+          EFA=$(yq -r ".images.\"${IMAGE}\".build_args.EFA_INSTALLER_VERSION" "${MANIFEST}")
+          OFI=$(yq -r ".images.\"${IMAGE}\".build_args.AWS_OFI_NCCL_VERSION" "${MANIFEST}")
+          NCCL=$(yq -r ".images.\"${IMAGE}\".build_args.NCCL_VERSION" "${MANIFEST}")
+          TESTS=$(yq -r ".images.\"${IMAGE}\".build_args.NCCL_TESTS_VERSION" "${MANIFEST}")
+          TAG="cuda${CUDA}-efa${EFA}-ofi${OFI}-nccl${NCCL}-tests${TESTS}"
+          echo "Derived TAG=${TAG}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        # platforms manifest field -> e.g. ["amd64","arm64"]. We deliberately do
+        # NOT use a matrix `include:` to map arch->project, because an include row
+        # spawns a phantom job for an arch that isn't in `platforms` (a single-arch
+        # image would still get an arm64 job). Instead the runner project is
+        # derived inline from matrix.arch below, so the matrix is exactly the
+        # manifest's platform list.
+        arch: ${{ fromJSON(needs.prepare.outputs.platforms) }}
+    # IMAGE-AGNOSTIC, shared runner projects. These names MUST match the Terraform
+    # CodeBuild project names exactly (<project_name_prefix>-x86 / -arm, with
+    # project_name_prefix = "adai-image-builder"). See the GitLab repo's
+    # terraform/codebuild.tf. CodeBuild ignores the webhook on a name mismatch and
+    # the job hangs. The run_id/run_attempt suffix is mandatory for runner claim.
+    runs-on: codebuild-adai-image-builder-${{ matrix.arch == 'arm64' && 'arm' || 'x86' }}-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials (GitHub OIDC)
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          # Existing GitHub OIDC role, reused (already trusted by FSDP/megatron
+          # workflows). vars.ECR_PUBLISH_ROLE_ARN =
+          #   arn:aws:iam::159553542841:role/awslabs-AOSH-GitHubActionsRole
+          role-to-assume: ${{ vars.ECR_PUBLISH_ROLE_ARN }}
+
+      - name: Login to ECR Public
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          aws ecr-public get-login-password --region "${AWS_REGION}" \
+            | docker login --username AWS --password-stdin "${ECR_PUBLIC_REGISTRY}"
+
+      - name: Build and push by digest (${{ matrix.arch }})
+        id: build
+        env:
+          ECR_REPO: ${{ needs.prepare.outputs.ecr_repo }}
+          CONTEXT: ${{ needs.prepare.outputs.context }}
+          DOCKERFILE: ${{ needs.prepare.outputs.dockerfile }}
+          BUILD_ARG_FLAGS: ${{ needs.prepare.outputs.build_arg_flags }}
+          ARCH: ${{ matrix.arch }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${ECR_PUBLIC_REGISTRY}/${ECR_PUBLIC_NAMESPACE}/${ECR_REPO}"
+          if [ "${IS_PR}" = "true" ]; then
+            # Validation only: build the single arch, do not push, do not export a digest.
+            docker buildx build \
+              --platform "linux/${ARCH}" \
+              ${BUILD_ARG_FLAGS} \
+              -f "${CONTEXT}/${DOCKERFILE}" \
+              "${CONTEXT}"
+            echo "Pull request build complete (not pushed)."
+            exit 0
+          fi
+          # push-by-digest: emit a digest-only image (no tag) per arch; the merge job
+          # stitches the per-arch digests into a tagged manifest list.
+          docker buildx build \
+            --platform "linux/${ARCH}" \
+            ${BUILD_ARG_FLAGS} \
+            -f "${CONTEXT}/${DOCKERFILE}" \
+            --output "type=image,name=${IMAGE_REF},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file metadata.json \
+            "${CONTEXT}"
+          DIGEST=$(jq -r '."containerimage.digest"' metadata.json)
+          echo "Pushed ${IMAGE_REF}@${DIGEST}"
+          # Sanitize the digest into a filename (sha256:... -> sha256-...) for the artifact.
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [prepare, build]
+    if: github.event_name != 'pull_request'
+    # The merge is lightweight (manifest-list assembly only, no Docker build), so
+    # it runs on a standard GitHub-hosted runner. It uses the SAME GitHub OIDC
+    # role as the build jobs for the ECR Public push — single push principal.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Configure AWS credentials (GitHub OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.ECR_PUBLISH_ROLE_ARN }}
+
+      - name: Login to ECR Public
+        run: |
+          set -euo pipefail
+          aws ecr-public get-login-password --region "${AWS_REGION}" \
+            | docker login --username AWS --password-stdin "${ECR_PUBLIC_REGISTRY}"
+
+      - name: Create and push multi-arch manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          ECR_REPO: ${{ needs.prepare.outputs.ecr_repo }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${ECR_PUBLIC_REGISTRY}/${ECR_PUBLIC_NAMESPACE}/${ECR_REPO}"
+          # Each artifact filename is a bare digest (sha256:... with the prefix stripped);
+          # rebuild the per-arch source references for the manifest list.
+          SOURCES=$(printf "${IMAGE_REF}@sha256:%s " *)
+          echo "Creating ${IMAGE_REF}:${TAG} and :latest from: ${SOURCES}"
+          docker buildx imagetools create \
+            -t "${IMAGE_REF}:${TAG}" \
+            -t "${IMAGE_REF}:latest" \
+            ${SOURCES}
+          docker buildx imagetools inspect "${IMAGE_REF}:${TAG}"

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,145 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Caller workflow that fans out to the reusable build-image.yml for each image.
+#
+# Triggers:
+#   - pull_request: build-only validation (no push) of changed images
+#   - push to main with per-image path filters (only the changed image rebuilds)
+#   - workflow_dispatch with a dropdown to pick a single image
+#   - release tags (build/publish all images for the release)
+#
+# The reusable build-image.yml skips push on pull_request, so the PR jobs below
+# validate the Docker build without publishing.
+
+name: release-images
+
+on:
+  pull_request:
+    paths:
+      - "micro-benchmarks/nccl-tests/**"
+      - ".github/image-manifest.yaml"
+      - ".github/workflows/build-image.yml"
+      - ".github/workflows/release-images.yml"
+  push:
+    branches:
+      - main
+    # Top-level paths gate the whole workflow run. With a single image today this is
+    # sufficient; the per-image dispatch below uses a paths-filter job so that adding
+    # more images rebuilds only the one that changed.
+    paths:
+      - "micro-benchmarks/nccl-tests/**"
+      - ".github/image-manifest.yaml"
+      - ".github/workflows/build-image.yml"
+      - ".github/workflows/release-images.yml"
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Which image to build and publish"
+        required: true
+        type: choice
+        options:
+          - nccl-tests
+  release:
+    types:
+      - published
+
+# Reusable workflows inherit the caller's permissions and can only narrow them,
+# so the OIDC permission MUST be granted here for the downstream ECR Public
+# push (assume awslabs-AOSH-GitHubActionsRole) to succeed.
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  # ---- D1: version source-of-truth parity gate ----
+  # The manifest (.github/image-manifest.yaml) and the manual-fallback buildspec
+  # (micro-benchmarks/nccl-tests/buildspec.yaml) both carry the six versions.
+  # This job FAILS if they disagree, so a PR that bumps one but not the other
+  # cannot merge. It also closes the cutover-validation gap (D2): a PR that edits
+  # only buildspec.yaml will fail here until the manifest is updated to match.
+  manifest-buildspec-parity:
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assert manifest versions equal buildspec versions
+        run: |
+          set -euo pipefail
+          MANIFEST=.github/image-manifest.yaml
+          BUILDSPEC=micro-benchmarks/nccl-tests/buildspec.yaml
+          fail=0
+          for KEY in CUDA_VERSION GDRCOPY_VERSION EFA_INSTALLER_VERSION \
+                     AWS_OFI_NCCL_VERSION NCCL_VERSION NCCL_TESTS_VERSION; do
+            M=$(yq -r ".images.\"nccl-tests\".build_args.${KEY}" "${MANIFEST}")
+            B=$(yq -r ".env.variables.${KEY}" "${BUILDSPEC}")
+            if [ "${M}" != "${B}" ]; then
+              echo "::error file=${MANIFEST}::${KEY} mismatch: manifest='${M}' buildspec='${B}'"
+              fail=1
+            else
+              echo "OK ${KEY}=${M}"
+            fi
+          done
+          if [ "${fail}" -ne 0 ]; then
+            echo "::error::manifest and buildspec versions disagree; sync both files."
+            exit 1
+          fi
+
+  # Detect which images changed (push to main OR pull_request) so the fan-out
+  # only fires for the affected images.
+  changes:
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      nccl-tests: ${{ steps.filter.outputs.nccl-tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            nccl-tests:
+              - 'micro-benchmarks/nccl-tests/**'
+              - '.github/image-manifest.yaml'
+
+  # ---- pull_request: validate the build of changed images (no push) ----
+  pr-nccl-tests:
+    needs: [changes, manifest-buildspec-parity]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.nccl-tests == 'true'
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: nccl-tests
+    permissions:
+      id-token: write
+      contents: read
+
+  # ---- push to main: rebuild changed images only ----
+  push-nccl-tests:
+    needs: [changes, manifest-buildspec-parity]
+    if: github.event_name == 'push' && needs.changes.outputs.nccl-tests == 'true'
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: nccl-tests
+    permissions:
+      id-token: write
+      contents: read
+
+  # ---- workflow_dispatch: build the single chosen image ----
+  dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: ${{ inputs.image }}
+    permissions:
+      id-token: write
+      contents: read
+
+  # ---- release published: build/publish every image ----
+  release-nccl-tests:
+    if: github.event_name == 'release'
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: nccl-tests
+    permissions:
+      id-token: write
+      contents: read


### PR DESCRIPTION
## What

Adds a reusable, manifest-driven GitHub Actions pipeline that builds and publishes the `hpc-cloud`
container images, wired up for **nccl-tests** as the first image.

- `.github/image-manifest.yaml` — per-image build args + tag inputs (source of truth for `nccl-tests`).
- `.github/workflows/build-image.yml` — reusable (`workflow_call`): `prepare → build (arch matrix) → merge`.
  Heavy builds run on **CodeBuild-hosted GitHub Actions runners** (native x86 + Graviton fleets,
  privileged), each arch pushes **by digest**, then a `merge` job assembles the multi-arch manifest list
  and tags `:<TAG>` + `:latest`.
- `.github/workflows/release-images.yml` — caller: PR / push-to-main (path-filtered) / `workflow_dispatch` /
  release triggers, plus a `manifest-buildspec-parity` gate that fails the run if the six versions drift
  between the manifest and `micro-benchmarks/nccl-tests/buildspec.yaml`.

For `nccl-tests` this publishes
`public.ecr.aws/hpc-cloud/nccl-tests:cuda13.0.2-efa1.48.0-ofiv1.19.0-ncclv2.30.4-1-testsv2.18.3` (+ `:latest`),
multi-arch amd64 + arm64.

## Why

The per-image CodePipelines that previously published these images pulled source via **GitHub v1 OAuth**
source actions, which broke when this repo was transferred/renamed
(`aws-samples/awsome-distributed-training` → `awslabs/awsome-distributed-ai`). The last successful
`nccl-tests` publish was 2026-02-20; the CUDA-13 image was never built. Moving the pipeline to GitHub
Actions makes build status visible on the PR and removes the deprecated OAuth integration.

## ⚠️ Merge order / dependencies (why this is a draft)

The build jobs **cannot succeed until** the supporting AWS infrastructure is in place:

1. The **CodeBuild runner projects/fleets** (`adai-image-builder-{x86,arm}`), their `WORKFLOW_JOB_QUEUED`
   webhooks, and the ECR-Public push policy — provisioned by Terraform in the internal infra repo.
2. The repo variable **`ECR_PUBLISH_ROLE_ARN`** set to
   `arn:aws:iam::159553542841:role/awslabs-AOSH-GitHubActionsRole`.

The `manifest-buildspec-parity` job runs on `ubuntu-latest` and is safe to run immediately. Mark this PR
ready (`gh pr ready`) once the infra is applied and validated on `nccl-tests`.

## Validation

- `build-image.yml` / `release-images.yml` / `image-manifest.yaml` are YAML-valid; tag derivation matches
  `buildspec.yaml` byte-for-byte; the parity gate covers all six versions (incl. `GDRCOPY_VERSION`).
