### PR TITLE
Updated version for Deepspeed

### DIFF
--- a/3.test_cases/pytorch/deepspeed/0.deepspeed.dockerfile
+++ b/3.test_cases/pytorch/deepspeed/0.deepspeed.dockerfile
@@ -7,7 +7,11 @@
 # ============================================================
 FROM nvcr.io/nvidia/pytorch:25.04-py3
 
-ARG TRANSFORMERS_VERSION=4.44.2
+ARG TRANSFORMERS_VERSION=4.52.0
+ARG ACCELERATE_VERSION=1.6.0
+ARG DEEPSPEED_VERSION=0.16.4
+ARG PYNVML_VERSION=12.0.0
+ARG SENTENCEPIECE_VERSION=0.2.0
 ARG OPEN_MPI_PATH=/opt/amazon/openmpi
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -144,10 +148,12 @@ RUN mv ${OPEN_MPI_PATH}/bin/mpirun ${OPEN_MPI_PATH}/bin/mpirun.real \
 # 9. Python packages for DeepSpeed training
 # ============================================================
 RUN pip3 install --no-cache-dir \
-    awscli pynvml \
+    awscli \
+    pynvml==${PYNVML_VERSION} \
     transformers==${TRANSFORMERS_VERSION} \
-    sentencepiece python-etcd \
-    deepspeed>=0.16,<1.0 accelerate>=1.0,<2.0
+    sentencepiece==${SENTENCEPIECE_VERSION} \
+    deepspeed==${DEEPSPEED_VERSION} \
+    accelerate==${ACCELERATE_VERSION}
 
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/3.test_cases/pytorch/deepspeed/0.deepspeed.dockerfile
+++ b/3.test_cases/pytorch/deepspeed/0.deepspeed.dockerfile
@@ -12,6 +12,7 @@ ARG ACCELERATE_VERSION=1.6.0
 ARG DEEPSPEED_VERSION=0.16.4
 ARG PYNVML_VERSION=12.0.0
 ARG SENTENCEPIECE_VERSION=0.2.0
+ARG AWSCLI_MIN_VERSION=2.0.0
 ARG OPEN_MPI_PATH=/opt/amazon/openmpi
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -148,7 +149,7 @@ RUN mv ${OPEN_MPI_PATH}/bin/mpirun ${OPEN_MPI_PATH}/bin/mpirun.real \
 # 9. Python packages for DeepSpeed training
 # ============================================================
 RUN pip3 install --no-cache-dir \
-    awscli \
+    "awscli>=${AWSCLI_MIN_VERSION}" \
     pynvml==${PYNVML_VERSION} \
     transformers==${TRANSFORMERS_VERSION} \
     sentencepiece==${SENTENCEPIECE_VERSION} \

--- a/3.test_cases/pytorch/deepspeed/README.md
+++ b/3.test_cases/pytorch/deepspeed/README.md
@@ -72,7 +72,8 @@ The benchmark uses preprocessed data in Megatron format with the GPT-2 tokenizer
    ```bash
    git clone https://github.com/microsoft/Megatron-DeepSpeed /fsx/deepspeed/Megatron-DeepSpeed
 
-   python3 /fsx/deepspeed/Megatron-DeepSpeed/tools/preprocess_data.py \
+    enroot start --rw /fsx/apps/deepspeed.sqsh \
+    python3 /fsx/deepspeed/Megatron-DeepSpeed/tools/preprocess_data.py \
        --input synthetic_corpus.json \
        --output-prefix BookCorpusDataset_text_document \
        --vocab-file gpt2-vocab.json \


### PR DESCRIPTION
## Purpose

Update the DeepSpeed test case to align with current library versions. The previous test relied on outdated dependencies that are no longer compatible, causing failures. This PR updates the test configuration to restore passing status.

## Changes
- Updated the TRANSFORMERS_VERSION to 4.52.0 from 4.44.0
- Updated an AWS CLI command to properly launch with new code versions
- Changed DeepSpeed Test Case README.md to properly use enroot to start the container.
- Removed Python-etcd as it is not needed with Slurm and python-etcd is abandoned (last release 2019) with no Python 3.12 support.
- Pinned to AWS CLI minimum version of 2.0 as v1 is in Maintenance Mode starting on July 15th, 2026.

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service: SageMaker Hyperpod w/ Slurm Orchestration
- Instance type: Used ml.g6.4xlarge for the compute instance type
- Number of nodes: 1 compute node. 

**Test commands:**
- Followed the README.md for the test case. 

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── pytorch/                # e.g. pytorch, megatron, jax
    └── deepspeed/              # e.g. picotron, FSDP, megatron-lm
        └── example_megatron_deepspeed/
         |_____ gpt
         |_____ qlora
        ├── 0.deepspeed.dockerfile      # Container / environment setup
        ├── README.md       # Overview, prerequisites, usage
        ├── 1.buildimage.sbatch
        ├── MakeFile




## Checklist

- [X] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [X] I am working against the latest `main` branch.
- [X] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [X] The contribution is self-contained with documentation and scripts.
- [X] External dependencies are pinned to a specific version or tag (no `latest`).
- [X] A README is included or updated with prerequisites, instructions, and known issues.
- [X} New test cases follow the [expected directory structure](#directory-structure).
