### PR TITLE
Fix lcs u24 hotfix

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/hotfix/enabling-slurm-25.md
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/hotfix/enabling-slurm-25.md
@@ -1,0 +1,1 @@
+# Enabling Slurm 25

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/hotfix/enabling-slurm-25.md
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/hotfix/enabling-slurm-25.md
@@ -1,1 +1,0 @@
-# Enabling Slurm 25

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/hotfix/mock-gpu-driver-deb.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/hotfix/mock-gpu-driver-deb.sh
@@ -9,17 +9,30 @@ MOCK_PKG=libnvidia-compute-${DRV_VERSION_MAJOR}
 #apt-get -y -o DPkg::Lock::Timeout=120 update   # Most likely this has been been done by another script.
 apt-get -y -o DPkg::Lock::Timeout=120 install equivs
 
-# Try different package revision suffixes to find the correct one
+# 1) Try exact-patch match first (preferred: mock matches the running kmod exactly).
 for SUFFIX in "-1ubuntu1" "-0ubuntu1" ""; do
     if apt-cache show ${MOCK_PKG}=${DRV_VERSION}${SUFFIX} 2>/dev/null | egrep '^Package|^Version|^Provides' &> ${MOCK_PKG}; then
-        echo "Found package with suffix: ${SUFFIX}"
+        echo "Found exact match for ${DRV_VERSION} with suffix: ${SUFFIX}"
         break
     fi
 done
 
-# Check if we successfully created the control file
+# 2) Fallback: kmod patch version isn't in apt-cache (e.g. AMI kmod 595.58.03 but
+#    apt only has 595.71.05). Use the latest candidate for the same major and
+#    rewrite Version: to the kmod's value so pins on the kmod patch still resolve.
 if [ ! -s ${MOCK_PKG} ]; then
-    echo "Error: Could not find package ${MOCK_PKG} with version ${DRV_VERSION} in apt-cache"
+    LATEST_VERSION=$(apt-cache policy ${MOCK_PKG} 2>/dev/null | awk '/Candidate:/ {print $2}')
+    if [ -n "${LATEST_VERSION}" ] && [ "${LATEST_VERSION}" != "(none)" ]; then
+        echo "Exact ${DRV_VERSION} not in apt-cache; falling back to candidate ${LATEST_VERSION} and rewriting Version to ${DRV_VERSION}"
+        apt-cache show ${MOCK_PKG}=${LATEST_VERSION} \
+            | egrep '^Package|^Version|^Provides' \
+            | sed "s/^Version:.*/Version: ${DRV_VERSION}/" \
+            > ${MOCK_PKG}
+    fi
+fi
+
+if [ ! -s ${MOCK_PKG} ]; then
+    echo "Error: Could not find any ${MOCK_PKG} in apt-cache (kmod version ${DRV_VERSION})"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Make `mock-gpu-driver-deb.sh` resilient when the running NVIDIA kmod version isn't published in apt. Today the script hard-fails if `apt-cache show libnvidia-compute-${MAJOR}=${DRV_VERSION}` misses, which blocks HyperPod cluster lifecycle scripts on
AMIs whose kmod patch lags or leads what apt currently ships.

## Motivation

Observed on a Slurm cluster (Ubuntu 24.04 AMI) where `modinfo -F version nvidia` reported `595.58.03`, but apt only had `libnvidia-compute-595` candidate `595.71.05-0ubuntu0.24.04.1`. All three exact-match attempts (`-1ubuntu1`, `-0ubuntu1`, ``) missed
and the lifecycle script exited 1 on every node:

Error: Could not find package libnvidia-compute-595 with version 595.58.03 in apt-cache
[SageMaker] The lifecycle scripts failed.

## Change

- Keep the existing exact-patch lookup as the preferred path (no behavior change on AMIs that already work).
- Add a fallback: if no exact match, fetch the latest `libnvidia-compute-${MAJOR}` candidate via `apt-cache policy`, build the equivs control file from it, and rewrite `Version:` to the running kmod's version so any downstream pins on the kmod patch
still resolve.
- Keep the original error message path for the case where apt has no candidate at all.

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
