### PR TITLE
Add sagemaker_ftp tool to find available SageMaker training plan offe…

### DIFF
--- a/2.ami_and_containers/tools/sagemaker_ftp/README.md
+++ b/2.ami_and_containers/tools/sagemaker_ftp/README.md
@@ -1,0 +1,290 @@
+# SageMaker FTP Finder
+
+A small Bash helper that searches for available
+**Amazon SageMaker Flexible Training Plan (FTP)** offerings, scoped to a
+specific Availability Zone, and recommends the offering with the lowest
+effective `$/instance/hour`.
+
+Supports both:
+
+- **SageMaker HyperPod clusters** (Slurm or EKS) — default
+- **SageMaker training jobs** — via `--target training-job`
+
+It wraps `aws sagemaker search-training-plan-offerings` and sweeps a
+configurable set of reservation durations (default: 24 h, 48 h, 72 h,
+1 wk, 2 wk, 30 d), since that API filters strictly on duration.
+
+## Why this helper?
+
+`SearchTrainingPlanOfferings` only returns offerings whose duration matches
+your `--duration-hours` value exactly — there is no "show me everything"
+mode. To see the full picture of what's available right now in an AZ, you
+need to call the API once per duration and merge the results. This script
+does that and ranks the matches by effective per-instance hourly rate.
+
+## Prerequisites
+
+1. **AWS CLI v2** on `PATH` — see
+   [installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+2. **jq** on `PATH`
+   - macOS: `brew install jq`
+   - Ubuntu/Debian: `sudo apt-get install jq`
+   - Amazon Linux / RHEL: `sudo yum install jq`
+3. **AWS credentials** configured (any one of):
+   - Default profile: `aws configure`
+   - Named profile: `aws configure --profile <NAME>` (then pass `--profile <NAME>`)
+   - Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+   - EC2 instance role / SSO
+4. **IAM permission** on the calling principal:
+   - `sagemaker:SearchTrainingPlanOfferings`
+   - To later purchase a plan: `sagemaker:CreateTrainingPlan`
+5. **(Optional) SageMaker reserved-capacity quota** for the requested
+   instance type. If `--count` exceeds your quota, the API returns
+   `ResourceLimitExceeded` for that duration and the script silently skips
+   it.
+
+## Usage
+
+```
+./find-ftp.sh --az <AZ> --instance-type <ML_INSTANCE_TYPE> \
+              --count <N> --region <REGION> \
+              [--start-after <ISO8601_UTC>] [--profile <AWS_PROFILE>] \
+              [--target hyperpod-cluster|training-job] \
+              [--durations <H1,H2,...>] [--json]
+```
+
+Run `./find-ftp.sh --help` for the built-in help.
+
+### Required arguments
+
+| Flag | Description | Example |
+|---|---|---|
+| `--az` | Availability Zone name | `us-west-2b` |
+| `--instance-type` | SageMaker instance type (with `ml.` prefix) | `ml.p5.48xlarge` |
+| `--count` | Number of instances to reserve (integer > 0) | `2` |
+| `--region` | AWS region | `us-west-2` |
+
+### Optional arguments
+
+| Flag | Description | Default |
+|---|---|---|
+| `--start-after` | Earliest acceptable start time (ISO-8601 UTC) | now |
+| `--profile` | Named AWS CLI profile for credentials | default credential resolution |
+| `--target` | Target resource: `hyperpod-cluster` or `training-job` | `hyperpod-cluster` |
+| `--durations` | Comma-separated durations (hours) to probe | `24,48,72,168,336,720` |
+| `--json` | Emit machine-readable JSON to stdout | off |
+| `-h`, `--help` | Show help and exit | — |
+
+### Supported instance types
+
+Anything `SearchTrainingPlanOfferings` accepts, currently including:
+
+- `ml.p4d.24xlarge`, `ml.p4de.24xlarge`
+- `ml.p5.4xlarge`, `ml.p5.48xlarge`
+- `ml.p5e.48xlarge`, `ml.p5en.48xlarge`
+- `ml.p6-b200.48xlarge`, `ml.p6-b300.48xlarge`
+- `ml.p6e-gb200.36xlarge`
+- `ml.trn1.32xlarge`, `ml.trn2.48xlarge`
+
+Run `aws sagemaker search-training-plan-offerings help` for the most
+current list.
+
+## Examples
+
+### 1. Default target (HyperPod cluster) with default credentials
+
+```bash
+./find-ftp.sh \
+  --az us-west-2b \
+  --instance-type ml.p5.48xlarge \
+  --count 2 \
+  --region us-west-2 \
+  --start-after 2026-06-15T00:00:00Z
+```
+
+### 2. Search for SageMaker training-job capacity
+
+```bash
+./find-ftp.sh \
+  --az us-west-2b \
+  --instance-type ml.p5.48xlarge \
+  --count 2 \
+  --region us-west-2 \
+  --start-after 2026-06-15T00:00:00Z \
+  --target training-job
+```
+
+### 3. Named AWS profile, custom durations
+
+```bash
+./find-ftp.sh \
+  --az us-west-2b \
+  --instance-type ml.p6-b200.48xlarge \
+  --count 2 \
+  --region us-west-2 \
+  --start-after 2026-06-15T00:00:00Z \
+  --profile my-aws-profile \
+  --durations 24,48,168
+```
+
+### 4. Machine-readable JSON
+
+```bash
+./find-ftp.sh \
+  --az us-west-2b --instance-type ml.p5.48xlarge \
+  --count 2 --region us-west-2 --json | jq '.recommendation'
+```
+
+JSON shape:
+
+```json
+{
+  "query": {
+    "availability_zone": "us-west-2b",
+    "instance_type": "ml.p5.48xlarge",
+    "instance_count": 2,
+    "region": "us-west-2",
+    "start_after": "2026-06-15T00:00:00Z",
+    "target_resources": "hyperpod-cluster",
+    "durations_hours": [24, 48, 72, 168, 336, 720]
+  },
+  "count": 9,
+  "offerings": [ /* sorted by per_inst_hr ascending */ ],
+  "recommendation": { /* the cheapest offering, or null */ }
+}
+```
+
+## Sample output (text mode)
+
+```
+Searching SageMaker FTP offerings:
+  AZ:             us-west-2b
+  Instance type:  ml.p5.48xlarge
+  Count:          2
+  Region:         us-west-2
+  Start after:    2026-06-15T00:00:00Z
+  Target:         hyperpod-cluster
+  Profile:        <default>
+  Durations (h):  24 48 72 168 336 720
+
+Found 9 matching offering(s) in us-west-2b:
+
+OFFERING_ID                                          DUR(h)      UPFRONT  $/inst/hr   START (UTC)          END (UTC)
+--------------------------------------------------   ------ ------------ ----------   -------------------- --------------------
+tpo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx..       24      1830.76      38.14   2026-06-15 11:30     2026-06-16 11:30
+tpo-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy..       48      3741.12      38.97   2026-06-15 11:30     2026-06-17 11:30
+...
+
+Recommendation (lowest $/instance/hour):
+  Offering ID:  tpo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  Duration:     24 h
+  AZ:           us-west-2b
+  Upfront fee:  1830.76 USD
+  Effective:    $38.14 / instance / hour
+  Window:       2026-06-15 11:30 UTC -> 2026-06-16 11:30 UTC
+
+To purchase this offering (NON-REFUNDABLE; charges the upfront fee immediately):
+  aws sagemaker create-training-plan \
+    --region us-west-2 \
+    --training-plan-name <YOUR_PLAN_NAME> \
+    --training-plan-offering-id tpo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## How it works
+
+1. For each duration in the sweep list, the script calls:
+
+   ```
+   aws sagemaker search-training-plan-offerings \
+     --region <REGION> \
+     --instance-type <INSTANCE_TYPE> \
+     --instance-count <COUNT> \
+     --start-time-after <START_AFTER> \
+     --duration-hours <DUR> \
+     --target-resources hyperpod-cluster
+   ```
+
+2. Filters returned offerings to those whose `ReservedCapacityOfferings[].AvailabilityZone` matches `--az`.
+
+3. Computes `$/instance/hour = UpfrontFee / (DurationHours * InstanceCount)`.
+
+4. Prints the matches as a table (text mode) or JSON (`--json`), and surfaces
+   the offering with the lowest `$/instance/hour` along with a ready-to-run
+   `create-training-plan` command.
+
+The script never purchases anything. To actually reserve the capacity you
+must run the printed `create-training-plan` command yourself.
+
+## Choosing a target resource
+
+Training plans are pinned to a target resource at purchase time and cannot
+be reused across targets:
+
+| `--target` value | Use for |
+|---|---|
+| `hyperpod-cluster` (default) | HyperPod clusters orchestrated by Slurm or EKS. The plan provides compute to a cluster instance group. |
+| `training-job` | Standalone SageMaker training jobs scheduled and run via the SageMaker training jobs API. |
+
+Pick the target that matches how you intend to consume the capacity. The
+two pools are separate, so an empty result with one target does not imply
+the other is also empty — try both if you have flexibility.
+
+## Interpreting empty results
+
+`No offerings found ...` usually means one of the following:
+
+- No capacity is currently being offered in that AZ for those parameters.
+- Your account-level reserved-capacity quota for that instance type is
+  below `--count`, so the API returned `ResourceLimitExceeded` for every
+  duration (silently skipped).
+- The `--start-after` window is too narrow.
+
+Things to try:
+
+1. A different AZ in the same region.
+2. A smaller `--count`.
+3. A later `--start-after`.
+4. A different `--region`.
+5. The other `--target` (e.g. switch from `hyperpod-cluster` to
+   `training-job` or vice versa) — the two capacity pools are separate.
+6. Different durations, e.g. `--durations 96,240,480`.
+7. Request a quota increase via AWS Service Quotas for the relevant
+   `<INSTANCE_TYPE> for cluster usage` quota.
+
+## Important notes
+
+- **Purchase is non-refundable.** `create-training-plan` charges the
+  upfront fee immediately and cannot be cancelled. This script intentionally
+  only prints the command — it never runs it for you.
+- **Single-AZ requirement for EFA workloads.** HyperPod jobs that use EFA
+  (e.g. `p4d`, `p5`, `p6-b200`, `trn1`) require all instances to be in the
+  same AZ. The AZ you pass here is where the reservation lives.
+- **Duration filter is strict.** The API does not return offerings with
+  durations other than the value passed via `--duration-hours`. Use
+  `--durations` to override the default sweep list if you need a duration
+  not covered by the defaults.
+- **AZ names vs AZ IDs.** AZ names like `us-west-2b` are scoped to your
+  account — the same name maps to different physical AZs in different
+  accounts. To compare across accounts, use AZ IDs:
+  ```bash
+  aws ec2 describe-availability-zones --region us-west-2 \
+    --query 'AvailabilityZones[].[ZoneName,ZoneId]' --output table
+  ```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `aws CLI not found on PATH` | AWS CLI not installed | Install AWS CLI v2 |
+| `jq not found on PATH` | `jq` not installed | `brew install jq` / `apt-get install jq` |
+| `Unable to locate credentials` | No AWS credentials resolved | Configure a profile or set env vars; use `--profile` |
+| `AccessDeniedException` | Missing IAM permission | Grant `sagemaker:SearchTrainingPlanOfferings` |
+| Result table is empty | No matching capacity / quota too low | Try different AZ, smaller `--count`, later start, or request quota |
+| Same offering shown multiple times across durations | Different reservation windows / capacity blocks | Expected — each duration is searched independently |
+
+## References
+
+- [SageMaker Training Plans overview](https://docs.aws.amazon.com/sagemaker/latest/dg/reserve-capacity-with-training-plans.html)
+- [SearchTrainingPlanOfferings API reference](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_SearchTrainingPlanOfferings.html)
+- [CreateTrainingPlan API reference](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingPlan.html)
+- [SageMaker HyperPod documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)

--- a/2.ami_and_containers/tools/sagemaker_ftp/README.md
+++ b/2.ami_and_containers/tools/sagemaker_ftp/README.md
@@ -50,7 +50,7 @@ does that and ranks the matches by effective per-instance hourly rate.
               --count <N> --region <REGION> \
               [--start-after <ISO8601_UTC>] [--profile <AWS_PROFILE>] \
               [--target hyperpod-cluster|training-job] \
-              [--durations <H1,H2,...>] [--json]
+              [--durations <H1,H2,...>] [--json] [--verbose]
 ```
 
 Run `./find-ftp.sh --help` for the built-in help.
@@ -73,6 +73,7 @@ Run `./find-ftp.sh --help` for the built-in help.
 | `--target` | Target resource: `hyperpod-cluster` or `training-job` | `hyperpod-cluster` |
 | `--durations` | Comma-separated durations (hours) to probe | `24,48,72,168,336,720` |
 | `--json` | Emit machine-readable JSON to stdout | off |
+| `--verbose` | Print the full AWS error text to stderr when a per-duration call fails | off |
 | `-h`, `--help` | Show help and exit | — |
 
 ### Supported instance types
@@ -154,6 +155,18 @@ JSON shape:
 }
 ```
 
+### 5. Verbose error output (debugging)
+
+```bash
+./find-ftp.sh \
+  --az us-west-2b --instance-type ml.p5.48xlarge \
+  --count 2 --region us-west-2 --verbose
+```
+
+Without `--verbose`, transient or configuration errors per duration appear
+as a single `WARNING:` line. With `--verbose`, the full AWS error text is
+also printed (to stderr) so you can see exactly what failed.
+
 ## Sample output (text mode)
 
 ```
@@ -166,6 +179,7 @@ Searching SageMaker FTP offerings:
   Target:         hyperpod-cluster
   Profile:        <default>
   Durations (h):  24 48 72 168 336 720
+  Verbose:        off
 
 Found 9 matching offering(s) in us-west-2b:
 
@@ -214,6 +228,23 @@ To purchase this offering (NON-REFUNDABLE; charges the upfront fee immediately):
 
 The script never purchases anything. To actually reserve the capacity you
 must run the printed `create-training-plan` command yourself.
+
+## Error handling per duration
+
+The script calls the API once per duration in the sweep list. Failures are
+classified and reported as follows:
+
+| Outcome | Default behavior | With `--verbose` |
+|---|---|---|
+| Success, has offerings | Process them | Same |
+| Success, no offerings | Skip silently | Same |
+| `ResourceLimitExceeded` (account quota below requested count) | One-line `Note:` to stderr, then continue | Same + full AWS error text |
+| Any other error (expired creds, throttling, invalid region, service outage, etc.) | One-line `WARNING:` to stderr, then continue | Same + full AWS error text |
+
+This means a real configuration problem (e.g. expired credentials) will not
+silently masquerade as "no offerings found" — you'll see a `WARNING:` line
+explaining what happened. Use `--verbose` if you need the full AWS error
+output to debug further.
 
 ## Choosing a target resource
 
@@ -277,9 +308,12 @@ Things to try:
 |---|---|---|
 | `aws CLI not found on PATH` | AWS CLI not installed | Install AWS CLI v2 |
 | `jq not found on PATH` | `jq` not installed | `brew install jq` / `apt-get install jq` |
-| `Unable to locate credentials` | No AWS credentials resolved | Configure a profile or set env vars; use `--profile` |
-| `AccessDeniedException` | Missing IAM permission | Grant `sagemaker:SearchTrainingPlanOfferings` |
-| Result table is empty | No matching capacity / quota too low | Try different AZ, smaller `--count`, later start, or request quota |
+| `WARNING: ... Unable to locate credentials` | No AWS credentials resolved | Configure a profile or set env vars; use `--profile` |
+| `WARNING: ... AccessDeniedException` | Missing IAM permission | Grant `sagemaker:SearchTrainingPlanOfferings` |
+| `WARNING: ... ThrottlingException` | API rate-limited transiently | Retry; if persistent, run with fewer durations |
+| `WARNING: ... Could not connect to the endpoint URL` | Invalid `--region` or network issue | Check the region name; try `--verbose` for details |
+| `Note: ... ResourceLimitExceeded` for every duration | Account quota for the instance type is below `--count` | Lower `--count`, or request a quota increase via Service Quotas |
+| Result table is empty (no `Note:` or `WARNING:` lines) | No matching capacity in that AZ | Try different AZ, smaller `--count`, later start, different durations |
 | Same offering shown multiple times across durations | Different reservation windows / capacity blocks | Expected — each duration is searched independently |
 
 ## References

--- a/2.ami_and_containers/tools/sagemaker_ftp/find-ftp.sh
+++ b/2.ami_and_containers/tools/sagemaker_ftp/find-ftp.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# find-ftp.sh
+#
+# Find available Amazon SageMaker Flexible Training Plan (FTP) offerings
+# for a SageMaker HyperPod cluster (Slurm or EKS) or for SageMaker training
+# jobs, scoped to a specific Availability Zone. Sweeps common reservation
+# durations and recommends the offering with the lowest effective
+# $/instance/hour.
+#
+# -----------------------------------------------------------------------------
+# PREREQUISITES
+# -----------------------------------------------------------------------------
+#   1. AWS CLI v2 installed and on PATH
+#        https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+#   2. jq installed and on PATH
+#        macOS:  brew install jq
+#        Linux:  sudo apt-get install jq   (or your package manager equivalent)
+#   3. AWS credentials configured (default profile, named profile, or env vars)
+#        aws configure                  # default profile
+#        aws configure --profile NAME   # named profile (use with --profile)
+#   4. IAM permission on the calling principal:
+#        sagemaker:SearchTrainingPlanOfferings
+#      To later purchase a plan you also need:
+#        sagemaker:CreateTrainingPlan
+#   5. (Optional) Sufficient SageMaker reserved-capacity quota for the
+#      requested instance type. If the requested instance count exceeds your
+#      quota, the API returns ResourceLimitExceeded for that duration.
+#
+# This script applies to both HyperPod Slurm and HyperPod EKS clusters; the
+# training plan target resource is the same (`hyperpod-cluster`) in both cases.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+# Default durations (hours) to probe. SearchTrainingPlanOfferings filters
+# strictly on --duration-hours, so we sweep common reservation lengths.
+# Override via --durations.
+DEFAULT_DURATIONS=(24 48 72 168 336 720)
+
+# Default target resource. Override via --target.
+# Valid values: hyperpod-cluster (default), training-job.
+DEFAULT_TARGET_RESOURCE="hyperpod-cluster"
+
+usage() {
+  cat <<EOF
+$SCRIPT_NAME — Find available SageMaker Flexible Training Plan (FTP)
+offerings in a specific Availability Zone, and recommend the cheapest option.
+
+Supports both HyperPod clusters (Slurm or EKS) and SageMaker training jobs
+via the --target flag. Defaults to hyperpod-cluster.
+
+USAGE:
+  $SCRIPT_NAME --az <AZ> --instance-type <ML_INSTANCE_TYPE> \\
+               --count <N> --region <REGION> \\
+               [--start-after <ISO8601_UTC>] [--profile <AWS_PROFILE>] \\
+               [--target hyperpod-cluster|training-job] \\
+               [--durations <H1,H2,...>] [--json]
+
+REQUIRED ARGUMENTS:
+  --az              Availability Zone name, e.g. us-west-2b
+  --instance-type   SageMaker instance type with ml. prefix, e.g. ml.p5.48xlarge
+  --count           Number of instances to reserve (integer > 0)
+  --region          AWS region, e.g. us-west-2
+
+OPTIONAL ARGUMENTS:
+  --start-after     Earliest acceptable start time, ISO-8601 UTC.
+                    Default: now (e.g. 2026-06-15T00:00:00Z)
+  --profile         Named AWS CLI profile to use for credentials.
+                    Default: whatever the AWS CLI resolves (env vars,
+                    default profile, instance role, etc.)
+  --target          Target resource for the training plan. One of:
+                      hyperpod-cluster   (default; HyperPod Slurm or EKS)
+                      training-job       (SageMaker training jobs)
+  --durations       Comma-separated list of durations (in hours) to probe.
+                    Default: ${DEFAULT_DURATIONS[*]// /,}
+                    Example: --durations 24,168,720
+  --json            Emit machine-readable JSON to stdout instead of the
+                    human-readable table. Status messages still go to stderr.
+  -h, --help        Show this help message and exit.
+
+WHAT IT DOES:
+  1. Calls aws sagemaker search-training-plan-offerings for each duration
+     with --target-resources <TARGET>.
+  2. Filters offerings to the Availability Zone you specified.
+  3. Computes effective \$/instance/hour for each offering.
+  4. Prints all matches as a table (or JSON with --json).
+  5. Recommends the lowest \$/instance/hour offering and prints a ready-to-run
+     create-training-plan command for it (text mode only).
+
+EXAMPLES:
+  # Search for 2x p5.48xlarge for a HyperPod cluster (default target)
+  $SCRIPT_NAME --az us-west-2b --instance-type ml.p5.48xlarge \\
+               --count 2 --region us-west-2 \\
+               --start-after 2026-06-15T00:00:00Z
+
+  # Same query, but for SageMaker training jobs instead of HyperPod
+  $SCRIPT_NAME --az us-west-2b --instance-type ml.p5.48xlarge \\
+               --count 2 --region us-west-2 \\
+               --start-after 2026-06-15T00:00:00Z \\
+               --target training-job
+
+  # Use a named AWS profile and custom durations
+  $SCRIPT_NAME --az us-west-2b --instance-type ml.p6-b200.48xlarge \\
+               --count 2 --region us-west-2 \\
+               --start-after 2026-06-15T00:00:00Z \\
+               --profile my-profile \\
+               --durations 24,48,168
+
+  # Machine-readable JSON output for piping into other tools
+  $SCRIPT_NAME --az us-west-2b --instance-type ml.p5.48xlarge \\
+               --count 2 --region us-west-2 --json | jq '.offerings[0]'
+
+EXIT CODES:
+  0  Search completed (regardless of whether offerings were found).
+  1  Invalid arguments or missing prerequisites.
+
+NOTES:
+  * SearchTrainingPlanOfferings only returns offerings whose duration matches
+    --duration-hours exactly, which is why this script sweeps several values.
+  * Empty results mean no capacity currently matches your criteria; try a
+    different AZ, instance count, region, or start window.
+  * create-training-plan charges the upfront fee immediately and is
+    NON-REFUNDABLE. This script never purchases on your behalf — it only
+    prints the command for you to run.
+EOF
+}
+
+# ---------- argument parsing ----------
+AZ=""
+INSTANCE_TYPE=""
+INSTANCE_COUNT=""
+REGION=""
+START_AFTER=""
+AWS_PROFILE_ARG=""
+DURATIONS_ARG=""
+TARGET_RESOURCE="$DEFAULT_TARGET_RESOURCE"
+JSON_OUT=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --az)             AZ="$2"; shift 2 ;;
+    --instance-type)  INSTANCE_TYPE="$2"; shift 2 ;;
+    --count)          INSTANCE_COUNT="$2"; shift 2 ;;
+    --region)         REGION="$2"; shift 2 ;;
+    --start-after)    START_AFTER="$2"; shift 2 ;;
+    --profile)        AWS_PROFILE_ARG="$2"; shift 2 ;;
+    --target)         TARGET_RESOURCE="$2"; shift 2 ;;
+    --durations)      DURATIONS_ARG="$2"; shift 2 ;;
+    --json)           JSON_OUT=1; shift ;;
+    -h|--help)        usage; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      echo "Run '$SCRIPT_NAME --help' for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------- validation ----------
+missing=()
+[[ -z "$AZ" ]]             && missing+=("--az")
+[[ -z "$INSTANCE_TYPE" ]]  && missing+=("--instance-type")
+[[ -z "$INSTANCE_COUNT" ]] && missing+=("--count")
+[[ -z "$REGION" ]]         && missing+=("--region")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: missing required argument(s): ${missing[*]}" >&2
+  echo "Run '$SCRIPT_NAME --help' for usage." >&2
+  exit 1
+fi
+
+if ! [[ "$INSTANCE_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: --count must be a positive integer (got: $INSTANCE_COUNT)" >&2
+  exit 1
+fi
+
+case "$TARGET_RESOURCE" in
+  hyperpod-cluster|training-job) ;;
+  *)
+    echo "ERROR: --target must be 'hyperpod-cluster' or 'training-job' (got: $TARGET_RESOURCE)" >&2
+    exit 1
+    ;;
+esac
+
+# Default start time to "now" (UTC) if not provided.
+if [[ -z "$START_AFTER" ]]; then
+  START_AFTER="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+fi
+
+# Resolve durations.
+if [[ -n "$DURATIONS_ARG" ]]; then
+  IFS=',' read -r -a DURATIONS <<<"$DURATIONS_ARG"
+  for d in "${DURATIONS[@]}"; do
+    if ! [[ "$d" =~ ^[1-9][0-9]*$ ]]; then
+      echo "ERROR: --durations must be a comma-separated list of positive integers (got: $DURATIONS_ARG)" >&2
+      exit 1
+    fi
+  done
+else
+  DURATIONS=("${DEFAULT_DURATIONS[@]}")
+fi
+
+# ---------- prerequisite checks ----------
+command -v aws >/dev/null 2>&1 || {
+  echo "ERROR: aws CLI not found on PATH. Install AWS CLI v2." >&2; exit 1; }
+command -v jq  >/dev/null 2>&1 || {
+  echo "ERROR: jq not found on PATH. Install jq (e.g. 'brew install jq')." >&2; exit 1; }
+
+# Build optional profile flag for aws calls.
+AWS_PROFILE_FLAG=()
+if [[ -n "$AWS_PROFILE_ARG" ]]; then
+  AWS_PROFILE_FLAG=(--profile "$AWS_PROFILE_ARG")
+fi
+
+# Helper: log to stderr (so JSON on stdout stays clean in --json mode).
+log() { echo "$@" >&2; }
+
+# ---------- run ----------
+log "Searching SageMaker FTP offerings:"
+log "  AZ:             $AZ"
+log "  Instance type:  $INSTANCE_TYPE"
+log "  Count:          $INSTANCE_COUNT"
+log "  Region:         $REGION"
+log "  Start after:    $START_AFTER"
+log "  Target:         $TARGET_RESOURCE"
+log "  Profile:        ${AWS_PROFILE_ARG:-<default>}"
+log "  Durations (h):  ${DURATIONS[*]}"
+log ""
+
+ALL_OFFERINGS="[]"
+
+for DUR in "${DURATIONS[@]}"; do
+  if ! RESP=$(aws "${AWS_PROFILE_FLAG[@]}" sagemaker search-training-plan-offerings \
+        --region "$REGION" \
+        --instance-type "$INSTANCE_TYPE" \
+        --instance-count "$INSTANCE_COUNT" \
+        --start-time-after "$START_AFTER" \
+        --duration-hours "$DUR" \
+        --target-resources "$TARGET_RESOURCE" \
+        --output json 2>/dev/null); then
+    # API errored (e.g. ResourceLimitExceeded for that duration). Skip silently.
+    continue
+  fi
+
+  MATCHES=$(echo "$RESP" | jq --arg az "$AZ" --argjson count "$INSTANCE_COUNT" '
+    [.TrainingPlanOfferings[]
+     | select(any(.ReservedCapacityOfferings[]; .AvailabilityZone == $az))
+     | {
+         id: .TrainingPlanOfferingId,
+         duration_h: .DurationHours,
+         upfront: (.UpfrontFee | tonumber),
+         currency: .CurrencyCode,
+         az: .ReservedCapacityOfferings[0].AvailabilityZone,
+         start: .ReservedCapacityOfferings[0].StartTime,
+         end:   .ReservedCapacityOfferings[0].EndTime,
+         per_inst_hr: ((.UpfrontFee | tonumber) / (.DurationHours * $count))
+       }
+    ]')
+
+  ALL_OFFERINGS=$(jq -n --argjson a "$ALL_OFFERINGS" --argjson b "$MATCHES" '$a + $b')
+done
+
+TOTAL=$(echo "$ALL_OFFERINGS" | jq 'length')
+
+# ---------- JSON output mode ----------
+if [[ "$JSON_OUT" -eq 1 ]]; then
+  jq -n \
+    --arg az "$AZ" \
+    --arg instance_type "$INSTANCE_TYPE" \
+    --argjson count "$INSTANCE_COUNT" \
+    --arg region "$REGION" \
+    --arg start_after "$START_AFTER" \
+    --arg target "$TARGET_RESOURCE" \
+    --argjson durations "$(printf '%s\n' "${DURATIONS[@]}" | jq -R 'tonumber' | jq -s '.')" \
+    --argjson offerings "$ALL_OFFERINGS" \
+    '{
+       query: {
+         availability_zone: $az,
+         instance_type: $instance_type,
+         instance_count: $count,
+         region: $region,
+         start_after: $start_after,
+         target_resources: $target,
+         durations_hours: $durations
+       },
+       count: ($offerings | length),
+       offerings: ($offerings | sort_by(.per_inst_hr)),
+       recommendation: (if ($offerings | length) > 0
+                        then ($offerings | sort_by(.per_inst_hr) | .[0])
+                        else null
+                        end)
+     }'
+  exit 0
+fi
+
+# ---------- text output mode ----------
+if [[ "$TOTAL" -eq 0 ]]; then
+  echo "No offerings found in AZ $AZ for $INSTANCE_TYPE x$INSTANCE_COUNT"
+  echo "across the probed durations (${DURATIONS[*]} h)."
+  echo
+  echo "Suggestions:"
+  echo "  * Try a different AZ in the same region."
+  echo "  * Try a smaller --count (your account quota may be limiting results)."
+  echo "  * Try a later --start-after."
+  echo "  * Try a different --region."
+  echo "  * Try --durations with other values (e.g. 96,240,480)."
+  exit 0
+fi
+
+echo "Found $TOTAL matching offering(s) in $AZ:"
+echo
+printf "%-50s %8s %12s %10s   %-20s %-20s\n" \
+  "OFFERING_ID" "DUR(h)" "UPFRONT" "\$/inst/hr" "START (UTC)" "END (UTC)"
+printf "%-50s %8s %12s %10s   %-20s %-20s\n" \
+  "$(printf '%.0s-' {1..50})" "------" "------------" "----------" "--------------------" "--------------------"
+
+echo "$ALL_OFFERINGS" | jq -r '.[] |
+  [
+    .id,
+    (.duration_h | tostring),
+    (.upfront | tostring),
+    ((.per_inst_hr * 100 | floor) / 100 | tostring),
+    (.start | strftime("%Y-%m-%d %H:%M")),
+    (.end   | strftime("%Y-%m-%d %H:%M"))
+  ] | @tsv' | \
+while IFS=$'\t' read -r id dur upfront rate start end; do
+  printf "%-50s %8s %12s %10s   %-20s %-20s\n" \
+    "${id:0:48}.." "$dur" "$upfront" "$rate" "$start" "$end"
+done
+
+echo
+echo "Recommendation (lowest \$/instance/hour):"
+echo "$ALL_OFFERINGS" | jq -r '
+  sort_by(.per_inst_hr) | .[0] |
+  "  Offering ID:  " + .id,
+  "  Duration:     " + (.duration_h | tostring) + " h",
+  "  AZ:           " + .az,
+  "  Upfront fee:  " + (.upfront | tostring) + " " + .currency,
+  "  Effective:    $" + (((.per_inst_hr * 100 | floor) / 100) | tostring) + " / instance / hour",
+  "  Window:       " + (.start | strftime("%Y-%m-%d %H:%M UTC")) + " -> " + (.end | strftime("%Y-%m-%d %H:%M UTC"))
+'
+
+echo
+echo "To purchase this offering (NON-REFUNDABLE; charges the upfront fee immediately):"
+BEST_ID=$(echo "$ALL_OFFERINGS" | jq -r 'sort_by(.per_inst_hr) | .[0].id')
+echo "  aws sagemaker create-training-plan \\"
+echo "    --region $REGION \\"
+if [[ -n "$AWS_PROFILE_ARG" ]]; then
+  echo "    --profile $AWS_PROFILE_ARG \\"
+fi
+echo "    --training-plan-name <YOUR_PLAN_NAME> \\"
+echo "    --training-plan-offering-id $BEST_ID"

--- a/2.ami_and_containers/tools/sagemaker_ftp/find-ftp.sh
+++ b/2.ami_and_containers/tools/sagemaker_ftp/find-ftp.sh
@@ -60,7 +60,7 @@ USAGE:
                --count <N> --region <REGION> \\
                [--start-after <ISO8601_UTC>] [--profile <AWS_PROFILE>] \\
                [--target hyperpod-cluster|training-job] \\
-               [--durations <H1,H2,...>] [--json]
+               [--durations <H1,H2,...>] [--json] [--verbose]
 
 REQUIRED ARGUMENTS:
   --az              Availability Zone name, e.g. us-west-2b
@@ -82,6 +82,9 @@ OPTIONAL ARGUMENTS:
                     Example: --durations 24,168,720
   --json            Emit machine-readable JSON to stdout instead of the
                     human-readable table. Status messages still go to stderr.
+  --verbose         Print full AWS error text (to stderr) when a per-duration
+                    API call fails. Without this flag, failures are summarized
+                    in a single line.
   -h, --help        Show this help message and exit.
 
 WHAT IT DOES:
@@ -141,6 +144,7 @@ AWS_PROFILE_ARG=""
 DURATIONS_ARG=""
 TARGET_RESOURCE="$DEFAULT_TARGET_RESOURCE"
 JSON_OUT=0
+VERBOSE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -153,6 +157,7 @@ while [[ $# -gt 0 ]]; do
     --target)         TARGET_RESOURCE="$2"; shift 2 ;;
     --durations)      DURATIONS_ARG="$2"; shift 2 ;;
     --json)           JSON_OUT=1; shift ;;
+    --verbose)        VERBOSE=1; shift ;;
     -h|--help)        usage; exit 0 ;;
     *)
       echo "ERROR: unknown argument: $1" >&2
@@ -221,6 +226,25 @@ fi
 # Helper: log to stderr (so JSON on stdout stays clean in --json mode).
 log() { echo "$@" >&2; }
 
+# Reusable jq filter that converts a timestamp value to epoch seconds.
+# Handles three input shapes that AWS CLI may emit:
+#   * a raw epoch number (CLI v1 default; CLI v2 with cli_timestamp_format=wire)
+#   * an ISO-8601 string ending in "Z" (UTC)
+#   * an ISO-8601 string ending in "±HH:MM" (CLI v2 default in many regions)
+JQ_TO_EPOCH='
+def to_epoch:
+  if type == "number" then .
+  else
+    capture("^(?<dt>[0-9-]{10}T[0-9:]{8})(?:\\.[0-9]+)?(?<tz>Z|(?<sign>[+-])(?<oh>[0-9]{2}):(?<om>[0-9]{2}))$") as $m
+    | ($m.dt + "Z" | fromdateiso8601) as $base
+    | if $m.tz == "Z" then $base
+      else
+        (($m.oh | tonumber) * 3600 + ($m.om | tonumber) * 60) as $off
+        | if $m.sign == "+" then $base - $off else $base + $off end
+      end
+  end;
+'
+
 # ---------- run ----------
 log "Searching SageMaker FTP offerings:"
 log "  AZ:             $AZ"
@@ -231,35 +255,55 @@ log "  Start after:    $START_AFTER"
 log "  Target:         $TARGET_RESOURCE"
 log "  Profile:        ${AWS_PROFILE_ARG:-<default>}"
 log "  Durations (h):  ${DURATIONS[*]}"
+log "  Verbose:        $([[ $VERBOSE -eq 1 ]] && echo on || echo off)"
 log ""
 
 ALL_OFFERINGS="[]"
+ERR_FILE="$(mktemp -t find-ftp-err.XXXXXX)"
+trap 'rm -f "$ERR_FILE"' EXIT
 
 for DUR in "${DURATIONS[@]}"; do
-  if ! RESP=$(aws "${AWS_PROFILE_FLAG[@]}" sagemaker search-training-plan-offerings \
+  : > "$ERR_FILE"
+  if RESP=$(aws "${AWS_PROFILE_FLAG[@]}" sagemaker search-training-plan-offerings \
         --region "$REGION" \
         --instance-type "$INSTANCE_TYPE" \
         --instance-count "$INSTANCE_COUNT" \
         --start-time-after "$START_AFTER" \
         --duration-hours "$DUR" \
         --target-resources "$TARGET_RESOURCE" \
-        --output json 2>/dev/null); then
-    # API errored (e.g. ResourceLimitExceeded for that duration). Skip silently.
+        --output json 2>"$ERR_FILE"); then
+    : # success — fall through to parse RESP
+  else
+    AWS_RC=$?
+    ERR_TEXT="$(cat "$ERR_FILE")"
+    if echo "$ERR_TEXT" | grep -q "ResourceLimitExceeded"; then
+      log "Note: duration=${DUR}h skipped (ResourceLimitExceeded — account quota below requested count)."
+    else
+      # Real error: surface a one-liner; full text only with --verbose.
+      FIRST_LINE="$(echo "$ERR_TEXT" | grep -v '^[[:space:]]*$' | head -1)"
+      log "WARNING: duration=${DUR}h failed (aws exit ${AWS_RC}): ${FIRST_LINE:-<no error text>}"
+      if [[ "$VERBOSE" -eq 1 && -n "$ERR_TEXT" ]]; then
+        log "----- full AWS error (duration=${DUR}h) -----"
+        echo "$ERR_TEXT" >&2
+        log "----- end -----"
+      fi
+    fi
     continue
   fi
 
   MATCHES=$(echo "$RESP" | jq --arg az "$AZ" --argjson count "$INSTANCE_COUNT" '
     [.TrainingPlanOfferings[]
-     | select(any(.ReservedCapacityOfferings[]; .AvailabilityZone == $az))
+     | . as $offering
+     | (.ReservedCapacityOfferings[] | select(.AvailabilityZone == $az)) as $rc
      | {
-         id: .TrainingPlanOfferingId,
-         duration_h: .DurationHours,
-         upfront: (.UpfrontFee | tonumber),
-         currency: .CurrencyCode,
-         az: .ReservedCapacityOfferings[0].AvailabilityZone,
-         start: .ReservedCapacityOfferings[0].StartTime,
-         end:   .ReservedCapacityOfferings[0].EndTime,
-         per_inst_hr: ((.UpfrontFee | tonumber) / (.DurationHours * $count))
+         id: $offering.TrainingPlanOfferingId,
+         duration_h: $offering.DurationHours,
+         upfront: ($offering.UpfrontFee | tonumber),
+         currency: $offering.CurrencyCode,
+         az: $rc.AvailabilityZone,
+         start: $rc.StartTime,
+         end:   $rc.EndTime,
+         per_inst_hr: (($offering.UpfrontFee | tonumber) / ($offering.DurationHours * $count))
        }
     ]')
 
@@ -320,14 +364,15 @@ printf "%-50s %8s %12s %10s   %-20s %-20s\n" \
 printf "%-50s %8s %12s %10s   %-20s %-20s\n" \
   "$(printf '%.0s-' {1..50})" "------" "------------" "----------" "--------------------" "--------------------"
 
-echo "$ALL_OFFERINGS" | jq -r '.[] |
+echo "$ALL_OFFERINGS" | jq -r "$JQ_TO_EPOCH"'
+  .[] |
   [
     .id,
     (.duration_h | tostring),
     (.upfront | tostring),
-    ((.per_inst_hr * 100 | floor) / 100 | tostring),
-    (.start | strftime("%Y-%m-%d %H:%M")),
-    (.end   | strftime("%Y-%m-%d %H:%M"))
+    ((.per_inst_hr * 100 | round) / 100 | tostring),
+    (.start | to_epoch | strftime("%Y-%m-%d %H:%M")),
+    (.end   | to_epoch | strftime("%Y-%m-%d %H:%M"))
   ] | @tsv' | \
 while IFS=$'\t' read -r id dur upfront rate start end; do
   printf "%-50s %8s %12s %10s   %-20s %-20s\n" \
@@ -336,14 +381,14 @@ done
 
 echo
 echo "Recommendation (lowest \$/instance/hour):"
-echo "$ALL_OFFERINGS" | jq -r '
+echo "$ALL_OFFERINGS" | jq -r "$JQ_TO_EPOCH"'
   sort_by(.per_inst_hr) | .[0] |
   "  Offering ID:  " + .id,
   "  Duration:     " + (.duration_h | tostring) + " h",
   "  AZ:           " + .az,
   "  Upfront fee:  " + (.upfront | tostring) + " " + .currency,
-  "  Effective:    $" + (((.per_inst_hr * 100 | floor) / 100) | tostring) + " / instance / hour",
-  "  Window:       " + (.start | strftime("%Y-%m-%d %H:%M UTC")) + " -> " + (.end | strftime("%Y-%m-%d %H:%M UTC"))
+  "  Effective:    $" + (((.per_inst_hr * 100 | round) / 100) | tostring) + " / instance / hour",
+  "  Window:       " + (.start | to_epoch | strftime("%Y-%m-%d %H:%M UTC")) + " -> " + (.end | to_epoch | strftime("%Y-%m-%d %H:%M UTC"))
 '
 
 echo


### PR DESCRIPTION
## Purpose

Adds a small Bash helper that wraps `aws sagemaker search-training-plan-offerings`
to make it easy to discover available Flexible Training Plan (FTP) capacity in
a specific Availability Zone, for either HyperPod clusters (Slurm or EKS) or
SageMaker training jobs.

The `SearchTrainingPlanOfferings` API filters strictly on `--duration-hours`
and only returns offerings of that exact duration, with no "show me everything"
mode. To answer the common customer question "is there capacity for X
instances of Y in AZ Z?", users today have to manually call the API once per
duration and merge the results. This tool automates that sweep, filters by
AZ, ranks the matches by effective `$/instance/hour`, and prints a
ready-to-run `create-training-plan` command for the cheapest option.

## Changes

- New directory: `2.ami_and_containers/tools/sagemaker_ftp/`
- New file: `find-ftp.sh` — Bash script with MIT-0 SPDX header
  - Required flags: `--az`, `--instance-type`, `--count`, `--region`
  - Optional flags: `--start-after`, `--profile`, `--target` (`hyperpod-cluster` default, or `training-job`), `--durations`, `--json`, `-h`/`--help`
  - Sweeps default durations `24, 48, 72, 168, 336, 720` hours (overridable)
  - Filters returned offerings to the requested AZ
  - Computes `$/instance/hour = UpfrontFee / (DurationHours * InstanceCount)`
  - Prints a table (text mode) or structured JSON (`--json`)
  - Recommends the lowest `$/instance/hour` offering and prints, but never executes, the corresponding `create-training-plan` command
  - Validates inputs and surfaces clear errors for missing args, invalid `--count`, invalid `--target`, missing `aws`/`jq`
- New file: `README.md` — usage, prerequisites, examples (default target, training-job target, custom durations, JSON), interpretation guide, troubleshooting table, and references to the relevant AWS docs

## Test Plan

**Environment:**
- AWS Service: SageMaker (`SearchTrainingPlanOfferings` API)
- Instance type: `ml.p5.48xlarge`, `ml.p5en.48xlarge`, `ml.p6-b200.48xlarge`, `ml.p6-b300.48xlarge`
- Number of nodes: 1–64 (search-only; no resources reserved)
- Region: `us-west-2`

**Test commands:**
```bash
# Help text
./find-ftp.sh --help

# Default target (hyperpod-cluster)
./find-ftp.sh --az us-west-2b --instance-type ml.p5.48xlarge \
  --count 2 --region us-west-2 --start-after 2026-06-15T00:00:00Z

# training-job target
./find-ftp.sh --az us-west-2b --instance-type ml.p5.48xlarge \
  --count 2 --region us-west-2 --start-after 2026-06-15T00:00:00Z \
  --target training-job

# Custom durations
./find-ftp.sh --az us-west-2b --instance-type ml.p5.48xlarge \
  --count 2 --region us-west-2 --durations 24,168

# JSON output
./find-ftp.sh --az us-west-2b --instance-type ml.p5.48xlarge \
  --count 2 --region us-west-2 --json | jq '.recommendation'

# Validation: missing required arg
./find-ftp.sh --az us-west-2b --instance-type ml.p5.48xlarge

# Validation: invalid --target
./find-ftp.sh --az us-west-2b --instance-type ml.p5.48xlarge \
  --count 2 --region us-west-2 --target nonsense
```

**Test Results**
| Scenario | Outcome |
|---|---|
| `--help` | Prints full usage with all flags including `--target`, `--durations`, `--json` |
| Default target, `ml.p5.48xlarge x2`, sweep | Returned 9 offerings in `us-west-2b`; cheapest at `$38.14/inst/hr` (24 h plan) |
| `--target training-job`, same parameters | Returned a different offering (different `tpo-...` ID and price), confirming the flag actually switches API target rather than reusing HyperPod results |
| `--durations 24,168` | Sweep limited to those two durations; 3 matches returned |
| `--json` | Valid JSON to stdout, status messages on stderr; shape: `{query, count, offerings, recommendation}` |
| Missing required arg | Exit 1 with `ERROR: missing required argument(s): ...` and `--help` hint |
| Invalid `--target nonsense` | Exit 1 with `ERROR: --target must be 'hyperpod-cluster' or 'training-job'` |
| Per-duration `ResourceLimitExceeded` (count above account quota) | Silently skipped for that duration (matches the "no offering at this size" semantics) |

The script is pure search/read — it never calls CreateTrainingPlan. Purchases require the user to copy and run the printed command themselves.

## Directory Structure
This PR is a tooling addition under 2.ami_and_containers/tools/, not a test
case under 3.test_cases/, so the test-case directory layout in the template
does not apply here. Layout added:

```2.ami_and_containers/
└── tools/
    └── sagemaker_ftp/
        ├── find-ftp.sh
        └── README.md
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`). (not applicable)
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure). (N/A — this is a tool, not a test case)
