### PR TITLE
fix: add DependsOn on IGW attachment for public routes (intermittent stack rollback)

### DIFF
--- a/1.architectures/1.vpc_network/1.vpc-multi-az.yaml
+++ b/1.architectures/1.vpc_network/1.vpc-multi-az.yaml
@@ -417,6 +417,7 @@ Resources:
   PublicRoute1:
     Condition: PublicSubnetCondition
     Type: AWS::EC2::Route
+    DependsOn: GatewayToInternet
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: '0.0.0.0/0'

--- a/1.architectures/1.vpc_network/2.vpc-one-az.yaml
+++ b/1.architectures/1.vpc_network/2.vpc-one-az.yaml
@@ -276,6 +276,7 @@ Resources:
 
   PublicRoute:
     Type: AWS::EC2::Route
+    DependsOn: GatewayToInternet
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0

--- a/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites-p1.yaml
+++ b/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites-p1.yaml
@@ -233,6 +233,7 @@ Resources:
 
   PublicRoute:
     Type: AWS::EC2::Route
+    DependsOn: GatewayToInternet
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0

--- a/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
+++ b/1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml
@@ -324,6 +324,7 @@ Resources:
 
   PublicRoute:
     Type: AWS::EC2::Route
+    DependsOn: GatewayToInternet
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0

--- a/1.architectures/5.sagemaker-hyperpod/2.SageMakerVPC.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/2.SageMakerVPC.yaml
@@ -359,6 +359,7 @@ Resources:
 
   PublicRoute:
     Type: AWS::EC2::Route
+    DependsOn: GatewayToInternet
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0

--- a/1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml
@@ -376,6 +376,7 @@ Resources:
 
   PublicRoute:
     Type: AWS::EC2::Route
+    DependsOn: GatewayToInternet
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0

--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/sagemaker-studio-stack.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/sagemaker-studio-stack.yaml
@@ -1053,6 +1053,7 @@ Resources:
   SageMakerStudioVpcPublicRouteOne:
     Type: AWS::EC2::Route
     Condition: CreateNewVpc
+    DependsOn: SageMakerStudioVpcGatewayAttachment
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId:
@@ -1077,6 +1078,7 @@ Resources:
   SageMakerStudioVpcPublicRouteTwo:
     Type: AWS::EC2::Route
     Condition: CreateNewVpc
+    DependsOn: SageMakerStudioVpcGatewayAttachment
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId:

--- a/architectures/aws-pcs/assets/ml-cluster-prerequisites.yaml
+++ b/architectures/aws-pcs/assets/ml-cluster-prerequisites.yaml
@@ -410,6 +410,7 @@ Resources:
 
   PublicRoute:
     Type: AWS::EC2::Route
+    DependsOn: GatewayToInternet
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0


### PR DESCRIPTION
## Problem

Several CloudFormation templates create an `AWS::EC2::Route` to the internet gateway (`GatewayId: !Ref InternetGateway`) **without** an explicit `DependsOn` on the `AWS::EC2::VPCGatewayAttachment`. CloudFormation orders the route after the IGW *resource* exists, but **not** after the IGW is *attached* to the VPC — so the route can be created first and EC2 rejects it:

```
PublicRoute  AWS::EC2::Route
  Resource handler returned message: "route table rtb-… and network gateway igw-…
  belong to different networks (Service: Ec2, Status Code: 400 …)"
```

The whole stack then rolls back. Because it's a creation-time race, it's **intermittent** — the same template succeeds in regions/runs where the attachment happens to finish first, which is why it has gone unnoticed.

Observed live deploying the **aws-pcs** reference cluster in `us-east-1` (2026-06-20):
```
PrerequisitesStack → The following resource(s) failed to create: [PublicRoute].
... route table rtb-0f639e181dfc4430d and network gateway igw-05f2848b86bc4620d
    belong to different networks (Status Code: 400)
```

## Fix

Add `DependsOn` on the gateway attachment to each affected public route (one line each):

- `architectures/aws-pcs/assets/ml-cluster-prerequisites.yaml` ✅ *reproduced + re-verified end-to-end after the fix*
- `1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites.yaml`
- `1.architectures/2.aws-parallelcluster/infra-templates/parallelcluster-prerequisites-p1.yaml`
- `1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml`
- `1.architectures/5.sagemaker-hyperpod/2.SageMakerVPC.yaml`
- `1.architectures/1.vpc_network/1.vpc-multi-az.yaml`
- `1.architectures/1.vpc_network/2.vpc-one-az.yaml`
- `1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/sagemaker-studio-stack.yaml` (two routes)

## Scope / notes

- **Private routes are unaffected** — they `!Ref` the NAT gateway, which already forces correct ordering.
- The **hyperpod-eks** `hyperpod-eks-full-stack.yaml` / `nested-stacks/vpc-stack.yaml` already had `DependsOn: InternetGatewayAttachment` and are intentionally left unchanged.
- Only the PCS template was deployed/verified end-to-end; the others are the identical static one-line fix to the same pattern.

## Verification

Reproduced the rollback, applied the PCS fix in a private test bucket, and redeployed in `us-east-1` — `PrerequisitesStack` and the full cluster reached `CREATE_COMPLETE`, validated by an end-to-end multi-user OpenLDAP run (user resolution, Slurm accounting, login-node replacement).