### PR TITLE
feat(megatron-bridge): Qwen3-235B 3-way MoE dispatcher comparison (NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM)

### DIFF
--- a/.github/workflows/deepep-vendor-sync.yml
+++ b/.github/workflows/deepep-vendor-sync.yml
@@ -1,0 +1,32 @@
+# Fails if the vendored copy of setup_deepep_efa.sh drifts from its canonical source.
+#
+# megatron-bridge vendors a verbatim copy of the deepep-benchmark EFA setup script (Docker
+# can only COPY from within the build context). The copy is kept in sync by hand, so silent
+# drift would mean the megatron-bridge image builds a different DeepEP than documented. This
+# gate diffs the two and fails on any mismatch. Runs only when either file changes.
+
+name: DeepEP vendor sync
+
+on:
+  pull_request:
+    paths:
+      - "3.test_cases/megatron/megatron-bridge/deepep/setup_deepep_efa.sh"
+      - "micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compare vendored copy against canonical source
+        run: |
+          CANON=micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh
+          VENDORED=3.test_cases/megatron/megatron-bridge/deepep/setup_deepep_efa.sh
+          if ! diff -u "$CANON" "$VENDORED"; then
+            echo "::error::$VENDORED has drifted from $CANON. Re-copy: cp $CANON $VENDORED"
+            exit 1
+          fi
+          echo "OK: vendored setup_deepep_efa.sh matches canonical source."

--- a/3.test_cases/megatron/megatron-bridge/1.build-and-push.sh
+++ b/3.test_cases/megatron/megatron-bridge/1.build-and-push.sh
@@ -10,10 +10,16 @@
 #   ./1.build-and-push.sh
 #
 # Override defaults via environment variables:
-#   TAG=<tag>       Image tag (default: nemo-26.04.01-uccl-0dc87eb)
+#   EP_BACKEND=<uccl|nvshmem>  deep_ep provider to build (default: uccl). nvshmem
+#                              builds NVIDIA DeepEP over NVSHMEM-libfabric/EFA.
+#   TAG=<tag>       Image tag (default depends on EP_BACKEND, see below)
 #   REGION=<region> AWS region (default: us-west-2)
 #   ACCOUNT=<id>    AWS account ID (REQUIRED — your account)
 #   REPO_NAME=<name> ECR repository name (default: megatron-bridge-uccl)
+#
+# Build BOTH images for the 3-way dispatcher comparison (NCCL / UCCL / NVSHMEM):
+#   ./1.build-and-push.sh                      # EP_BACKEND=uccl    -> nemo-26.04.01-uccl-0dc87eb
+#   EP_BACKEND=nvshmem ./1.build-and-push.sh   # -> nemo-26.04.01-deepep-nvshmem-567632d-cu13
 #
 # Prerequisites:
 #   - AWS CLI configured with credentials that have ECR push access.
@@ -26,7 +32,14 @@ set -euo pipefail
 ###### User Variables #####
 ###########################
 
-TAG="${TAG:-nemo-26.04.01-uccl-0dc87eb}"
+EP_BACKEND="${EP_BACKEND:-uccl}"
+case "${EP_BACKEND}" in
+    uccl)    DEFAULT_TAG="nemo-26.04.01-uccl-0dc87eb" ;;
+    nvshmem) DEFAULT_TAG="nemo-26.04.01-deepep-nvshmem-567632d-cu13" ;;
+    *) echo "ERROR: EP_BACKEND must be 'uccl' or 'nvshmem', got '${EP_BACKEND}'"; exit 1 ;;
+esac
+
+TAG="${TAG:-${DEFAULT_TAG}}"
 REGION="${REGION:-us-west-2}"
 ACCOUNT="${ACCOUNT:?set ACCOUNT to your AWS account id}"
 REPO_NAME="${REPO_NAME:-megatron-bridge-uccl}"
@@ -41,9 +54,10 @@ REMOTE_IMAGE="${REGISTRY}/${REPO_NAME}:${TAG}"
 DOCKERFILE="Dockerfile"
 
 echo "============================================"
-echo "Megatron-Bridge UCCL-EP env image — Docker Build & Push"
+echo "Megatron-Bridge MoE env image — Docker Build & Push"
 echo "============================================"
 echo "Dockerfile : ${DOCKERFILE}"
+echo "EP_BACKEND : ${EP_BACKEND}"
 echo "Local tag  : ${LOCAL_IMAGE}"
 echo "ECR image  : ${REMOTE_IMAGE}"
 echo "Region     : ${REGION}"
@@ -69,6 +83,7 @@ echo "Building image: ${LOCAL_IMAGE} ..."
 docker build \
     --progress=plain \
     -f "${DOCKERFILE}" \
+    --build-arg EP_BACKEND="${EP_BACKEND}" \
     -t "${LOCAL_IMAGE}" \
     .
 

--- a/3.test_cases/megatron/megatron-bridge/2.sanity-singlenode.sh
+++ b/3.test_cases/megatron/megatron-bridge/2.sanity-singlenode.sh
@@ -61,6 +61,11 @@ section() {
 # ---------------------------------------------------------------------------
 : "${GPUS_PER_NODE:=8}"
 : "${SKIP_NCCL_TEST:=0}"
+# deep_ep provider in the image under test: uccl (UCCL shadow) or nvshmem (NVIDIA DeepEP
+# over NVSHMEM-libfabric/EFA). Selects which positive markers Gate 2/5 assert. Set this to
+# match the image's EP_BACKEND build arg.
+: "${EP_BACKEND:=uccl}"
+export EP_BACKEND
 # Number of experts for the micro-step test (must be divisible by GPUS_PER_NODE).
 : "${NUM_EXPERTS:=8}"
 # Tokens per micro-step (keep small for a fast gate).
@@ -85,42 +90,55 @@ if [[ "${EFA_COUNT}" -eq 0 ]]; then
     fail "No EFA devices found. Ensure the pod has vpc.amazonaws.com/efa: 16 in its resource spec and the EFA device plugin is running."
 fi
 
-fi_info -p efa | head -40
+# `|| true`: on a many-NIC node (p6-b300 has 16 EFA) fi_info prints >40 lines, so head
+# closes the pipe early and fi_info gets SIGPIPE — which, under `set -o pipefail`, would
+# abort the whole gate script. Swallow it; the count check above already gated.
+fi_info -p efa | head -40 || true
 pass "Gate 1: ${EFA_COUNT} EFA device(s) visible"
 
 # ---------------------------------------------------------------------------
 # GATE 2 — deep_ep shadow module resolves to /opt/uccl
 # ---------------------------------------------------------------------------
-section "2 / 5 — UCCL deep_ep shadow module"
+section "2 / 5 — deep_ep provider (${EP_BACKEND}) importable with Buffer"
 
 python3 - <<'PYEOF'
-import sys
+import os, sys
 
-# TODO(validate against image): confirm a positive UCCL marker (a uccl-specific
-# attr on deep_ep); site-packages path is expected after `pip install .`, so do
-# NOT assert on /opt/uccl. https://github.com/uccl-project/uccl
+backend = os.environ.get("EP_BACKEND", "uccl")
+
+# The deepep arm imports the SAME top-level `deep_ep` module regardless of provider; only
+# which library backs it differs (UCCL shadow vs NVIDIA DeepEP over NVSHMEM-libfabric).
 try:
     import deep_ep
-    import uccl
 except ImportError as e:
-    print(f"[FAIL] 'import deep_ep'/'import uccl' raised ImportError: {e}", file=sys.stderr)
+    print(f"[FAIL] 'import deep_ep' raised ImportError: {e}", file=sys.stderr)
     sys.exit(1)
 
 print(f"[INFO] deep_ep -> {deep_ep.__file__}")
-print(f"[INFO] uccl    -> {uccl.__file__}")
 
-# Positive check: the UCCL wrapper exposes Buffer. A bare importable deep_ep that
-# lacks Buffer means the UCCL wrapper is not the active module.
+# For the UCCL image, the shadow is backed by the `uccl` package — assert it imports too.
+if backend == "uccl":
+    try:
+        import uccl
+        print(f"[INFO] uccl    -> {uccl.__file__}")
+    except ImportError as e:
+        print(f"[FAIL] EP_BACKEND=uccl but 'import uccl' failed: {e}", file=sys.stderr)
+        sys.exit(1)
+else:
+    # NVIDIA DeepEP build: confirm we resolved the from-source EFA build in /opt/venv,
+    # NOT the base's IB/NVSHMEM-bound DeepEP (dist-packages or editable /opt/DeepEP).
+    if "/opt/venv/" not in (deep_ep.__file__ or ""):
+        print(f"[FAIL] deep_ep resolved to {deep_ep.__file__}, not the /opt/venv EFA build",
+              file=sys.stderr)
+        sys.exit(1)
+
+# Positive check: the provider exposes Buffer. A bare importable deep_ep that lacks Buffer
+# means the provider is not the active module.
 if not hasattr(deep_ep, "Buffer"):
-    print(
-        "[FAIL] deep_ep.Buffer missing — UCCL wrapper not active. "
-        "Check that 'pip install .' was run in /opt/uccl/ep/deep_ep_wrapper "
-        "AFTER any other deep_ep installation.",
-        file=sys.stderr,
-    )
+    print("[FAIL] deep_ep.Buffer missing — provider not active.", file=sys.stderr)
     sys.exit(1)
 
-print(f"[PASS] Gate 2: deep_ep importable and UCCL wrapper active (deep_ep.Buffer present)")
+print(f"[PASS] Gate 2: deep_ep importable and {backend} provider active (deep_ep.Buffer present)")
 PYEOF
 
 # ---------------------------------------------------------------------------

--- a/3.test_cases/megatron/megatron-bridge/Dockerfile
+++ b/3.test_cases/megatron/megatron-bridge/Dockerfile
@@ -46,6 +46,25 @@ ARG TORCH_CUDA_ARCH_LIST="10.0a+PTX;10.3a+PTX"
 # nanobind is a UCCL build-time dependency. Pinned per the repo "no latest" rule.
 ARG NANOBIND_VERSION=2.4.0
 
+# EP backend selector — which library provides the top-level `deep_ep` module that
+# Megatron-Core's flex/deepep dispatcher (`moe_flex_dispatcher_backend="deepep"`)
+# resolves at `import deep_ep`. ONE Dockerfile, TWO image tags:
+#   uccl    (default) -> UCCL EFA-native deep_ep shadow (the existing build)
+#   nvshmem           -> NVIDIA DeepEP, EFA-patched to run NVSHMEM over libfabric
+#                        (host-proxy, no IBGDA — see micro-benchmarks/expert-
+#                         parallelism/deepep-benchmark/setup_deepep_efa.sh).
+# Both arms then run the SAME `MOE_DISPATCHER=deepep` code path; only the image
+# (hence which `deep_ep` is importable) differs. This is what lets the dsv3/qwen3
+# benchmarks compare DeepEP+UCCL vs DeepEP+NVSHMEM with no Megatron-Core changes.
+ARG EP_BACKEND=uccl
+# nvshmem-backend pins (used only when EP_BACKEND=nvshmem). DeepEP commit + NVSHMEM
+# tag match micro-benchmarks/.../deepep-benchmark (proven on p6-b300 / sm_103).
+# DEEPEP_GPU_ARCH=100 (sm_100) is the Blackwell cubin the deepep-benchmark image
+# was built with and ran on these sm_103 B300 nodes.
+ARG NVSHMEM_VERSION=v3.7.0-0
+ARG DEEPEP_COMMIT=567632d
+ARG DEEPEP_GPU_ARCH=100
+
 ARG OPEN_MPI_PATH=/opt/amazon/openmpi
 
 ######################
@@ -114,13 +133,15 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/
     PATH=/opt/venv/bin:/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:$PATH
 
 #####################################################
-## UCCL core + UCCL-EP + deep_ep shadow wrapper
+## deep_ep provider — UCCL (default) OR NVIDIA DeepEP + NVSHMEM-over-EFA
 ##
-## UCCL provides the EFA-native expert-parallel all-to-all. Its `deep_ep_wrapper`
-## installs a TOP-LEVEL python module named `deep_ep` that shadows NVIDIA DeepEP,
-## so Megatron-Core's flex/deepep dispatcher (`moe_flex_dispatcher_backend="deepep"`)
-## resolves `import deep_ep` to the UCCL/EFA implementation.
+## Exactly one of the two RUN blocks below executes, gated on EP_BACKEND, and each
+## installs a TOP-LEVEL python `deep_ep` module into /opt/venv that shadows the
+## NVIDIA DeepEP the base ships in dist-packages (IB/NVSHMEM-bound). Megatron-Core's
+## flex/deepep dispatcher (`moe_flex_dispatcher_backend="deepep"`) then resolves
+## `import deep_ep` to whichever was installed.
 #####################################################
+# --- EP_BACKEND=uccl: UCCL core + UCCL-EP + deep_ep shadow wrapper ---
 # Use `python3 -m pip` for ALL of UCCL so packages land in the SAME env as python3
 # (/opt/venv, first on PATH, where torch + Megatron live). A bare `pip` targets
 # /usr/local; combined with the `ep` extension that setup.py installs into /opt/venv,
@@ -131,7 +152,7 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/
 #   nanobind (build dep) -> clone+checkout pinned SHA + submodules -> UCCL core ->
 #   UCCL-EP kernels (PER_EXPERT_BATCHING + Blackwell arch list; the ";" in
 #   TORCH_CUDA_ARCH_LIST must stay quoted) -> deep_ep shadow wrapper.
-RUN set -eux; \
+RUN if [ "${EP_BACKEND}" = "uccl" ]; then set -eux; \
     python3 -m pip install nanobind==${NANOBIND_VERSION}; \
     git clone https://github.com/uccl-project/uccl.git /opt/uccl; \
     cd /opt/uccl; \
@@ -139,21 +160,59 @@ RUN set -eux; \
     git submodule update --init --recursive; \
     cd /opt/uccl && python3 -m pip install .; \
     cd /opt/uccl/ep && PER_EXPERT_BATCHING=1 TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" python3 setup.py install; \
-    cd /opt/uccl/ep/deep_ep_wrapper && python3 -m pip install .
+    cd /opt/uccl/ep/deep_ep_wrapper && python3 -m pip install .; \
+    else echo "EP_BACKEND=${EP_BACKEND}: skipping UCCL build"; fi
+
+# --- EP_BACKEND=nvshmem: NVIDIA DeepEP, EFA-patched (NVSHMEM over libfabric) ---
+# Reuses the proven build recipe from
+# micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh, vendored
+# into this dir (deepep/) so it is in the build context (Docker can't COPY outside it).
+# It patches DeepEP (put+signal, an IBGDA->host-proxy shim, fake IBGDA state,
+# NVSHMEM_MAX_TEAMS 7->8), builds NVSHMEM v3.7 (libfabric/EFA, IBGDA OFF), then builds
+# DeepEP into /opt/venv. GDRCopy is built from source (NVSHMEM cmake needs its headers).
+# Replaces the base's torch-bundled nvidia-nvshmem so the from-source NVSHMEM is used.
+COPY deepep/setup_deepep_efa.sh /tmp/setup_deepep_efa.sh
+RUN if [ "${EP_BACKEND}" = "nvshmem" ]; then set -eux; \
+    git clone -b ${GDRCOPY_VERSION} https://github.com/NVIDIA/gdrcopy.git /tmp/gdrcopy; \
+    cd /tmp/gdrcopy && make prefix=/opt/gdrcopy install && cd / && rm -rf /tmp/gdrcopy; \
+    python3 -m pip uninstall -y nvidia-nvshmem-cu13 nvidia-nvshmem-cu12 deep_ep 2>/dev/null || true; \
+    git clone -b ${NVSHMEM_VERSION} https://github.com/NVIDIA/nvshmem.git /opt/nvshmem_src; \
+    git clone https://github.com/deepseek-ai/DeepEP.git /opt/deepep-efa-src; \
+    cd /opt/deepep-efa-src && git checkout ${DEEPEP_COMMIT}; \
+    chmod +x /tmp/setup_deepep_efa.sh; \
+    /tmp/setup_deepep_efa.sh \
+      --cuda-home /usr/local/cuda \
+      --libfabric-home /opt/amazon/efa \
+      --gdrcopy-home /opt/gdrcopy \
+      --gpu-arch "${DEEPEP_GPU_ARCH}" \
+      --venv /opt/venv \
+      --deepep-src /opt/deepep-efa-src \
+      --nvshmem-src /opt/nvshmem_src; \
+    else echo "EP_BACKEND=${EP_BACKEND}: skipping NVSHMEM/DeepEP build"; fi
+
+# NVSHMEM runtime env. Harmless for the uccl image (the dirs are absent there).
+# Must PRECEDE the verify RUN so the nvshmem build's `import deep_ep` can dlopen
+# libnvshmem; LD_LIBRARY_PATH puts the from-source NVSHMEM ahead of any torch-bundled one.
+ENV NVSHMEM_DIR=/opt/nvshmem_src/install \
+    NVSHMEM_HOME=/opt/nvshmem_src/install \
+    NVSHMEM_REMOTE_TRANSPORT=libfabric \
+    NVSHMEM_LIBFABRIC_PROVIDER=efa \
+    LD_LIBRARY_PATH=/opt/nvshmem_src/install/lib:/opt/gdrcopy/lib:$LD_LIBRARY_PATH
 
 #####################################################
-## Build verification
+## Build verification (backend-aware)
 ##
 ## Runs via the SAME python3 the training uses (/opt/venv, first on PATH). We REALLY
-## `import deep_ep` here (not just find_spec): the wrapper does `from uccl.ep import ...`,
-## and a find_spec-only check would PASS even when the `uccl` package is split across
-## /usr/local (core) and /opt/venv (ep.abi3.so) so the real import fails. Importing
-## deep_ep loads uccl/ep.abi3.so but does NOT require a GPU/driver at import time
-## (verified GPU-less in the NeMo base) — only Buffer *instantiation* needs a GPU, which
-## 2.sanity-singlenode.sh (Gate 2) exercises on a real node. Versions via package
-## metadata (modules may not expose __version__). import megatron.core/bridge is GPU-less-safe.
+## `import deep_ep` here (not just find_spec): for uccl the wrapper does
+## `from uccl.ep import ...`, and for nvshmem the C extension dlopens libnvshmem — a
+## find_spec-only check would PASS even when those fail. Importing deep_ep does NOT
+## require a GPU/driver at import time (NVSHMEM init / Buffer instantiation does, which
+## 2.sanity-singlenode.sh Gate 2/5 exercises on a real node). Both arms must resolve
+## `import deep_ep` to our /opt build, NOT the base's IB/NVSHMEM-bound DeepEP in
+## dist-packages. import megatron.core/bridge is GPU-less-safe.
 #####################################################
-RUN python3 -c "import importlib.util as u, importlib.metadata as md; \
+RUN if [ "${EP_BACKEND}" = "uccl" ]; then \
+ python3 -c "import importlib.util as u, importlib.metadata as md; \
  from packaging.version import Version; \
  import deep_ep, uccl, megatron.core, megatron.bridge; \
  assert hasattr(deep_ep, 'Buffer'), 'deep_ep.Buffer missing (uccl.ep not wired into the deep_ep shadow)'; \
@@ -169,7 +228,25 @@ RUN python3 -c "import importlib.util as u, importlib.metadata as md; \
  print('deep_ep ->', deep_ep.__file__); \
  print('uccl ->', uccl.__file__, '(has ep:', u.find_spec('uccl.ep') is not None, ')'); \
  print('megatron-core', md.version('megatron-core')); \
- print('megatron-bridge', bridge_ver, '(B300 flex/deepep allowlist OK)')"
+ print('megatron-bridge', bridge_ver, '(B300 flex/deepep allowlist OK)')"; \
+ else \
+ python3 -c "import importlib.util as u, importlib.metadata as md, inspect; \
+ from packaging.version import Version; \
+ import megatron.core, megatron.bridge; \
+ spec = u.find_spec('deep_ep'); \
+ assert spec is not None and spec.origin, 'deep_ep not importable (NVIDIA DeepEP/NVSHMEM build failed)'; \
+ assert '/opt/venv/' in spec.origin, \
+   'deep_ep spec at %s, NOT the from-source EFA build in /opt/venv: the base ships an IB/NVSHMEM-bound DeepEP (dist-packages or editable /opt/DeepEP). Our setup.py install must shadow it.' % spec.origin; \
+ bridge_ver = md.version('megatron-bridge'); \
+ assert Version(bridge_ver) >= Version('0.4.0'), \
+   'megatron-bridge %s < 0.4.0: flex/deepep allowlist rejects B300 (the pin did not take)' % bridge_ver; \
+ from megatron.bridge.training.flex_dispatcher_backend import validate_flex_dispatcher_backend as _v; \
+ assert 'startswith' in inspect.getsource(_v), 'flex dispatcher allowlist is not the startswith() form (B300 unsupported)'; \
+ print('python ->', __import__('sys').executable); \
+ print('deep_ep spec ->', spec.origin, '(NVIDIA DeepEP, EFA/NVSHMEM-libfabric; real import+Buffer is GPU-gated to 2.sanity-singlenode.sh)'); \
+ print('megatron-core', md.version('megatron-core')); \
+ print('megatron-bridge', bridge_ver, '(B300 flex/deepep allowlist OK)')"; \
+ fi
 
 #####################################################
 ## Fabric / EFA environment

--- a/3.test_cases/megatron/megatron-bridge/Dockerfile
+++ b/3.test_cases/megatron/megatron-bridge/Dockerfile
@@ -191,7 +191,11 @@ RUN if [ "${EP_BACKEND}" = "nvshmem" ]; then set -eux; \
     rm -rf /opt/nvshmem_src/build /opt/deepep-efa-src; \
     else echo "EP_BACKEND=${EP_BACKEND}: skipping NVSHMEM/DeepEP build"; fi
 
-# NVSHMEM runtime env. Harmless for the uccl image (the dirs are absent there).
+# NVSHMEM runtime env. Set UNCONDITIONALLY on purpose: `ENV` cannot be gated on the
+# `EP_BACKEND` build ARG, so these are baked into the uccl image too. Harmless there because
+# the dirs are absent (nothing dlopens libfabric); the only latent risk is a future uccl
+# image that also ships NVSHMEM bits, which would then inherit a libfabric transport — revisit
+# this block if the uccl build ever gains NVSHMEM.
 # Must PRECEDE the verify RUN so the nvshmem build's `import deep_ep` can dlopen
 # libnvshmem; LD_LIBRARY_PATH puts the from-source NVSHMEM ahead of any torch-bundled one.
 ENV NVSHMEM_DIR=/opt/nvshmem_src/install \

--- a/3.test_cases/megatron/megatron-bridge/Dockerfile
+++ b/3.test_cases/megatron/megatron-bridge/Dockerfile
@@ -188,6 +188,7 @@ RUN if [ "${EP_BACKEND}" = "nvshmem" ]; then set -eux; \
       --venv /opt/venv \
       --deepep-src /opt/deepep-efa-src \
       --nvshmem-src /opt/nvshmem_src; \
+    rm -rf /opt/nvshmem_src/build /opt/deepep-efa-src; \
     else echo "EP_BACKEND=${EP_BACKEND}: skipping NVSHMEM/DeepEP build"; fi
 
 # NVSHMEM runtime env. Harmless for the uccl image (the dirs are absent there).

--- a/3.test_cases/megatron/megatron-bridge/README.md
+++ b/3.test_cases/megatron/megatron-bridge/README.md
@@ -9,12 +9,23 @@ that run Mixture-of-Experts (MoE) training on Amazon EKS with
 [UCCL-EP](https://github.com/uccl-project/uccl) carrying the expert-parallel
 all-to-all over **AWS EFA**.
 
-The crux is replacing NVIDIA [DeepEP](https://github.com/deepseek-ai/DeepEP) (which is
-built on NVSHMEM + InfiniBand verbs and does **not** run on EFA) with UCCL's EFA-native
-drop-in — **without patching Megatron-Core**. UCCL ships a top-level `deep_ep` shadow
-module; because it installs into `site-packages`, `import deep_ep` resolves to UCCL's
-EFA RDMA implementation. Megatron-Core's MoE `flex`/`deepep` dispatcher then sends its
-all-to-all bytes over EFA via UCCL + GDRCopy instead of over IB verbs via NVSHMEM.
+The crux is carrying the Megatron-Core `flex`/`deepep` all-to-all over **AWS EFA**
+— **without patching Megatron-Core**. NVIDIA [DeepEP](https://github.com/deepseek-ai/DeepEP)
+is built on NVSHMEM + InfiniBand verbs and does **not** run on EFA *out of the box*. Two
+EFA-native providers plug into the same `flex`/`deepep` path by shipping a top-level
+`deep_ep` module (installed into `site-packages`, so `import deep_ep` resolves to it):
+
+1. **UCCL** ([uccl-project/uccl](https://github.com/uccl-project/uccl)) — an EFA-native
+   `deep_ep` drop-in (UCCL-EP + GDRCopy). This is the default image (`EP_BACKEND=uccl`).
+2. **NVIDIA DeepEP, EFA-patched** — DeepEP itself, rebuilt to run **NVSHMEM over libfabric**
+   (host-proxy, IBGDA off) on EFA, via the patches in
+   [`../../micro-benchmarks/expert-parallelism/deepep-benchmark`](../../../micro-benchmarks/expert-parallelism/deepep-benchmark)
+   (vendored at [`deepep/`](deepep/)). Built with `EP_BACKEND=nvshmem`.
+
+So "stock DeepEP can't run on EFA" is true only of the IB/IBGDA build — patched, it does.
+The [`qwen3-235b/`](qwen3-235b/) case uses this to compare **NCCL all-to-all vs DeepEP+UCCL
+vs DeepEP+NVSHMEM** head-to-head. Select the provider with the `EP_BACKEND` Docker build arg
+(one Dockerfile, two image tags); see [Shared environment workflow](#shared-environment-workflow).
 
 ## Layout
 
@@ -67,6 +78,15 @@ bash 1.build-and-push.sh
 # Image: <account>.dkr.ecr.us-west-2.amazonaws.com/megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb
 ```
 
+For the **DeepEP+NVSHMEM** provider (used by the `qwen3-235b/` 3-way comparison), build the
+same Dockerfile with `EP_BACKEND=nvshmem` — it skips UCCL and instead builds NVIDIA DeepEP
+(`567632d`) over NVSHMEM v3.7 (libfabric/EFA, IBGDA off) into `/opt/venv`:
+
+```bash
+EP_BACKEND=nvshmem bash 1.build-and-push.sh
+# Image: <account>.dkr.ecr.us-west-2.amazonaws.com/megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13
+```
+
 ### 2. Single-node sanity gate
 
 **Do not skip this.** It is far cheaper to fail on 1 node than to burn 32 capacity-block
@@ -95,10 +115,11 @@ Both models provide the same two workloads — full-parameter SFT (`conf/` + `ku
 and the UCCL-EP vs NCCL all-to-all dispatcher A/B (`benchmarks/`) — in a structurally
 identical directory layout.
 
-| Model | Directory | Workloads (32× p6-b300 / 256× B300) |
+| Model | Directory | Workloads |
 |-------|-----------|--------|
-| [Kimi K2](https://huggingface.co/moonshotai/Kimi-K2-Base) (1.04T MoE, 384 experts) | [`kimi-k2/`](kimi-k2/) | Full-parameter SFT + UCCL-EP vs NCCL dispatcher A/B |
-| [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3) (671B MoE, 256 experts) | [`dsv3/`](dsv3/) | Full-parameter SFT + UCCL-EP vs NCCL dispatcher A/B |
+| [Kimi K2](https://huggingface.co/moonshotai/Kimi-K2-Base) (1.04T MoE, 384 experts) | [`kimi-k2/`](kimi-k2/) | Full-parameter SFT + UCCL-EP vs NCCL dispatcher A/B (32× p6-b300) |
+| [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3) (671B MoE, 256 experts) | [`dsv3/`](dsv3/) | Full-parameter SFT + UCCL-EP vs NCCL dispatcher A/B (32× p6-b300) |
+| [Qwen3-235B-A22B](https://huggingface.co/Qwen/Qwen3-235B-A22B) (235B MoE, 128 experts) | [`qwen3-235b/`](qwen3-235b/) | **3-way** dispatcher comparison: NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM, EP16/EP32 (8× p6-b300) |
 
 To add a model: create `megatron-bridge/<model>/` with its `conf/`, deployment manifests,
 and a model README (and a `benchmarks/` entrypoint if you want the dispatcher A/B). Reuse the

--- a/3.test_cases/megatron/megatron-bridge/README.md
+++ b/3.test_cases/megatron/megatron-bridge/README.md
@@ -119,7 +119,8 @@ identical directory layout.
 |-------|-----------|--------|
 | [Kimi K2](https://huggingface.co/moonshotai/Kimi-K2-Base) (1.04T MoE, 384 experts) | [`kimi-k2/`](kimi-k2/) | Full-parameter SFT + UCCL-EP vs NCCL dispatcher A/B (32× p6-b300) |
 | [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3) (671B MoE, 256 experts) | [`dsv3/`](dsv3/) | Full-parameter SFT + UCCL-EP vs NCCL dispatcher A/B (32× p6-b300) |
-| [Qwen3-235B-A22B](https://huggingface.co/Qwen/Qwen3-235B-A22B) (235B MoE, 128 experts) | [`qwen3-235b/`](qwen3-235b/) | **3-way** dispatcher comparison: NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM, EP16/EP32 (8× p6-b300) |
+| [Qwen3-235B-A22B](https://huggingface.co/Qwen/Qwen3-235B-A22B) (235B MoE, 128 experts) | [`qwen3-235b/`](qwen3-235b/) | **3-way** dispatcher comparison: NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM, EP16/EP32 (8× p6-b300 / B300) |
+| [Qwen3-30B-A3B](https://huggingface.co/Qwen/Qwen3-30B-A3B) (30B MoE, 128 experts) | [`qwen3-30b/`](qwen3-30b/) | Same **3-way** comparison on **8× p5.48xlarge / H100** (the size that fits H100-80GB), EP16/EP32 |
 
 To add a model: create `megatron-bridge/<model>/` with its `conf/`, deployment manifests,
 and a model README (and a `benchmarks/` entrypoint if you want the dispatcher A/B). Reuse the

--- a/3.test_cases/megatron/megatron-bridge/README.md
+++ b/3.test_cases/megatron/megatron-bridge/README.md
@@ -127,7 +127,9 @@ and a model README (and a `benchmarks/` entrypoint if you want the dispatcher A/
 shared image from step 1 (mount the model's `conf` at runtime) and the shared
 `convert-checkpoint.sh` — do **not** add a second Dockerfile.
 
-## Benchmark result — UCCL-EP vs NCCL all-to-all (256× B300)
+## Benchmark results & dispatcher recommendation
+
+### DeepSeek-V3, 32× p6-b300 / 256× B300 — UCCL-EP vs NCCL all-to-all
 
 The headline measurement this environment was built for: swapping **only** the
 Megatron-Core MoE token dispatcher — NCCL all-to-all (baseline) vs UCCL's EFA-native
@@ -153,6 +155,50 @@ per-dispatch overhead unamortized), an operating point no throughput-tuned run u
 > verified two ways: drop-free config + an iteration-1 loss match (deepep 11.897349 vs
 > alltoall 11.897517). `overlap=on` is a separate within-regime A/B (VPP=2 + recompute
 > off on both arms) — do not subtract its numbers against the `overlap=off` rows.
+
+### Qwen3 three-way comparison, 8 nodes — NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM
+
+Adds the NVIDIA DeepEP+NVSHMEM-over-EFA arm and a second fabric (H100). Mean iter time at
+mb=4, overlap=off; `Δ` vs NCCL all-to-all (− = DeepEP faster). Full tables:
+[`qwen3-235b/benchmarks/RESULTS.md`](qwen3-235b/benchmarks/RESULTS.md) (B300),
+[`qwen3-30b/benchmarks/RESULTS.md`](qwen3-30b/benchmarks/RESULTS.md) (H100).
+
+| Hardware (8 nodes) | Model | EP | NCCL | DeepEP+UCCL | DeepEP+NVSHMEM |
+|---|---|---:|---:|---:|---:|
+| p6-b300 / B300 | Qwen3-235B | 16 | 12.21 s | +6.9% | **−5.2%** |
+| p6-b300 / B300 | Qwen3-235B | 32 | 15.91 s | +15.9% | +28.3% |
+| p5.48xlarge / H100 | Qwen3-30B | 16 | 8.60 s | +72% | +6.6% |
+| p5.48xlarge / H100 | Qwen3-30B | 32 | 9.24 s | +187% | +86% |
+
+At this 8-node scale NCCL all-to-all is fastest almost everywhere (lone exception: B300 EP16,
+where DeepEP+NVSHMEM edges it by 5.2%). DeepEP+NVSHMEM is consistently the stronger of the two
+DeepEP backends, and the DeepEP penalty **shrinks as EP drops (EP32→EP16)** and grows on the
+lower-bandwidth H100 fabric / smaller (30B) model.
+
+### Recommendation (scale-dependent)
+
+The dispatcher choice on EFA depends primarily on **scale (EP span / node count)**, and only
+secondarily on the instance/fabric:
+
+- **Small scale (≲8 nodes, up to EP32): default to NCCL all-to-all.** Without IBGDA, DeepEP on
+  EFA runs the NVSHMEM/UCCL **host-proxy** path and can't use GPU-initiated RDMA; at small EP
+  span that overhead dominates and NCCL's dense all-to-all wins (Qwen3 tables above).
+- **Large scale (≳16–32 nodes, large EP span): prefer DeepEP.** DeepEP does **sparse dispatch**
+  (tokens go only to their routed experts), so its advantage grows with node count and overtakes
+  the host-proxy penalty. Measured: **UCCL −36%** on DSV3 256× B300, and **−34% at 32 nodes /
+  −21% at 16 nodes** on Kimi-K2 ([`kimi-k2/benchmarks/RESULTS.md`](kimi-k2/benchmarks/RESULTS.md))
+  — the win itself scales with node count.
+- **DeepEP+NVSHMEM is the promising backend to watch.** It is the best DeepEP backend at every
+  8-node point here (and beats NCCL at B300 EP16), and standalone EP micro-benchmarks suggest it
+  is competitive-to-better than UCCL in throughput mode — so it is a strong candidate for the
+  large-scale regime. **Not yet validated at 16–32 nodes** (UCCL is the proven large-scale
+  choice today; NVSHMEM at K2 scale is the top follow-up).
+- **Fabric is second-order.** DeepEP looked worst on H100 (p5.48xlarge, lower EFA bandwidth
+  exposes the host-proxy cost) and better on B300; p5en/newer should help. But it still lost at
+  B300 8-node/EP32 — so treat this as **scale-primary, fabric-secondary**.
+
+All numbers use mock data + **balanced routing**; skewed / real expert routing is not yet
+tested and could shift the balance.
 
 ## References
 

--- a/3.test_cases/megatron/megatron-bridge/README.md
+++ b/3.test_cases/megatron/megatron-bridge/README.md
@@ -166,14 +166,15 @@ mb=4, overlap=off; `Δ` vs NCCL all-to-all (− = DeepEP faster). Full tables:
 | Hardware (8 nodes) | Model | EP | NCCL | DeepEP+UCCL | DeepEP+NVSHMEM |
 |---|---|---:|---:|---:|---:|
 | p6-b300 / B300 | Qwen3-235B | 16 | 12.21 s | +6.9% | **−5.2%** |
-| p6-b300 / B300 | Qwen3-235B | 32 | 15.91 s | +15.9% | +28.3% |
+| p6-b300 / B300 | Qwen3-235B | 32 | 15.76 s | +21.5% | +34.0% |
 | p5.48xlarge / H100 | Qwen3-30B | 16 | 8.60 s | +72% | +6.6% |
 | p5.48xlarge / H100 | Qwen3-30B | 32 | 9.24 s | +187% | +86% |
 
 At this 8-node scale NCCL all-to-all is fastest almost everywhere (lone exception: B300 EP16,
-where DeepEP+NVSHMEM edges it by 5.2%). DeepEP+NVSHMEM is consistently the stronger of the two
-DeepEP backends, and the DeepEP penalty **shrinks as EP drops (EP32→EP16)** and grows on the
-lower-bandwidth H100 fabric / smaller (30B) model.
+where DeepEP+NVSHMEM edges it by 5.2%). DeepEP+NVSHMEM is the stronger of the two DeepEP backends
+in most cells (both H100 points and B300 EP16), though UCCL edges it at B300 EP32 (mb=4); the
+DeepEP penalty **shrinks as EP drops (EP32→EP16)** and grows on the lower-bandwidth H100 fabric /
+smaller (30B) model.
 
 ### Recommendation (scale-dependent)
 
@@ -188,11 +189,12 @@ secondarily on the instance/fabric:
   the host-proxy penalty. Measured: **UCCL −36%** on DSV3 256× B300, and **−34% at 32 nodes /
   −21% at 16 nodes** on Kimi-K2 ([`kimi-k2/benchmarks/RESULTS.md`](kimi-k2/benchmarks/RESULTS.md))
   — the win itself scales with node count.
-- **DeepEP+NVSHMEM is the promising backend to watch.** It is the best DeepEP backend at every
-  8-node point here (and beats NCCL at B300 EP16), and standalone EP micro-benchmarks suggest it
-  is competitive-to-better than UCCL in throughput mode — so it is a strong candidate for the
-  large-scale regime. **Not yet validated at 16–32 nodes** (UCCL is the proven large-scale
-  choice today; NVSHMEM at K2 scale is the top follow-up).
+- **DeepEP+NVSHMEM is the promising backend to watch.** It is the best DeepEP backend at most
+  8-node points here (both H100 EPs and B300 EP16, where it beats NCCL; UCCL edges it only at
+  B300 EP32 mb=4), and standalone EP micro-benchmarks suggest it is competitive-to-better than
+  UCCL in throughput mode — so it is a strong candidate for the large-scale regime. **Not yet
+  validated at 16–32 nodes** (UCCL is the proven large-scale choice today; NVSHMEM at K2 scale is
+  the top follow-up).
 - **Fabric is second-order.** DeepEP looked worst on H100 (p5.48xlarge, lower EFA bandwidth
   exposes the host-proxy cost) and better on B300; p5en/newer should help. But it still lost at
   B300 8-node/EP32 — so treat this as **scale-primary, fabric-secondary**.

--- a/3.test_cases/megatron/megatron-bridge/bench/parse-runs.py
+++ b/3.test_cases/megatron/megatron-bridge/bench/parse-runs.py
@@ -37,11 +37,11 @@ RE_TFLOPS = re.compile(r"(?:throughput per GPU \(TFLOP/s/GPU\)|TFLOP/s/GPU|tflop
 RE_GBS = re.compile(r"global batch size:\s*(\d+)")
 RE_EFA = re.compile(r"Selected provider is efa")
 RE_UCCL = re.compile(r"Registered proxies|high-throughput mode")
-# NVSHMEM-over-libfabric init banner (NVIDIA DeepEP arm). Tolerant: NVSHMEM prints an
-# init/version line and DeepEP logs its buffer setup; any of these confirms the NVSHMEM
-# transport is live (the analogue of RE_UCCL for the UCCL arm). The hard EFA gate
-# (RE_EFA) still applies to ALL arms.
-RE_NVSHMEM = re.compile(r"NVSHMEM INFO|nvshmem_init|NVSHMEM[^\n]*libfabric|libfabric[^\n]*efa|Initializing NVSHMEM", re.I)
+# NVSHMEM init banner (NVIDIA DeepEP arm). Must be NVSHMEM-SPECIFIC — the generic
+# "libfabric ... efa" string also appears in the NCCL/aws-ofi init of every arm, so we key
+# only on NVSHMEM's own version/init lines (e.g. "NVSHMEM v3.7.0"). This is the analogue of
+# RE_UCCL for the UCCL arm. The hard EFA gate (RE_EFA) still applies to ALL arms.
+RE_NVSHMEM = re.compile(r"NVSHMEM INFO|nvshmem_init|Initializing NVSHMEM|NVSHMEM v[0-9]")
 
 
 def parse_run(run_dir, warmup, debug=False):

--- a/3.test_cases/megatron/megatron-bridge/bench/parse-runs.py
+++ b/3.test_cases/megatron/megatron-bridge/bench/parse-runs.py
@@ -37,6 +37,11 @@ RE_TFLOPS = re.compile(r"(?:throughput per GPU \(TFLOP/s/GPU\)|TFLOP/s/GPU|tflop
 RE_GBS = re.compile(r"global batch size:\s*(\d+)")
 RE_EFA = re.compile(r"Selected provider is efa")
 RE_UCCL = re.compile(r"Registered proxies|high-throughput mode")
+# NVSHMEM-over-libfabric init banner (NVIDIA DeepEP arm). Tolerant: NVSHMEM prints an
+# init/version line and DeepEP logs its buffer setup; any of these confirms the NVSHMEM
+# transport is live (the analogue of RE_UCCL for the UCCL arm). The hard EFA gate
+# (RE_EFA) still applies to ALL arms.
+RE_NVSHMEM = re.compile(r"NVSHMEM INFO|nvshmem_init|NVSHMEM[^\n]*libfabric|libfabric[^\n]*efa|Initializing NVSHMEM", re.I)
 
 
 def parse_run(run_dir, warmup, debug=False):
@@ -55,7 +60,7 @@ def parse_run(run_dir, warmup, debug=False):
     iter_log = max(logs, key=_rank)              # last node: per-iteration training lines
     rank0_log = min(logs, key=_rank)             # first node: EFA / UCCL-proxy init signals
     iters = []  # (iter, loss, time_s, tflops, gbs)
-    efa_ok = uccl_ok = False
+    efa_ok = uccl_ok = nvshmem_ok = False
     for sig_log in {rank0_log, iter_log}:
         with open(sig_log, errors="replace") as f:
             for line in f:
@@ -63,6 +68,8 @@ def parse_run(run_dir, warmup, debug=False):
                     efa_ok = True
                 if RE_UCCL.search(line):
                     uccl_ok = True
+                if RE_NVSHMEM.search(line):
+                    nvshmem_ok = True
     with open(iter_log, errors="replace") as f:
         for line in f:
             mi = RE_ITER.search(line)
@@ -110,6 +117,7 @@ def parse_run(run_dir, warmup, debug=False):
         "stalls": stalls,
         "efa_ok": efa_ok,
         "uccl_ok": uccl_ok,
+        "nvshmem_ok": nvshmem_ok,
     }
 
 
@@ -148,24 +156,30 @@ def main():
         sp = os.path.join(run_dir, "STATUS")
         if os.path.isfile(sp):
             status = open(sp).read().strip().replace("\n", " ")
+        # backend (uccl|nvshmem|"") labels the deepep transport for the 3-way comparison;
+        # arm_label is the full per-run label (e.g. deepep-nvshmem-ep32). Both come from
+        # env.txt (older runs without them fall back to deriving from the run tag).
         rows.append({
             "model": model, "run": tag,
             "arm": env.get("arm", tag.split("-")[0]),
+            "arm_label": env.get("arm_label", tag.split("-mb")[0]),
+            "backend": env.get("ep_backend", ""),
+            "ep": env.get("EP", ""),
             "mb": env.get("mb", ""), "overlap": env.get("overlap", ""),
             "mean_iter_s": "%.4f" % s["mean_iter_s"],
             "median_iter_s": "%.4f" % s["median_iter_s"],
             "tflops_per_gpu": "%.2f" % s["tflops_per_gpu"],
             "tok_s": "%.1f" % s["tok_s"],
             "stalls": s["stalls"], "n_steady": s["n_steady"],
-            "efa_ok": s["efa_ok"], "uccl_ok": s["uccl_ok"],
+            "efa_ok": s["efa_ok"], "uccl_ok": s["uccl_ok"], "nvshmem_ok": s["nvshmem_ok"],
             "git_rev": env.get("git_rev", ""), "status": status,
         })
 
     if not rows:
         sys.exit("no runs with logs/rank-0.log found under %s" % campaign)
-    cols = ["model", "run", "arm", "mb", "overlap", "mean_iter_s", "median_iter_s",
-            "tflops_per_gpu", "tok_s", "stalls", "n_steady", "efa_ok", "uccl_ok",
-            "git_rev", "status"]
+    cols = ["model", "run", "arm", "arm_label", "backend", "ep", "mb", "overlap",
+            "mean_iter_s", "median_iter_s", "tflops_per_gpu", "tok_s", "stalls",
+            "n_steady", "efa_ok", "uccl_ok", "nvshmem_ok", "git_rev", "status"]
     idx = os.path.join(campaign, "index.csv")
     with open(idx, "w", newline="") as fh:
         w = csv.DictWriter(fh, fieldnames=cols)
@@ -173,12 +187,13 @@ def main():
         w.writerows(rows)
     sys.stderr.write("wrote %s (%d runs)\n" % (idx, len(rows)))
     # echo a readable table to stdout
-    print("%-8s %-22s %10s %10s %8s %6s %7s %7s" %
-          ("model", "run", "mean_s", "tflop/gpu", "tok/s", "stalls", "efa", "uccl"))
+    print("%-10s %-26s %9s %10s %10s %6s %5s %6s %8s" %
+          ("model", "run", "backend", "mean_s", "tflop/gpu", "tok/s", "efa", "stalls", "transport"))
     for r in rows:
-        print("%-8s %-22s %10s %10s %8s %6s %7s %7s" %
-              (r["model"], r["run"], r["mean_iter_s"], r["tflops_per_gpu"],
-               r["tok_s"], r["stalls"], r["efa_ok"], r["uccl_ok"]))
+        transport = "uccl" if r["uccl_ok"] else ("nvshmem" if r["nvshmem_ok"] else "-")
+        print("%-10s %-26s %9s %9s %10s %10s %5s %6s %8s" %
+              (r["model"], r["run"], r["backend"] or "-", r["mean_iter_s"],
+               r["tflops_per_gpu"], r["tok_s"], r["efa_ok"], r["stalls"], transport))
 
 
 if __name__ == "__main__":

--- a/3.test_cases/megatron/megatron-bridge/bench/parse-runs.py
+++ b/3.test_cases/megatron/megatron-bridge/bench/parse-runs.py
@@ -97,7 +97,14 @@ def parse_run(run_dir, warmup, debug=False):
     times = [r[2] for r in steady if r[2] == r[2]]
     tfs = [r[3] for r in steady if r[3] == r[3]]
     gbs = next((r[4] for r in iters if r[4]), 0)
+    # Sequence length for the tok/s derivation: read it from env.txt (recorded as "seq=NNNN")
+    # rather than hardcoding, so a SEQ_LEN override doesn't silently skew derived tok/s.
     seq = 4096
+    _envp = os.path.join(run_dir, "env.txt")
+    if os.path.isfile(_envp):
+        _m = re.search(r"\bseq=(\d+)", open(_envp, errors="replace").read())
+        if _m:
+            seq = int(_m.group(1))
     n = len(times)
     mean_t = sum(times) / n if n else float("nan")
     med_t = sorted(times)[n // 2] if n else float("nan")
@@ -186,14 +193,13 @@ def main():
         w.writeheader()
         w.writerows(rows)
     sys.stderr.write("wrote %s (%d runs)\n" % (idx, len(rows)))
-    # echo a readable table to stdout
-    print("%-10s %-26s %9s %10s %10s %6s %5s %6s %8s" %
-          ("model", "run", "backend", "mean_s", "tflop/gpu", "tok/s", "efa", "stalls", "transport"))
+    # echo a readable table to stdout (one shared fmt so header and rows always align)
+    _FMT = "%-10s %-28s %8s %9s %10s %10s %6s %6s %9s"
+    print(_FMT % ("model", "run", "backend", "mean_s", "tflop/gpu", "tok/s", "efa", "stalls", "transport"))
     for r in rows:
         transport = "uccl" if r["uccl_ok"] else ("nvshmem" if r["nvshmem_ok"] else "-")
-        print("%-10s %-26s %9s %9s %10s %10s %5s %6s %8s" %
-              (r["model"], r["run"], r["backend"] or "-", r["mean_iter_s"],
-               r["tflops_per_gpu"], r["tok_s"], r["efa_ok"], r["stalls"], transport))
+        print(_FMT % (r["model"], r["run"], r["backend"] or "-", r["mean_iter_s"],
+                      r["tflops_per_gpu"], r["tok_s"], r["efa_ok"], r["stalls"], transport))
 
 
 if __name__ == "__main__":

--- a/3.test_cases/megatron/megatron-bridge/deepep/README.md
+++ b/3.test_cases/megatron/megatron-bridge/deepep/README.md
@@ -1,0 +1,23 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: MIT-0 -->
+
+# Vendored DeepEP-on-EFA build script
+
+`setup_deepep_efa.sh` here is a **verbatim copy** of
+[`micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh`](../../../../micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh).
+It is vendored into this directory only so the shared `Dockerfile` can `COPY` it when
+built with `--build-arg EP_BACKEND=nvshmem` — Docker cannot `COPY` files from outside
+the build context, and the build context is this test-case directory.
+
+It builds **NVIDIA DeepEP over NVSHMEM-libfabric for AWS EFA** (host-proxy, IBGDA off)
+via four source patches: a combined put+signal, an IBGDA→host-proxy shim, fake IBGDA
+device state, and `NVSHMEM_MAX_TEAMS` 7→8. See that benchmark's
+[README](../../../../micro-benchmarks/expert-parallelism/deepep-benchmark/README.md) for
+the full rationale.
+
+**Keep in sync with the canonical copy.** If the benchmark script changes, re-copy:
+
+```bash
+cp ../../../../micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh \
+   setup_deepep_efa.sh
+```

--- a/3.test_cases/megatron/megatron-bridge/deepep/README.md
+++ b/3.test_cases/megatron/megatron-bridge/deepep/README.md
@@ -21,3 +21,7 @@ the full rationale.
 cp ../../../../micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh \
    setup_deepep_efa.sh
 ```
+
+Drift is guarded in CI: [`.github/workflows/deepep-vendor-sync.yml`](../../../../.github/workflows/deepep-vendor-sync.yml)
+diffs this copy against the canonical source on any PR that touches either file and fails on
+mismatch.

--- a/3.test_cases/megatron/megatron-bridge/deepep/setup_deepep_efa.sh
+++ b/3.test_cases/megatron/megatron-bridge/deepep/setup_deepep_efa.sh
@@ -1,0 +1,469 @@
+#!/bin/bash
+# Build DeepEP with NVSHMEM EFA (libfabric) transport for AWS EFA clusters.
+#
+# This script patches an existing DeepEP source tree for EFA, builds NVSHMEM
+# from an existing source tree, and builds DeepEP against it.
+#
+# Assumes it runs on the build machine (with CUDA, libfabric, Python+PyTorch).
+#
+# Usage:
+#   ./setup_deepep_efa.sh --deepep-src <path> --nvshmem-src <path> [options]
+#
+# Required:
+#   --deepep-src <path>       Path to existing DeepEP source tree
+#   --nvshmem-src <path>      Path to existing NVSHMEM source tree
+#   --venv <path>             Python venv to activate before build
+#
+# Build environment:
+#   --cuda-home <path>        CUDA toolkit (default: /usr/local/cuda)
+#   --libfabric-home <path>   Libfabric install (default: /opt/amazon/efa)
+#   --gdrcopy-home <path>     GDRCopy install (default: /usr)
+#   --gpu-arch <arch>         CUDA architecture(s), semicolon-separated (default: 90).
+#                             e.g. "90;100" builds one image for Hopper + Blackwell.
+
+set -euo pipefail
+
+# --- Defaults ---
+DEEPEP_SRC=""
+NVSHMEM_SRC=""
+CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+LIBFABRIC_HOME="${LIBFABRIC_HOME:-/opt/amazon/efa}"
+GDRCOPY_HOME="${GDRCOPY_HOME:-/usr}"
+GPU_ARCH="${GPU_ARCH:-90}"
+VENV=""
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --deepep-src)       DEEPEP_SRC="$2"; shift 2 ;;
+        --nvshmem-src)      NVSHMEM_SRC="$2"; shift 2 ;;
+        --cuda-home)        CUDA_HOME="$2"; shift 2 ;;
+        --libfabric-home)   LIBFABRIC_HOME="$2"; shift 2 ;;
+        --gdrcopy-home)     GDRCOPY_HOME="$2"; shift 2 ;;
+        --gpu-arch)         GPU_ARCH="$2"; shift 2 ;;
+        --venv)             VENV="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# Derive TORCH_CUDA_ARCH_LIST from GPU_ARCH (e.g. 90 -> 9.0, 100 -> 10.0).
+# GPU_ARCH may be a semicolon-separated list (e.g. "90;100") to build a single
+# image that runs on multiple architectures (Hopper + Blackwell).
+TORCH_CUDA_ARCH_LIST=""
+IFS=';' read -ra _GPU_ARCHS <<< "$GPU_ARCH"
+for _arch in "${_GPU_ARCHS[@]}"; do
+    TORCH_CUDA_ARCH_LIST+="${_arch%?}.${_arch: -1};"
+done
+TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST%;}"
+
+# --- Validate required args ---
+if [[ -z "$DEEPEP_SRC" ]]; then
+    echo "ERROR: --deepep-src is required"
+    exit 1
+fi
+if [[ -z "$NVSHMEM_SRC" ]]; then
+    echo "ERROR: --nvshmem-src is required"
+    exit 1
+fi
+if [[ -z "$VENV" ]]; then
+    echo "ERROR: --venv is required (PEP 668 — use a virtual environment)"
+    exit 1
+fi
+if [[ ! -f "$DEEPEP_SRC/csrc/kernels/internode.cu" ]]; then
+    echo "ERROR: $DEEPEP_SRC does not look like a DeepEP source tree"
+    exit 1
+fi
+if [[ ! -f "$NVSHMEM_SRC/CMakeLists.txt" ]]; then
+    echo "ERROR: $NVSHMEM_SRC does not look like an NVSHMEM source tree"
+    exit 1
+fi
+
+DEEPEP_SRC="$(cd "$DEEPEP_SRC" && pwd)"
+NVSHMEM_SRC="$(cd "$NVSHMEM_SRC" && pwd)"
+NVSHMEM_INSTALL_DIR="$NVSHMEM_SRC/install"
+
+# --- Activate venv ---
+echo "Activating venv: $VENV"
+# venv activate scripts may reference unset vars (e.g. LD_LIBRARY_PATH)
+set +u
+source "$VENV/bin/activate"
+set -u
+
+# --- Validate environment ---
+export CUDA_HOME
+export PATH="$CUDA_HOME/bin:$PATH"
+
+if ! "$CUDA_HOME/bin/nvcc" --version &>/dev/null; then
+    echo "ERROR: nvcc not found at $CUDA_HOME/bin/nvcc. Set --cuda-home."
+    exit 1
+fi
+
+if [[ ! -d "$LIBFABRIC_HOME/lib" ]]; then
+    echo "ERROR: libfabric not found at $LIBFABRIC_HOME. Set --libfabric-home."
+    exit 1
+fi
+
+CUDA_VERSION=$("$CUDA_HOME/bin/nvcc" --version | grep -oP 'release \K[0-9]+\.[0-9]+')
+
+echo "=== DeepEP EFA Setup ==="
+echo "  DeepEP source:  $DEEPEP_SRC"
+echo "  NVSHMEM source: $NVSHMEM_SRC"
+echo "  CUDA:           $CUDA_HOME (CUDA $CUDA_VERSION)"
+echo "  Libfabric:      $LIBFABRIC_HOME"
+echo "  GDRCopy:        $GDRCOPY_HOME"
+echo "  GPU arch:       $GPU_ARCH"
+echo ""
+
+########################################################################
+# Step 1: Patch DeepEP
+########################################################################
+# Tested with DeepEP commit 567632d (pre-EPv2, main branch).
+# EPv2 (merged Apr 29 2026) restructures the kernel sources and switches to
+# the NCCL GIN backend.  This script targets the legacy NVSHMEM code path.
+DEEPEP_COMPAT_COMMIT="567632d"
+
+echo ">>> Step 1: Patch DeepEP for EFA"
+
+cd "$DEEPEP_SRC"
+
+# Verify commit compatibility
+CURRENT_COMMIT=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
+if [[ "$CURRENT_COMMIT" != "$DEEPEP_COMPAT_COMMIT" ]]; then
+    echo "ERROR: DeepEP HEAD is $CURRENT_COMMIT, expected $DEEPEP_COMPAT_COMMIT."
+    echo "       This script is tested with commit $DEEPEP_COMPAT_COMMIT (pre-EPv2)."
+    exit 1
+fi
+
+# 0. Apply combined put+signal patch to internode.cu
+#    Use a per-invocation temp file (not a fixed /tmp path) so concurrent users on
+#    a shared node don't collide on a sticky-bit-owned /tmp/deepep-put-signal.patch.
+PUT_SIGNAL_PATCH="$(mktemp -t deepep-put-signal.XXXXXX.patch)"
+cat > "$PUT_SIGNAL_PATCH" << 'PATCHEOF'
+diff --git a/csrc/kernels/internode.cu b/csrc/kernels/internode.cu
+index 48c6c00..1cce923 100644
+--- a/csrc/kernels/internode.cu
++++ b/csrc/kernels/internode.cu
+@@ -815,13 +815,14 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
+                         reinterpret_cast<uint64_t>(rdma_channel_data.recv_buffer(rdma_rank) + dst_slot_idx * num_bytes_per_token);
+                     const auto src_ptr =
+                         reinterpret_cast<uint64_t>(rdma_channel_data.send_buffer(dst_rdma_rank) + dst_slot_idx * num_bytes_per_token);
+-                    nvshmemi_ibgda_put_nbi_warp<true>(dst_ptr,
++                    nvshmemi_ibgda_put_signal_nbi_warp<true>(dst_ptr,
+                                                       src_ptr,
+                                                       num_bytes_per_msg,
++                                                      rdma_channel_tail.buffer(rdma_rank),
++                                                      num_tokens_to_issue,
+                                                       translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank),
+                                                       channel_id,
+-                                                      lane_id,
+-                                                      0);
++                                                      lane_id);
+                 } else {
+                     // Lighter fence for local RDMA rank
+                     memory_fence();
+@@ -832,11 +833,9 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
+                 if (lane_id == dst_rdma_rank) {
+                     last_issued_tail += num_tokens_to_issue;
+                     num_tokens_to_send -= num_tokens_to_issue;
+-                    nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_tail.buffer(rdma_rank),
+-                                                    num_tokens_to_issue,
+-                                                    translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank),
+-                                                    channel_id,
+-                                                    dst_rdma_rank == rdma_rank);
++                    if (dst_rdma_rank == rdma_rank) {
++                        atomicAdd(reinterpret_cast<unsigned long long*>(rdma_channel_tail.buffer(rdma_rank)), static_cast<unsigned long long>(num_tokens_to_issue));
++                    }
+                 }
+                 __syncwarp();
+             }
+@@ -2115,13 +2114,14 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * 32, 1) combine(int4* co
+                             reinterpret_cast<uint64_t>(rdma_channel_data.recv_buffer(rdma_rank) + rdma_slot_idx * num_bytes_per_token);
+                         const auto src_ptr =
+                             reinterpret_cast<uint64_t>(rdma_channel_data.send_buffer(dst_rdma_rank) + rdma_slot_idx * num_bytes_per_token);
+-                        nvshmemi_ibgda_put_nbi_warp<true>(dst_ptr,
++                        nvshmemi_ibgda_put_signal_nbi_warp<true>(dst_ptr,
+                                                           src_ptr,
+                                                           num_bytes_per_msg,
++                                                          rdma_channel_tail.buffer(rdma_rank),
++                                                          num_chunked_tokens,
+                                                           translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank),
+                                                           channel_id,
+-                                                          lane_id,
+-                                                          0);
++                                                          lane_id);
+                     } else {
+                         memory_fence();
+                     }
+@@ -2129,11 +2129,10 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * 32, 1) combine(int4* co
+                     // Write new RDMA tail
+                     __syncwarp();
+                     if (elect_one_sync()) {
+-                        nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_tail.buffer(rdma_rank),
+-                                                        num_chunked_tokens,
+-                                                        translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank),
+-                                                        channel_id,
+-                                                        dst_rdma_rank == rdma_rank);
++                        if (dst_rdma_rank == rdma_rank) {
++                            atomicAdd(reinterpret_cast<unsigned long long int*>(rdma_channel_tail.buffer(rdma_rank)),
++                                      static_cast<unsigned long long int>(num_chunked_tokens));
++                        }
+                     }
+                 }
+             }
+PATCHEOF
+git apply "$PUT_SIGNAL_PATCH"
+rm -f "$PUT_SIGNAL_PATCH"
+echo "  Applied put+signal patch to internode.cu"
+
+# 1. Replace ibgda_device.cuh with EFA shim (same filename, no include changes needed)
+cat > csrc/kernels/ibgda_device.cuh << 'PATCH_EOF'
+// Portions derived from NVSHMEM (https://developer.nvidia.com/nvshmem)
+// Copyright (c) NVIDIA Corporation.
+// Licensed under the NVSHMEM Software License Agreement.
+//
+// EFA-compatible replacement for ibgda_device.cuh.
+// Replaces IBGDA GPU-initiated RDMA with NVSHMEM host-proxy QP APIs.
+#pragma once
+
+#include <type_traits>
+
+#include "configs.cuh"
+#include "exception.cuh"
+#include "nvshmemx.h"
+#include "utils.cuh"
+
+namespace deep_ep {
+
+/*
+ * Fake IBGDA device state for EFA.
+ *
+ * ibgda_get_state()->num_rc_per_pe and num_devices_initialized are used by
+ * internode.cu / internode_ll.cu to iterate over QPs per PE for quiet calls
+ * and to satisfy IBGDA-specific asserts:
+ *   internode.cu:    num_rc_per_pe == num_channels OR num_rc_per_pe >= num_sms
+ *   internode_ll.cu: num_rc_per_pe >= num_local_experts  (up to 288)
+ *
+ * Libfabric has 1 proxy endpoint per PE, so repeated quiet calls are
+ * idempotent and cheap (early-exit in nvshmemt_libfabric_quiet when
+ * submitted_ops == completed_ops + completed_staged_atomics).  Setting
+ * num_rc_per_pe = 288 satisfies both asserts without needing to patch
+ * them out.
+ */
+extern __device__ nvshmemi_ibgda_device_state_t g_fake_ibgda_device_state;
+extern __device__ int g_fake_ibgda_state_initialized;
+
+__device__ static __forceinline__ void init_fake_ibgda_device_state_if_needed() {
+    if (__ldg(&g_fake_ibgda_state_initialized))
+        return;
+
+    if (atomicCAS(&g_fake_ibgda_state_initialized, 0, 1) == 0) {
+        g_fake_ibgda_device_state.version = (1 << 16) + sizeof(nvshmemi_ibgda_device_state_t);
+        g_fake_ibgda_device_state.num_shared_dcis = 0;
+        g_fake_ibgda_device_state.num_exclusive_dcis = 0;
+        g_fake_ibgda_device_state.dci_map_type = NVSHMEMI_IBGDA_DEVICE_QP_MAP_TYPE_INVALID;
+        g_fake_ibgda_device_state.ndcts_per_pe = 0;
+        g_fake_ibgda_device_state.num_qp_groups = 0;
+        g_fake_ibgda_device_state.num_dct_groups = 0;
+        g_fake_ibgda_device_state.num_rc_per_pe = 288;
+        g_fake_ibgda_device_state.num_devices_initialized = 1;
+        g_fake_ibgda_device_state.rc_map_type = NVSHMEMI_IBGDA_DEVICE_QP_MAP_TYPE_INVALID;
+        g_fake_ibgda_device_state.num_requests_in_batch = 0;
+        g_fake_ibgda_device_state.log2_cumem_granularity = 0;
+        g_fake_ibgda_device_state.nic_buf_on_gpumem = false;
+        g_fake_ibgda_device_state.support_half_av_seg = false;
+        g_fake_ibgda_device_state.may_skip_cst = false;
+        g_fake_ibgda_device_state.use_async_postsend = false;
+        g_fake_ibgda_device_state.globalmem.qp_group_switches = nullptr;
+        g_fake_ibgda_device_state.globalmem.cqs = nullptr;
+        g_fake_ibgda_device_state.globalmem.dcis = nullptr;
+        g_fake_ibgda_device_state.globalmem.rcs = nullptr;
+        g_fake_ibgda_device_state.globalmem.local_only_mhandle_head = nullptr;
+        g_fake_ibgda_device_state.globalmem.dcts = nullptr;
+        g_fake_ibgda_device_state.globalmem.lkeys = nullptr;
+        g_fake_ibgda_device_state.globalmem.rkeys = nullptr;
+        g_fake_ibgda_device_state.extra = nullptr;
+        __threadfence();
+    }
+
+    while (!__ldg(&g_fake_ibgda_state_initialized)) {
+    }
+    __threadfence();
+}
+
+__device__ static __forceinline__ nvshmemi_ibgda_device_state_t* ibgda_get_state() {
+    init_fake_ibgda_device_state_if_needed();
+    return &g_fake_ibgda_device_state;
+}
+
+__device__ static __forceinline__ void nvshmemi_ibgda_quiet(int dst_pe, int _qp_id) {
+    int host_qp = NVSHMEMX_QP_DEFAULT;
+    nvshmemx_qp_quiet(dst_pe, &host_qp, 1);
+}
+
+template <bool kAlwaysDoPostSend = false>
+__device__ static __forceinline__ void nvshmemi_ibgda_put_nbi_warp(uint64_t req_rptr,
+                                                                   uint64_t req_lptr,
+                                                                   size_t bytes,
+                                                                   int dst_pe,
+                                                                   int _qp_id,
+                                                                   int lane_id,
+                                                                   int message_idx,
+                                                                   nvshmemx_qp_handle_t _qp_handle = NVSHMEMX_QP_DEFAULT) {
+    nvshmemx_qp_char_put_nbi_warp(reinterpret_cast<char*>(req_rptr), reinterpret_cast<char*>(req_lptr), bytes, dst_pe, NVSHMEMX_QP_DEFAULT);
+}
+
+__device__ __forceinline__ void nvshmemi_ibgda_amo_nonfetch_add(
+    void* rptr, const int& value, int pe, int _qp_id, bool is_local_copy = false) {
+    if (is_local_copy) {
+        atomicAdd(static_cast<unsigned long long*>(rptr), value);
+    } else {
+        nvshmem_int_atomic_add(static_cast<int*>(rptr), value, pe);
+    }
+}
+
+__device__ __forceinline__ uint64_t nvshmemi_get_p2p_ptr(const uint64_t& ptr, const int& rank, const int& dst_rank) {
+    if (rank == dst_rank)
+        return ptr;
+    auto peer_base = __ldg(reinterpret_cast<uint64_t*>(nvshmemi_device_state_d.peer_heap_base_p2p) + dst_rank);
+    if (peer_base == 0)
+        return 0;
+    return peer_base + (ptr - reinterpret_cast<uint64_t>(nvshmemi_device_state_d.heap_base));
+}
+
+// Combined put + signal: posts data and signals the remote tail in one call.
+template <bool kAlwaysDoPostSend = false>
+__device__ static __forceinline__ void nvshmemi_ibgda_put_signal_nbi_warp(
+    uint64_t req_rptr, uint64_t req_lptr, size_t bytes,
+    void* signal_rptr, const int signal_value,
+    int dst_pe, int qp_id, int lane_id,
+    nvshmemx_qp_handle_t qp_handle = NVSHMEMX_QP_DEFAULT) {
+    nvshmemx_qp_char_put_signal_nbi_warp(reinterpret_cast<char*>(req_rptr),
+        reinterpret_cast<const char*>(req_lptr), bytes,
+        reinterpret_cast<uint64_t*>(signal_rptr), signal_value, NVSHMEM_SIGNAL_ADD,
+        dst_pe, qp_handle);
+}
+
+__device__ static __forceinline__ void nvshmemi_ibgda_rma_p(
+    int* rptr, const int value, int dst_pe, int _qp_id, uint32_t imm = std::numeric_limits<uint32_t>::max()) {
+    nvshmemx_qp_int_p(rptr, value, dst_pe, NVSHMEMX_QP_DEFAULT);
+}
+
+}  // namespace deep_ep
+PATCH_EOF
+
+# 2. Inject fake IBGDA state into runtime.cu
+#    (No assert comment-outs needed — num_rc_per_pe=288 satisfies both asserts.)
+if ! grep -q 'g_fake_ibgda_device_state' csrc/kernels/runtime.cu; then
+    sed -i '/^namespace deep_ep {/a \
+\
+#ifndef DISABLE_NVSHMEM\
+__device__ nvshmemi_ibgda_device_state_t g_fake_ibgda_device_state;\
+__device__ int g_fake_ibgda_state_initialized = 0;\
+#endif' csrc/kernels/runtime.cu
+fi
+
+# 3. Raise DeepEP's baked-in NVSHMEM_MAX_TEAMS from 7 to 8.
+#    buffer.py hard-codes NVSHMEM_MAX_TEAMS=7 ("6 default teams + 1 extra"), sized
+#    for an older NVSHMEM that stood up 6 internal teams at init. NVSHMEM 3.7 adds a
+#    7th (NVSHMEM_TEAM_MC_SHARED for NVLS multicast), so all 7 slots are taken before
+#    DeepEP's low-latency path splits its RDMA sub-team and nvshmem_team_split_strided
+#    fails with "No more teams available (max=7)". Bump it to 8 (7 internal + 1 for the
+#    split) so a freshly built tree runs out of the box with no runtime env var.
+if [[ -f deep_ep/buffer.py ]]; then
+    sed -i "s/os.environ\['NVSHMEM_MAX_TEAMS'\] = '7'/os.environ['NVSHMEM_MAX_TEAMS'] = '8'/" deep_ep/buffer.py
+    echo "  Set NVSHMEM_MAX_TEAMS to 8 in buffer.py (NVSHMEM 3.7 needs >7)"
+fi
+
+echo "  DeepEP patched at $DEEPEP_SRC"
+echo ""
+
+########################################################################
+# Step 2: Build NVSHMEM
+########################################################################
+echo ">>> Step 2: Build NVSHMEM"
+
+cd "$NVSHMEM_SRC"
+rm -rf build && mkdir build && cd build
+
+cmake .. \
+    -DCMAKE_INSTALL_PREFIX="$NVSHMEM_INSTALL_DIR" \
+    -DCUDA_HOME="$CUDA_HOME" \
+    -DLIBFABRIC_HOME="$LIBFABRIC_HOME" \
+    -DNVSHMEM_LIBFABRIC_SUPPORT=ON \
+    -DNVSHMEM_MPI_SUPPORT=OFF \
+    -DNVSHMEM_IBRC_SUPPORT=OFF \
+    -DNVSHMEM_IBGDA_SUPPORT=OFF \
+    -DNVSHMEM_IBDEVX_SUPPORT=OFF \
+    -DNVSHMEM_UCX_SUPPORT=OFF \
+    -DNVSHMEM_SHMEM_SUPPORT=OFF \
+    -DNVSHMEM_PMIX_SUPPORT=OFF \
+    -DNVSHMEM_USE_NCCL=OFF \
+    -DNVSHMEM_USE_GDRCOPY=ON \
+    -DGDRCOPY_HOME="$GDRCOPY_HOME" \
+    -DNVSHMEM_USE_MLX5DV=OFF \
+    -DNVSHMEM_BUILD_TESTS=OFF \
+    -DNVSHMEM_BUILD_EXAMPLES=OFF \
+    -DNVSHMEM_BUILD_PYTHON_LIB=OFF \
+    -DNVSHMEM_BUILD_BITCODE_LIBRARY=OFF \
+    -DCMAKE_CUDA_ARCHITECTURES="$GPU_ARCH"
+
+make -j"$(nproc)"
+make install
+
+echo "  NVSHMEM installed to $NVSHMEM_INSTALL_DIR"
+echo ""
+
+########################################################################
+# Step 3: Build DeepEP
+########################################################################
+echo ">>> Step 3: Build DeepEP"
+
+export NVSHMEM_DIR="$NVSHMEM_INSTALL_DIR"
+export NVSHMEM_HOME="$NVSHMEM_INSTALL_DIR"
+export LIBFABRIC_HOME
+export LD_LIBRARY_PATH="${LIBFABRIC_HOME}/lib:${NVSHMEM_INSTALL_DIR}/lib:${CUDA_HOME}/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+# CUDA 13 relocated libcu++ (the cuda/std/* headers) under include/cccl. NVSHMEM's
+# device headers include <cuda/std/array>, and DeepEP's host (.cpp) compile does not
+# get nvcc's automatic -isystem .../cccl, so add it to CPATH. No-op on CUDA <= 12.x
+# (the directory does not exist there).
+CCCL_INCLUDE="$CUDA_HOME/targets/x86_64-linux/include/cccl"
+[ -d "$CCCL_INCLUDE" ] && export CPATH="${CCCL_INCLUDE}${CPATH:+:$CPATH}"
+
+TORCH_CUDA=$(python3 -c "import torch; print(torch.version.cuda)" 2>/dev/null || echo "unknown")
+echo "  NVSHMEM:      $NVSHMEM_INSTALL_DIR"
+echo "  PyTorch CUDA: $TORCH_CUDA"
+
+if [[ "$TORCH_CUDA" != "unknown" && "$CUDA_VERSION" != "$TORCH_CUDA" ]]; then
+    echo "  WARNING: CUDA mismatch — nvcc=$CUDA_VERSION, PyTorch=$TORCH_CUDA"
+fi
+
+cd "$DEEPEP_SRC"
+
+pip uninstall -y deep_ep 2>/dev/null || true
+python setup.py clean --all 2>/dev/null || true
+
+# DeepEP's setup.py requires DISABLE_AGGRESSIVE_PTX_INSTRS=1 whenever sm_100
+# (Blackwell) is targeted; pure Hopper (sm_90) builds with it off. A combined
+# "90;100" build therefore disables it (the flag applies to the whole build, so
+# Hopper loses the aggressive-PTX optimization in exchange for one portable image).
+if [[ "$GPU_ARCH" == "90" ]]; then
+    DISABLE_AGGRESSIVE_PTX_INSTRS=0
+else
+    DISABLE_AGGRESSIVE_PTX_INSTRS=1
+fi
+
+DISABLE_AGGRESSIVE_PTX_INSTRS=$DISABLE_AGGRESSIVE_PTX_INSTRS \
+TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
+    python setup.py install
+
+echo ""
+echo "  DeepEP installed. Verify: python -c 'import deep_ep; print(\"OK\")'"
+echo ""
+
+echo "=== Setup complete ==="
+echo "  DeepEP source:   $DEEPEP_SRC"
+echo "  NVSHMEM install: $NVSHMEM_INSTALL_DIR"

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/README.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/README.md
@@ -43,7 +43,12 @@ random-init weights** (we measure step time, not loss).
 | 16 | 8 | 4 | 2 | 8 |
 | 32 | 8 | 2 | 4 | 4 |
 
-`PP = WORLD / EP` (TP8 fixed, ETP=1). Qwen3's 94 layers (= 2·47) are not VPP-divisible, so
+`PP = WORLD / EP` (TP8 fixed, ETP=1). The table above is the **8-node target** (WORLD=64).
+The measured campaign in [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md) ran on **4 nodes**
+(WORLD=32 → EP16=PP2/DP2, EP32=PP1/DP4) because the shared cluster had only 6 of 8 B300 nodes
+free; the EP degree (the variable that matters) is preserved either way.
+
+Qwen3's 94 layers (= 2·47) are not VPP-divisible, so
 the `overlap=on` cells round `num_layers` up to the nearest `PP·VPP` multiple (94 → 96) and
 disable the embedding/loss pipeline accounting — making `overlap=on` a separate within-regime
 A/B (never subtract its numbers against `overlap=off`).

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/README.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/README.md
@@ -1,0 +1,79 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: MIT-0 -->
+
+# Qwen3-235B-A22B (128-expert MoE) — NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM
+
+A **three-way** Megatron-Core MoE token-dispatcher comparison on up to **8× p6-b300**
+(64× B300), measured as end-to-end **training-step throughput**. The only thing that
+changes between arms is the expert-parallel all-to-all backend:
+
+| Arm | `MOE_DISPATCHER` | Image | all-to-all transport |
+|-----|------------------|-------|----------------------|
+| **NCCL all-to-all** (baseline) | `alltoall` | UCCL image | NCCL all-to-all over EFA |
+| **DeepEP + UCCL** | `deepep` | UCCL image | UCCL EFA-native `deep_ep` |
+| **DeepEP + NVSHMEM** | `deepep` | **NVSHMEM image** | NVIDIA DeepEP over NVSHMEM-libfabric/EFA |
+
+The two `deepep` arms run the **identical** Megatron-Core flex/deepep code path; they differ
+only in which `deep_ep` the image provides (see [`../README.md`](../README.md) for the
+`EP_BACKEND` build arg). Everything else — model, data, parallelism, precision, seed, EFA env,
+`MOE_A2A_OVERLAP` — is held byte-identical across arms within a run.
+
+> **The DeepEP+NVSHMEM arm is new to this library.** The parent README originally noted that
+> NVIDIA DeepEP "does not run on EFA". That is no longer true: the
+> [`deepep-benchmark`](../../../../micro-benchmarks/expert-parallelism/deepep-benchmark)
+> patches DeepEP to run **NVSHMEM over libfabric** (host-proxy, IBGDA off) on EFA, and this
+> test case reuses that build (vendored at [`../deepep/`](../deepep/)) as a Megatron-Core
+> dispatcher backend.
+
+## Why Qwen3-235B-A22B (and not DSV3) for the 8-node comparison
+
+The DSV3 dispatcher A/B ran at **EP32 on 32 nodes** to fit the 671B model. On 8 nodes the
+671B DSV3 cannot reach the EP32 regime without OOM. **Qwen3-235B-A22B** (235B total / 22B
+active, **128 experts**, top-8, 94 layers, hidden 4096, no shared expert) fits 8 nodes at
+**both EP16 and EP32**, so the comparison sweeps the variable the all-to-all turns on — the
+**EP degree** — at a realistic operating point (EP32 is the Qwen3-235B point cited in the
+DSV3 reference table). It is built from the shipped Megatron-Bridge recipe
+`megatron.bridge.recipes.qwen.qwen3_moe.qwen3_235b_a22b_pretrain_config` with **mock data +
+random-init weights** (we measure step time, not loss).
+
+## Parallelism (world = 64 = TP·PP·DP; EP divides TP·DP and the 128 experts)
+
+| EP | TP | PP | DP | experts/rank |
+|---:|---:|---:|---:|---:|
+| 16 | 8 | 4 | 2 | 8 |
+| 32 | 8 | 2 | 4 | 4 |
+
+`PP = WORLD / EP` (TP8 fixed, ETP=1). Qwen3's 94 layers (= 2·47) are not VPP-divisible, so
+the `overlap=on` cells round `num_layers` up to the nearest `PP·VPP` multiple (94 → 96) and
+disable the embedding/loss pipeline accounting — making `overlap=on` a separate within-regime
+A/B (never subtract its numbers against `overlap=off`).
+
+## Run it
+
+```bash
+# from megatron-bridge/ — build both images once (see ../README.md):
+bash 1.build-and-push.sh                       # UCCL    -> nemo-26.04.01-uccl-0dc87eb
+EP_BACKEND=nvshmem bash 1.build-and-push.sh    # NVSHMEM -> nemo-26.04.01-deepep-nvshmem-567632d-cu13
+
+# single-node bring-up gate per image (run inside the image on one p6-b300 node):
+EP_BACKEND=uccl    bash 2.sanity-singlenode.sh
+EP_BACKEND=nvshmem bash 2.sanity-singlenode.sh
+
+# the full 3-way x EP{16,32} campaign on 8 nodes:
+CTX=<kube-context> \
+UCCL_IMG=<acct>.dkr.ecr.<region>.amazonaws.com/megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb \
+NVSHMEM_IMG=<acct>.dkr.ecr.<region>.amazonaws.com/megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13 \
+  bash qwen3-235b/benchmarks/run-qwen3-campaign.sh
+```
+
+The campaign ([`benchmarks/run-qwen3-campaign.sh`](benchmarks/run-qwen3-campaign.sh)) runs
+each arm serially via the shared [`../run-ab-rawpods.sh`](../run-ab-rawpods.sh), gates every
+run on EFA-active on all ranks, and parses the tree with
+[`../bench/parse-runs.py`](../bench/parse-runs.py) into `index.csv`. Measured results:
+[`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).
+
+**Confounder guard.** Every rank of every run must log
+`NET/OFI Selected provider is efa` (true EFA RDMA, no socket fallback); the NVSHMEM arm must
+also show NVSHMEM-over-libfabric init. Work-equivalence (no token dropping from the NVSHMEM
+arm's put_signal + host-proxy shim) is checked with `LOSS_PROBE=1`: iteration-1 loss must
+match the `alltoall` arm to ~5 significant figures.

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
@@ -1,0 +1,87 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: MIT-0 -->
+
+# Qwen3-235B-A22B — NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM — Benchmark Results
+
+Three-way MoE token-dispatcher comparison on **8× p6-b300 (64× B300)**: NCCL all-to-all
+(baseline) vs DeepEP over **UCCL** (EFA-native) vs DeepEP over **NVSHMEM-libfabric** (NVIDIA
+DeepEP, EFA-patched). The only toggle that changes between arms is the dispatcher / image;
+everything else (Qwen3-235B-A22B 128-expert recipe, mock data, seq 4096, global batch,
+bf16, parallelism, seed, EFA env, `MOE_A2A_OVERLAP`) is held fixed within a run. Metric of
+record: **mean training-iteration time** over the steady state (first 4 iters dropped),
+plus analytical `MODEL TFLOP/s/GPU` and derived `tok/s = global_batch × seq_len / iter_time`.
+
+| Field | Value |
+|---|---|
+| Date | _TBD_ |
+| Hardware | 8 × `p6-b300.48xlarge` (B300, 8 GPU + 16 EFA / node), EKS `ml-shared` (us-west-2) |
+| Model | Qwen3-235B-A22B — 128 experts, top-8, 94 layers, hidden 4096, MoE FFN 1536, bf16 |
+| World | 64 ranks (8 nodes × 8 GPU), TP8, ETP1, balanced routing |
+| EP sweep | EP16 (PP4/DP2) · EP32 (PP2/DP4) |
+| UCCL image | `megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb` (UCCL `0dc87eb`) |
+| NVSHMEM image | `megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13` (DeepEP `567632d`, NVSHMEM v3.7.0-0, libfabric/EFA) |
+| Bridge / Core | megatron-bridge 0.4.2 / megatron-core 0.17.1 (nemo:26.04.01) |
+
+> Status: harness + both images validated end-to-end on a 2-node smoke (NUM_LAYERS=8);
+> full 64-GPU campaign numbers below are _TBD_ pending the run.
+
+## Measured result — mean iter time (lower = better), overlap=off (dispatcher-isolation)
+
+`delta` columns are vs the NCCL all-to-all baseline (negative = DeepEP faster).
+
+### EP32 (TP8/PP2/DP4)
+
+| micro_batch | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|------------:|----------------:|------------:|---------------:|-------:|----------:|
+| 1 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
+| 4 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
+
+### EP16 (TP8/PP4/DP2)
+
+| micro_batch | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|------------:|----------------:|------------:|---------------:|-------:|----------:|
+| 1 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
+| 4 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
+
+## Deployment-realistic overlap=on (mb=4) — separate within-regime A/B
+
+`overlap=on` enables `overlap_moe_expert_parallel_comm` (1F1B hides the EP all-to-all). On
+Core 0.17.1 with PP>1 this forces VPP=2 + recompute off, and Qwen3's 94 layers are rounded
+to **96** for VPP divisibility — so these numbers are an independent within-regime A/B, **not
+comparable cell-for-cell to overlap=off** (do not subtract across regimes).
+
+| EP | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|---:|----------------:|------------:|---------------:|-------:|----------:|
+| 16 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
+| 32 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
+
+## TFLOP/s/GPU and tok/s (steady state)
+
+| arm | EP | mb | overlap | mean iter (s) | MODEL TFLOP/s/GPU | tok/s | transport |
+|-----|---:|---:|---------|--------------:|------------------:|------:|-----------|
+| _TBD (filled from bench/last-campaign-index.csv)_ | | | | | | | |
+
+## Validity gates (every run)
+
+- **EFA active on all 64 ranks**: each rank logged `NET/OFI Selected provider is efa`
+  (true EFA RDMA, no socket fallback). _TBD: confirmed N/N._
+- **Transport-active per arm**: UCCL arm logs the UCCL-EP proxy banner; NVSHMEM arm logs
+  NVSHMEM-over-libfabric init. _TBD._
+- **Work-equivalence (no token dropping)**: `LOSS_PROBE=1` iteration-1 loss of the DeepEP
+  arms matches the NCCL `alltoall` arm to ~5 significant figures (bf16 round-off only).
+  _TBD: alltoall=____, deepep-uccl=____, deepep-nvshmem=____._
+
+## Caveats
+
+1. **Mock data + random-init + forced balancing** — measures the dispatcher on a balanced
+   token distribution (step time, not loss); same regime as the DSV3/Kimi-K2 A/Bs.
+2. **overlap=on uses 96 layers** (94 rounded up for VPP). Within-regime only.
+3. **NVSHMEM DeepEP = NVIDIA DeepEP `567632d`** patched for EFA (NVSHMEM-libfabric host-proxy,
+   IBGDA off) — see [`../../deepep/`](../../deepep/). Not DeepEP's IB/IBGDA fast path.
+4. Single run per cell (within-run σ reported by `parse-runs.py`; between-run variance not bounded).
+
+## How to reproduce
+
+See [`../README.md`](../README.md). One command:
+`CTX=… UCCL_IMG=… NVSHMEM_IMG=… bash run-qwen3-campaign.sh`, then
+`python3 ../bench/parse-runs.py <campaign_dir> --warmup 4`.

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
@@ -37,21 +37,22 @@ secondary is retained to show how the regime (PP depth + recompute) changes the 
 
 ### EP32 @ PP2, overlap=on (1F1B, deployment regime) — mean iter s
 
-| mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM |
-|---:|----------------:|------------:|---------------:|
-| 4 | **11.01 s · 225.0 · 95.3k** | _re-running_ | _re-running_ |
+| mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|---:|----------------:|------------:|---------------:|-------:|----------:|
+| 4 | **11.01 s · 225.0 · 95.3k** | 17.08 s · 150.6 · 61.4k | 17.08 s · 150.6 · 61.4k | +55.1% | +55.1% |
 
-### EP16 @ PP4, overlap off/on
+### EP16 @ PP4 (TP8/PP4/DP2) — internode EP across 2 nodes
 
-| mb · overlap | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM |
-|---|----------------:|------------:|---------------:|
-| 4 · off | _re-running_ | _re-running_ | _re-running_ |
-| 1 · off | _re-running_ | _re-running_ | _re-running_ |
-| 4 · on  | _re-running_ | _re-running_ | _re-running_ |
+| mb · overlap | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|---|----------------:|------------:|---------------:|-------:|----------:|
+| 4 · off | 12.21 s · 198.6 · 85.9k | 13.06 s · 185.8 · 80.3k | **11.57 s · 209.6 · 90.6k** | +6.9% | **−5.2%** |
+| 1 · off | 34.17 s · 71.0 · 30.7k | 40.00 s · 60.7 · 26.2k | _preempted_ | +17.1% | — |
+| 4 · on  | **10.53 s · 235.0 · 99.5k** | 13.24 s · 187.1 · 79.2k | 11.32 s · 218.7 · 92.6k | +25.7% | +7.5% |
 
-> The first 8-node campaign lost a node to another team mid-run (rendezvous 7/8); the EP32
-> overlap=off cells completed before that, the EP16 cells and the two EP32 overlap=on DeepEP
-> cells are being re-run into the same campaign dir. This section is updated when they land.
+> Two cells lost to mid-run node preemption (rendezvous < 8/8): `nvshmem-ep16-mb1-off` and (on
+> the first pass) the two EP32 overlap=on DeepEP cells, which were re-run successfully. The
+> EP32 overlap=off numbers above are from the first pass (their logs were cosmetically
+> overwritten by the same-campaign re-run; the harness skip-guard is now fixed for all ranks).
 
 ### What the numbers say (primary)
 
@@ -59,7 +60,14 @@ secondary is retained to show how the regime (PP depth + recompute) changes the 
    backends are slower** — and these are **large, robust deltas** (not n=1 noise): at mb=4,
    DeepEP+UCCL **+15.9%** and DeepEP+NVSHMEM **+28.3%** slower than NCCL; at mb=1, **+40%** and
    **+36%**. NCCL all-to-all also scales fine into the `overlap=on` deployment regime (11.0 s,
-   **95k tok/s**, 225 TFLOP/s/GPU at mb=4).
+   **95k tok/s**, 225 TFLOP/s/GPU at mb=4), where both DeepEP backends sit at +55%.
+1b. **The DeepEP penalty grows with EP degree.** At the lower **EP16** the gap nearly closes —
+   DeepEP+NVSHMEM is actually *fastest* at mb=4 overlap=off (**−5.2%** vs NCCL) and UCCL only
+   +6.9%; going EP16→EP32 the NVSHMEM delta swings from −5% to +28% and UCCL from +7% to +16%.
+   The same EP-scaling trend appears far more violently on H100/30B
+   ([`../../qwen3-30b`](../../qwen3-30b/benchmarks/RESULTS.md)). So the all-to-all fan-out, not
+   just the model, decides whether DeepEP is competitive — and on this B300/EFA fabric it only
+   is at the lower EP degree.
 2. **This overturns the 4-node EP32 result** (secondary table), where DeepEP+UCCL *looked* 5.6%
    *faster* than NCCL at EP32. That apparent win was an artifact of the 4-node **PP1 +
    `RECOMPUTE=full`** regime (recompute roughly doubles compute and shrinks the all-to-all's
@@ -71,10 +79,12 @@ secondary is retained to show how the regime (PP depth + recompute) changes the 
    all-to-all very strong. (DeepEP/UCCL wins in the literature are inference-scale or on
    InfiniBand / lower-bandwidth fabrics.)
 
-### Validity (primary, EP32 overlap=off + NCCL overlap=on)
+### Validity (primary)
 
-EFA active on all 64 ranks (`efa_ok`, 8/8 node logs) · 0 stalls · 8 steady iters · per-arm
-transport confirmed (`uccl_ok` / `nvshmem_ok`). Work-equivalence verified on a 2-node smoke
+16 of 18 cells valid: EFA active on all 64 ranks (`efa_ok`, 8/8 node logs) · 0 stalls · 8
+steady iters · per-arm transport confirmed (`uccl_ok` / `nvshmem_ok`). Two cells lost to node
+preemption (`nvshmem-ep16-mb1-off`, and on the first pass the two EP32 overlap=on DeepEP cells
+— re-run successfully). Work-equivalence verified on a 2-node smoke
 (`LOSS_PROBE`): deepep-nvshmem iter-1 loss matches NCCL to ~4 sig figs (12.701515 vs 12.702237,
 rel 5.7e-5). The NVSHMEM arm exits non-zero at NVSHMEM finalize *after* training — validate via
 `efa_ok` + `n_steady==8`, not exit code.

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
@@ -3,85 +3,115 @@
 
 # Qwen3-235B-A22B — NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM — Benchmark Results
 
-Three-way MoE token-dispatcher comparison on **8× p6-b300 (64× B300)**: NCCL all-to-all
-(baseline) vs DeepEP over **UCCL** (EFA-native) vs DeepEP over **NVSHMEM-libfabric** (NVIDIA
-DeepEP, EFA-patched). The only toggle that changes between arms is the dispatcher / image;
-everything else (Qwen3-235B-A22B 128-expert recipe, mock data, seq 4096, global batch,
-bf16, parallelism, seed, EFA env, `MOE_A2A_OVERLAP`) is held fixed within a run. Metric of
-record: **mean training-iteration time** over the steady state (first 4 iters dropped),
-plus analytical `MODEL TFLOP/s/GPU` and derived `tok/s = global_batch × seq_len / iter_time`.
+Three-way MoE token-dispatcher comparison on **`p6-b300`**: NCCL all-to-all (baseline) vs
+DeepEP over **UCCL** (EFA-native) vs DeepEP over **NVSHMEM-libfabric** (NVIDIA DeepEP,
+EFA-patched). The only toggle that changes between arms is the dispatcher / image; everything
+else (Qwen3-235B-A22B 128-expert recipe, mock data, seq 4096, global batch, bf16, parallelism,
+seed, EFA env, recompute) is held fixed within a run. Metric of record: **mean
+training-iteration time** over the steady state (first 4 of 12 iters dropped), plus analytical
+`MODEL TFLOP/s/GPU` and derived `tok/s = global_batch × seq_len / iter_time`.
 
 | Field | Value |
 |---|---|
-| Date | _TBD_ |
-| Hardware | 8 × `p6-b300.48xlarge` (B300, 8 GPU + 16 EFA / node), EKS `ml-shared` (us-west-2) |
+| Date | 2026-06-21 |
+| Hardware | **4 × `p6-b300.48xlarge`** (32× B300, 8 GPU + 16 EFA / node), EKS `ml-shared` (us-west-2) |
 | Model | Qwen3-235B-A22B — 128 experts, top-8, 94 layers, hidden 4096, MoE FFN 1536, bf16 |
-| World | 64 ranks (8 nodes × 8 GPU), TP8, ETP1, balanced routing |
-| EP sweep | EP16 (PP4/DP2) · EP32 (PP2/DP4) |
+| World | 32 ranks, TP8, ETP1, balanced routing, `RECOMPUTE=full`, overlap=off |
+| EP sweep | EP16 (PP2/DP2) · EP32 (PP1/DP4) — `PP = WORLD/EP`, WORLD=32 |
+| Global batch | 128 (12 iters/run, 8 steady) |
 | UCCL image | `megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb` (UCCL `0dc87eb`) |
 | NVSHMEM image | `megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13` (DeepEP `567632d`, NVSHMEM v3.7.0-0, libfabric/EFA) |
 | Bridge / Core | megatron-bridge 0.4.2 / megatron-core 0.17.1 (nemo:26.04.01) |
+| Campaign | `qwen3final-20260621T0215Z` (raw `index.csv`: [`last-campaign-index.csv`](last-campaign-index.csv)) |
 
-> Status: harness + both images validated end-to-end on a 2-node smoke (NUM_LAYERS=8);
-> full 64-GPU campaign numbers below are _TBD_ pending the run.
+> **Why 4 nodes, not 8.** The plan targeted 8× p6-b300 (EP32 at TP8/PP2/DP4). At run time
+> the shared `ml-shared` cluster had only 6 of its 8 B300 nodes free (2 held by another
+> team), and EP32 cannot tile 6 nodes with integer PP. The whole sweep was therefore run on
+> **4 nodes (32 GPU)**, where both EP16 (PP4/DP2) and EP32 (PP1/DP4) tile cleanly and the
+> EP degree — the variable the all-to-all turns on — is preserved. EP32 at PP1 needs
+> `RECOMPUTE=full` to fit; that recompute is applied to **all** arms and **both** EPs so the
+> per-cell 3-way comparison stays clean (see caveats).
 
-## Measured result — mean iter time (lower = better), overlap=off (dispatcher-isolation)
+## Measured result — mean iter time (lower = better), overlap=off, recompute=full
 
-`delta` columns are vs the NCCL all-to-all baseline (negative = DeepEP faster).
+`Δ` = vs the NCCL all-to-all baseline (negative = DeepEP faster). Each cell: mean iter s ·
+MODEL TFLOP/s/GPU · derived tok/s.
 
-### EP32 (TP8/PP2/DP4)
+### EP16 (TP8/PP2/DP2) — internode EP across 2 nodes
 
-| micro_batch | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
-|------------:|----------------:|------------:|---------------:|-------:|----------:|
-| 1 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
-| 4 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
-
-### EP16 (TP8/PP4/DP2)
-
-| micro_batch | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
-|------------:|----------------:|------------:|---------------:|-------:|----------:|
-| 1 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
-| 4 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
-
-## Deployment-realistic overlap=on (mb=4) — separate within-regime A/B
-
-`overlap=on` enables `overlap_moe_expert_parallel_comm` (1F1B hides the EP all-to-all). On
-Core 0.17.1 with PP>1 this forces VPP=2 + recompute off, and Qwen3's 94 layers are rounded
-to **96** for VPP divisibility — so these numbers are an independent within-regime A/B, **not
-comparable cell-for-cell to overlap=off** (do not subtract across regimes).
-
-| EP | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+| mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
 |---:|----------------:|------------:|---------------:|-------:|----------:|
-| 16 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
-| 32 | _TBD_ s | _TBD_ s | _TBD_ s | _TBD_ | _TBD_ |
+| 4 | 15.18 s · 159.8 · 34.5k | 17.85 s · 135.9 · 29.4k | **14.91 s · 162.7 · 35.2k** | +17.6% | **−1.8%** |
+| 1 | **46.81 s · 51.8 · 11.2k** | 56.00 s · 43.5 · 9.4k | 50.09 s · 48.4 · 10.5k | +19.6% | +7.0% |
 
-## TFLOP/s/GPU and tok/s (steady state)
+### EP32 (TP8/PP1/DP4) — internode EP across all 4 nodes
 
-| arm | EP | mb | overlap | mean iter (s) | MODEL TFLOP/s/GPU | tok/s | transport |
-|-----|---:|---:|---------|--------------:|------------------:|------:|-----------|
-| _TBD (filled from bench/last-campaign-index.csv)_ | | | | | | | |
+| mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|---:|----------------:|------------:|---------------:|-------:|----------:|
+| 4 | 22.20 s · 109.3 · 23.6k | **20.96 s · 117.2 · 25.0k** | 23.76 s · 103.1 · 22.1k | **−5.6%** | +7.1% |
+| 1 | **45.45 s · 53.4 · 11.5k** | 57.94 s · 42.2 · 9.0k | 55.35 s · 44.2 · 9.5k | +27.5% | +21.8% |
+
+## What the numbers say
+
+1. **At the efficient operating point (mb=4) the three dispatchers are within ~±18%, and the
+   winner depends on EP degree.** At **EP16**, DeepEP+NVSHMEM is fastest (−1.8% vs NCCL) and
+   UCCL is slowest (+17.6%). At **EP32** the order flips among the DeepEP backends: **UCCL is
+   fastest (−5.6% vs NCCL)** while NVSHMEM falls behind (+7.1%). UCCL degrades least going
+   EP16→EP32 (17.85→20.96 s), whereas NCCL and NVSHMEM degrade more (15.18→22.20 and
+   14.91→23.76) — UCCL scales to higher EP best here, NVSHMEM worst.
+2. **At mb=1 NCCL all-to-all wins at both EP degrees** (+7–28% over the DeepEP arms). This is
+   the smallest per-dispatch granularity (64/EP16 and 32/EP32 microbatches per iter), where
+   DeepEP's per-dispatch proxy/kernel-launch overhead is unamortized — the same crossover the
+   DSV3 A/B found. A throughput-tuned run uses mb≥4.
+3. **The deltas are far smaller than the DSV3 256-GPU result (−36% for UCCL at mb4).** The
+   dominant reason is `RECOMPUTE=full` (forced to fit EP32 on 4 nodes): recomputation roughly
+   doubles compute per step, so the all-to-all becomes a smaller fraction of the iteration and
+   any dispatcher delta is compressed. These numbers are therefore a **conservative,
+   recompute-on** comparison, not the dispatcher-isolation upper bound.
 
 ## Validity gates (every run)
 
-- **EFA active on all 64 ranks**: each rank logged `NET/OFI Selected provider is efa`
-  (true EFA RDMA, no socket fallback). _TBD: confirmed N/N._
-- **Transport-active per arm**: UCCL arm logs the UCCL-EP proxy banner; NVSHMEM arm logs
-  NVSHMEM-over-libfabric init. _TBD._
-- **Work-equivalence (no token dropping)**: `LOSS_PROBE=1` iteration-1 loss of the DeepEP
-  arms matches the NCCL `alltoall` arm to ~5 significant figures (bf16 round-off only).
-  _TBD: alltoall=____, deepep-uccl=____, deepep-nvshmem=____._
+- **EFA active on all 32 ranks**: every run logged `NET/OFI Selected provider is efa`
+  (`efa_ok=True`, 4/4 node logs) — true EFA RDMA, no socket fallback. ✓ all 12 runs.
+- **Transport-active per arm**: UCCL arms logged the UCCL-EP proxy banner (`uccl_ok=True`);
+  NVSHMEM arms logged `NVSHMEM v3.7.0` init (`nvshmem_ok=True`); NCCL arms neither. ✓
+- **No stalls**: 0/8 steady iters > 3× median in every run (balanced routing held).
+- **Work-equivalence (no token dropping)** — verified on a 2-node smoke (NUM_LAYERS=8) with
+  `LOSS_PROBE=1`: iteration-1 mean loss **deepep-nvshmem 12.701515 vs alltoall 12.702237**
+  (identical num_tokens=2048; relative diff 5.7e-5 = bf16 round-off). The NVSHMEM arm's
+  IBGDA→host-proxy + put_signal patches dispatch/combine the same tokens to numerically
+  equivalent output as NCCL.
 
 ## Caveats
 
-1. **Mock data + random-init + forced balancing** — measures the dispatcher on a balanced
-   token distribution (step time, not loss); same regime as the DSV3/Kimi-K2 A/Bs.
-2. **overlap=on uses 96 layers** (94 rounded up for VPP). Within-regime only.
-3. **NVSHMEM DeepEP = NVIDIA DeepEP `567632d`** patched for EFA (NVSHMEM-libfabric host-proxy,
-   IBGDA off) — see [`../../deepep/`](../../deepep/). Not DeepEP's IB/IBGDA fast path.
-4. Single run per cell (within-run σ reported by `parse-runs.py`; between-run variance not bounded).
+1. **`RECOMPUTE=full` on all arms** compresses the dispatcher delta (see point 3). To measure
+   the dispatcher-isolation upper bound, re-run with recompute off — which needs ≥8 nodes for
+   EP32 (more pipeline stages) to fit without it.
+2. **4 nodes / 32 GPU, not 8** — shared-cluster capacity at run time (see the note above). The
+   EP degree (16/32) is preserved; absolute scale is half the plan.
+3. **EP16 uses PP2, EP32 uses PP1** — within each EP the three arms are identical (clean 3-way),
+   but the cross-EP comparison also changes PP, so read EP16-vs-EP32 as indicative, not isolated.
+4. **`overlap=on` not run** here (it requires recompute off → OOM at PP1 on 4 nodes, plus
+   Qwen3's 94 layers need a 96-layer VPP round-up). Deferred to an 8-node run.
+5. **NVSHMEM arm exits non-zero (1) at process teardown** (NVSHMEM finalize after
+   `[after training is done]`); all 8 steady training iters are recorded and valid (tight
+   median≈mean), so the measurement is unaffected. STATUS shows `exit=1` for those runs.
+6. **Mock data + random-init + forced balancing** — measures the dispatcher on a balanced
+   token distribution (step time, not loss), same regime as the DSV3/Kimi-K2 A/Bs.
+7. Single run per cell (within-run σ small; between-run variance not bounded).
 
 ## How to reproduce
 
-See [`../README.md`](../README.md). One command:
-`CTX=… UCCL_IMG=… NVSHMEM_IMG=… bash run-qwen3-campaign.sh`, then
-`python3 ../bench/parse-runs.py <campaign_dir> --warmup 4`.
+See [`../README.md`](../README.md). The exact campaign:
+
+```bash
+CTX=ml-shared NS=kimi-k2-bench NNODES=4 EPS="16 32" CELLS="4:off 1:off" RECOMPUTE=full \
+TRAIN_ITERS=12 GLOBAL_BATCH=128 \
+UCCL_IMG=<…>:nemo-26.04.01-uccl-0dc87eb \
+NVSHMEM_IMG=<…>:nemo-26.04.01-deepep-nvshmem-567632d-cu13 \
+  bash run-qwen3-campaign.sh
+# then: python3 ../bench/parse-runs.py <campaign_dir> --warmup 4
+```
+
+**Confounder guard:** assert `NET/OFI Selected provider is efa` appears for every rank of
+every run (the parser's `efa_ok`); discard and re-run any run where it does not.

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
@@ -22,7 +22,7 @@ training-iteration time** over the steady state (first 4 of 12 iters dropped), p
 | UCCL image | `megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb` (UCCL `0dc87eb`) |
 | NVSHMEM image | `megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13` (DeepEP `567632d`, NVSHMEM v3.7.0-0, libfabric/EFA) |
 | Bridge / Core | megatron-bridge 0.4.2 / megatron-core 0.17.1 (nemo:26.04.01) |
-| Campaign | `qwen3final-20260621T0215Z` (raw `index.csv`: [`last-campaign-index.csv`](last-campaign-index.csv)) |
+| Campaign | `qwen3final-20260621T0215Z` (raw per-run `index.csv` is regenerated locally by `../bench/parse-runs.py`; `*.csv` is gitignored repo-wide) |
 
 > **Why 4 nodes, not 8.** The plan targeted 8× p6-b300 (EP32 at TP8/PP2/DP4). At run time
 > the shared `ml-shared` cluster had only 6 of its 8 B300 nodes free (2 held by another

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
@@ -27,7 +27,7 @@ training-iteration time** over the steady state (first 4 of 12 iters dropped), p
 > **Why 4 nodes, not 8.** The plan targeted 8× p6-b300 (EP32 at TP8/PP2/DP4). At run time
 > the shared `ml-shared` cluster had only 6 of its 8 B300 nodes free (2 held by another
 > team), and EP32 cannot tile 6 nodes with integer PP. The whole sweep was therefore run on
-> **4 nodes (32 GPU)**, where both EP16 (PP4/DP2) and EP32 (PP1/DP4) tile cleanly and the
+> **4 nodes (32 GPU)**, where both EP16 (PP2/DP2) and EP32 (PP1/DP4) tile cleanly and the
 > EP degree — the variable the all-to-all turns on — is preserved. EP32 at PP1 needs
 > `RECOMPUTE=full` to fit; that recompute is applied to **all** arms and **both** EPs so the
 > per-cell 3-way comparison stays clean (see caveats).
@@ -53,12 +53,16 @@ MODEL TFLOP/s/GPU · derived tok/s.
 
 ## What the numbers say
 
-1. **At the efficient operating point (mb=4) the three dispatchers are within ~±18%, and the
-   winner depends on EP degree.** At **EP16**, DeepEP+NVSHMEM is fastest (−1.8% vs NCCL) and
-   UCCL is slowest (+17.6%). At **EP32** the order flips among the DeepEP backends: **UCCL is
-   fastest (−5.6% vs NCCL)** while NVSHMEM falls behind (+7.1%). UCCL degrades least going
-   EP16→EP32 (17.85→20.96 s), whereas NCCL and NVSHMEM degrade more (15.18→22.20 and
-   14.91→23.76) — UCCL scales to higher EP best here, NVSHMEM worst.
+1. **At the efficient operating point (mb=4) all three dispatchers are close — within ~±18%.**
+   Read the magnitudes, not a fine ranking: this is **n=1 per cell** (caveat 7), so deltas
+   below roughly **±6%** are within plausible run-to-run variance and are **not resolved**
+   here. What *is* robust: at **EP16** DeepEP+UCCL is clearly the slowest (**+17.6%** vs NCCL),
+   while NCCL and DeepEP+NVSHMEM are statistically tied (NVSHMEM −1.8%, inside the noise
+   floor). At **EP32** the three converge further (UCCL −5.6%, NVSHMEM +7.1% vs NCCL) — a
+   possible reordering, but at this n and with `RECOMPUTE=full` compressing the deltas (point 3)
+   it should be treated as *indicative*, not established. Any cross-EP scaling read (EP16→EP32)
+   is further confounded because PP also changes with EP (caveat 3). To turn the sub-±6%
+   gaps into claims, re-run with n≥3 per cell and report spread.
 2. **At mb=1 NCCL all-to-all wins at both EP degrees** (+7–28% over the DeepEP arms). This is
    the smallest per-dispatch granularity (64/EP16 and 32/EP32 microbatches per iter), where
    DeepEP's per-dispatch proxy/kernel-launch overhead is unamortized — the same crossover the
@@ -78,7 +82,7 @@ MODEL TFLOP/s/GPU · derived tok/s.
 - **No stalls**: 0/8 steady iters > 3× median in every run (balanced routing held).
 - **Work-equivalence (no token dropping)** — verified on a 2-node smoke (NUM_LAYERS=8) with
   `LOSS_PROBE=1`: iteration-1 mean loss **deepep-nvshmem 12.701515 vs alltoall 12.702237**
-  (identical num_tokens=2048; relative diff 5.7e-5 = bf16 round-off). The NVSHMEM arm's
+  (identical num_tokens=2048; agree to ~4 sig figs, relative diff 5.7e-5 = bf16 round-off). The NVSHMEM arm's
   IBGDA→host-proxy + put_signal patches dispatch/combine the same tokens to numerically
   equivalent output as NCCL.
 
@@ -95,7 +99,10 @@ MODEL TFLOP/s/GPU · derived tok/s.
    Qwen3's 94 layers need a 96-layer VPP round-up). Deferred to an 8-node run.
 5. **NVSHMEM arm exits non-zero (1) at process teardown** (NVSHMEM finalize after
    `[after training is done]`); all 8 steady training iters are recorded and valid (tight
-   median≈mean), so the measurement is unaffected. STATUS shows `exit=1` for those runs.
+   median≈mean), so the measurement is unaffected. STATUS shows `exit=1` for those runs. Because
+   this benign finalize-failure and a *real* failure (e.g. mid-run OOM) both surface as pod
+   phase `Failed`, validity for the NVSHMEM arm rests on the EFA gate + `n_steady==8` in
+   `index.csv` — cross-check those before trusting an NVSHMEM-arm number, don't rely on exit code.
 6. **Mock data + random-init + forced balancing** — measures the dispatcher on a balanced
    token distribution (step time, not loss), same regime as the DSV3/Kimi-K2 A/Bs.
 7. Single run per cell (within-run σ small; between-run variance not bounded).

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
@@ -24,22 +24,22 @@ secondary is retained to show how the regime (PP depth + recompute) changes the 
 | Hardware | **8 × `p6-b300.48xlarge`** (64× B300, 8 GPU + 16 EFA / node), EKS `ml-shared` (us-west-2) |
 | World | 64 ranks, TP8, ETP1, balanced routing, **`RECOMPUTE=selective`** |
 | Parallelism | **EP32 = TP8/PP2/DP4** · EP16 = TP8/PP4/DP2 (`PP = WORLD/EP`, WORLD=64) |
-| Global batch | 256 (12 iters/run, 8 steady) |
+| Global batch | 256 — EP32: 16 iters/run (12 steady) · EP16: 12 iters/run (8 steady) |
 | Images | `…-uccl-0dc87eb` (UCCL) · `…-deepep-nvshmem-567632d-cu13` (NVSHMEM v3.7.0-0, DeepEP 567632d, libfabric/EFA) |
-| Campaign | `qwen3-8n-ep32pp2-20260621` |
+| Campaign | EP32 `qwen3-ep32-remeasure-20260624` (git b73a2d7) · EP16 `qwen3-8n-ep32pp2-20260621` (git 633c791) — both 8-node, recompute=selective |
 
 ### EP32 @ PP2, overlap=off (dispatcher-isolation) — mean iter s · TFLOP/s/GPU · tok/s
 
 | mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
 |---:|----------------:|------------:|---------------:|-------:|----------:|
-| 4 | **15.91 s · 152.4 · 65.9k** | 18.43 s · 134.5 · 56.9k | 20.41 s · 120.9 · 51.4k | +15.9% | +28.3% |
-| 1 | **33.41 s · 72.6 · 31.4k** | 46.90 s · 52.4 · 22.4k | 45.39 s · 54.2 · 23.1k | +40.4% | +35.9% |
+| 4 | **15.76 s · 153.9 · 66.5k** | 19.16 s · 130.8 · 54.7k | 21.12 s · 117.9 · 49.6k | +21.5% | +34.0% |
+| 1 | **33.36 s · 72.7 · 31.4k** | 46.88 s · 52.3 · 22.4k | 44.81 s · 54.9 · 23.4k | +40.5% | +34.3% |
 
-### EP32 @ PP2, overlap=on (1F1B, deployment regime) — mean iter s
+### EP32 @ PP2, overlap=on (1F1B, deployment regime) — mean iter s · TFLOP/s/GPU · tok/s
 
 | mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
 |---:|----------------:|------------:|---------------:|-------:|----------:|
-| 4 | **11.01 s · 225.0 · 95.3k** | 17.08 s · 150.6 · 61.4k | 17.08 s · 150.6 · 61.4k | +55.1% | +55.1% |
+| 4 | **10.90 s · 227.1 · 96.2k** | 18.31 s · 143.6 · 57.3k | 17.81 s · 148.0 · 58.9k | +68.0% | +63.4% |
 
 ### EP16 @ PP4 (TP8/PP4/DP2) — internode EP across 2 nodes
 
@@ -49,22 +49,31 @@ secondary is retained to show how the regime (PP depth + recompute) changes the 
 | 1 · off | 34.17 s · 71.0 · 30.7k | 40.00 s · 60.7 · 26.2k | _preempted_ | +17.1% | — |
 | 4 · on  | **10.53 s · 235.0 · 99.5k** | 13.24 s · 187.1 · 79.2k | 11.32 s · 218.7 · 92.6k | +25.7% | +7.5% |
 
-> Two cells lost to mid-run node preemption (rendezvous < 8/8): `nvshmem-ep16-mb1-off` and (on
-> the first pass) the two EP32 overlap=on DeepEP cells, which were re-run successfully. The
-> EP32 overlap=off numbers above are from the first pass (their logs were cosmetically
-> overwritten by the same-campaign re-run; the harness skip-guard is now fixed for all ranks).
+> **Provenance.** All nine EP32 cells above are from a single clean re-measure campaign
+> (`qwen3-ep32-remeasure-20260624`, git b73a2d7) and are fully reproducible from the retained
+> rank logs (`efa_ok` 8/8, transport confirmed per arm). This re-run replaces an earlier 8-node
+> pass whose EP32 overlap=off timing-rank logs were clobbered by a same-`CAMPAIGN_ID` re-run
+> (the all-rank skip-guard now fixed in `run-ab-rawpods.sh` prevents that). The re-measured
+> overlap=off numbers land within ~1–4% of the earlier pass — the ordering and conclusion are
+> unchanged — and the overlap=on row, which previously showed both DeepEP backends at a
+> suspicious digit-identical `+55.1%`, now resolves into two distinct runs (UCCL +68.0%,
+> NVSHMEM +63.4%). One EP16 cell (`nvshmem-ep16-mb1-off`) remains lost to mid-run preemption.
+> NCCL overlap=on logged 7 steady iters (teardown truncation) vs 12 for the DeepEP cells; mean
+> iter time is period-stable and matches the earlier pass (10.90 vs 11.01 s), so the large
+> +60-something% deltas are unaffected.
 
 ### What the numbers say (primary)
 
-1. **At the clean EP32 @ PP2 regime, NCCL all-to-all is the fastest dispatcher and both DeepEP
-   backends are slower** — and these are **large, robust deltas** (not n=1 noise): at mb=4,
-   DeepEP+UCCL **+15.9%** and DeepEP+NVSHMEM **+28.3%** slower than NCCL; at mb=1, **+40%** and
-   **+36%**. NCCL all-to-all also scales fine into the `overlap=on` deployment regime (11.0 s,
-   **95k tok/s**, 225 TFLOP/s/GPU at mb=4), where both DeepEP backends sit at +55%.
+1. **At the clean EP32 @ PP2 regime, NCCL all-to-all is the fastest dispatcher in every cell and
+   both DeepEP backends are slower** — **large, robust deltas** (not n=1 noise): at mb=4,
+   DeepEP+UCCL **+21.5%** and DeepEP+NVSHMEM **+34.0%** slower than NCCL; at mb=1, **+40.5%** and
+   **+34.3%**. NCCL all-to-all also scales fine into the `overlap=on` deployment regime (10.9 s,
+   **96k tok/s**, 227 TFLOP/s/GPU at mb=4), where the DeepEP backends sit at **+68.0%** (UCCL) /
+   **+63.4%** (NVSHMEM).
 1b. **The DeepEP penalty grows with EP degree.** At the lower **EP16** the gap nearly closes —
    DeepEP+NVSHMEM is actually *fastest* at mb=4 overlap=off (**−5.2%** vs NCCL) and UCCL only
-   +6.9%; going EP16→EP32 the NVSHMEM delta swings from −5% to +28% and UCCL from +7% to +16%.
-   The same EP-scaling trend appears far more violently on H100/30B
+   +6.9%; going EP16→EP32 the NVSHMEM delta swings from −5% to **+34%** and UCCL from +7% to
+   **+22%**. The same EP-scaling trend appears far more violently on H100/30B
    ([`../../qwen3-30b`](../../qwen3-30b/benchmarks/RESULTS.md)). So the all-to-all fan-out, not
    just the model, decides whether DeepEP is competitive — and on this B300/EFA fabric it only
    is at the lower EP degree.
@@ -72,8 +81,12 @@ secondary is retained to show how the regime (PP depth + recompute) changes the 
    *faster* than NCCL at EP32. That apparent win was an artifact of the 4-node **PP1 +
    `RECOMPUTE=full`** regime (recompute roughly doubles compute and shrinks the all-to-all's
    share of the step, compressing/distorting the dispatcher delta). At PP2 with lighter
-   `selective` recompute the all-to-all is a larger share of the step and the true ordering
-   shows: **NCCL > UCCL > NVSHMEM** at EP32 on this 6.4 Tbps/node B300 fabric.
+   `selective` recompute the all-to-all is a larger share of the step and **NCCL is unambiguously
+   fastest**. Between the two DeepEP backends the order is close and regime-dependent: UCCL edges
+   NVSHMEM at mb=4 overlap=off (+21.5% vs +34.0%), while NVSHMEM edges UCCL at mb=1 (+34.3% vs
+   +40.5%) and at overlap=on (+63.4% vs +68.0%) — NVSHMEM is the marginally stronger DeepEP
+   backend in the comm-heavier cells, but neither comes close to NCCL at EP32 on this 6.4
+   Tbps/node B300 fabric.
 3. Consistent with the DSV3 "honest bottom line": there is no published EFA *training* win for
    the DeepEP/UCCL path over NCCL all-to-all, and p6-b300's per-node bandwidth makes NCCL's
    all-to-all very strong. (DeepEP/UCCL wins in the literature are inference-scale or on
@@ -81,13 +94,15 @@ secondary is retained to show how the regime (PP depth + recompute) changes the 
 
 ### Validity (primary)
 
-16 of 18 cells valid: EFA active on all 64 ranks (`efa_ok`, 8/8 node logs) · 0 stalls · 8
-steady iters · per-arm transport confirmed (`uccl_ok` / `nvshmem_ok`). Two cells lost to node
-preemption (`nvshmem-ep16-mb1-off`, and on the first pass the two EP32 overlap=on DeepEP cells
-— re-run successfully). Work-equivalence verified on a 2-node smoke
-(`LOSS_PROBE`): deepep-nvshmem iter-1 loss matches NCCL to ~4 sig figs (12.701515 vs 12.702237,
-rel 5.7e-5). The NVSHMEM arm exits non-zero at NVSHMEM finalize *after* training — validate via
-`efa_ok` + `n_steady==8`, not exit code.
+17 of 18 cells valid: EFA active on all 64 ranks (`efa_ok`, 8/8 node logs) · 0 stalls ·
+per-arm transport confirmed (`uccl_ok` / `nvshmem_ok`). Steady iters: **12** for all nine EP32
+cells (16 iters, drop 4) except NCCL overlap=on at 7 (teardown truncation; period-stable mean);
+**8** for EP16. The one invalid cell is `nvshmem-ep16-mb1-off` (mid-run preemption).
+Work-equivalence is confirmed directly in-campaign: at EP32 overlap=on, iter-1 `lm loss` matches
+across all three arms to ~5 sig figs (NCCL 12.751420 · UCCL 12.751430 · NVSHMEM 12.751400,
+rel ≤2e-6) — the dispatchers compute the same thing, so the timing deltas are not a silent
+mis-route. The NVSHMEM arm exits non-zero at NVSHMEM finalize *after* training — validate via
+`efa_ok` + `n_steady`, not exit code.
 
 ---
 
@@ -129,12 +144,13 @@ mb=1 tiny-dispatch regime** (DeepEP per-dispatch overhead unamortized).
    (compute-vs-comm balance), as the primary-vs-secondary contrast shows. Compare only within a
    regime.
 2. **n=1 per cell.** Within-run σ is small (median≈mean), but between-run variance is not bounded.
-   The primary EP32 deltas are large enough (+16% to +40%) to be robust at n=1; the secondary's
-   sub-±6% deltas are not. n≥3 with error bars is the recommended next step.
+   The primary EP32 deltas are large enough (+21% to +68%) to be robust at n=1 — corroborated by
+   the re-measure landing within ~1–4% of the earlier pass; the secondary's sub-±6% deltas are
+   not. n≥3 with error bars is the recommended next step.
 3. **`overlap=on` uses 96 layers** (Qwen3's 94 rounded up for VPP divisibility) and recompute off
    — a separate within-regime A/B; do not subtract across overlap regimes.
 4. **NVSHMEM arm exits 1 at teardown** (NVSHMEM finalize after training); measured iters are valid
-   — gate on `efa_ok` + `n_steady==8`.
+   — gate on `efa_ok` + `n_steady`, not exit code.
 5. **Mock data + random-init + forced balancing** — measures the dispatcher on a balanced token
    distribution (step time, not loss), same regime as the DSV3/Kimi-K2 A/Bs.
 
@@ -144,7 +160,7 @@ See [`../README.md`](../README.md). Primary (8-node EP32@PP2):
 
 ```bash
 CTX=ml-shared NS=kimi-k2-bench NNODES=8 EPS="32 16" CELLS="4:off 1:off 4:on" RECOMPUTE=selective \
-TRAIN_ITERS=12 GLOBAL_BATCH=256 \
+TRAIN_ITERS=16 GLOBAL_BATCH=256 \
 UCCL_IMG=<…>:nemo-26.04.01-uccl-0dc87eb \
 NVSHMEM_IMG=<…>:nemo-26.04.01-deepep-nvshmem-567632d-cu13 \
   bash run-qwen3-campaign.sh

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/RESULTS.md
@@ -3,122 +3,144 @@
 
 # Qwen3-235B-A22B — NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM — Benchmark Results
 
-Three-way MoE token-dispatcher comparison on **`p6-b300`**: NCCL all-to-all (baseline) vs
-DeepEP over **UCCL** (EFA-native) vs DeepEP over **NVSHMEM-libfabric** (NVIDIA DeepEP,
+Three-way MoE token-dispatcher comparison on **`p6-b300`** (B300): NCCL all-to-all (baseline)
+vs DeepEP over **UCCL** (EFA-native) vs DeepEP over **NVSHMEM-libfabric** (NVIDIA DeepEP,
 EFA-patched). The only toggle that changes between arms is the dispatcher / image; everything
 else (Qwen3-235B-A22B 128-expert recipe, mock data, seq 4096, global batch, bf16, parallelism,
-seed, EFA env, recompute) is held fixed within a run. Metric of record: **mean
-training-iteration time** over the steady state (first 4 of 12 iters dropped), plus analytical
-`MODEL TFLOP/s/GPU` and derived `tok/s = global_batch × seq_len / iter_time`.
+seed, EFA env, recompute) is held fixed within a run. Metric of record: **mean training-iteration
+time** over the steady state (first 4 of 12 iters dropped), plus analytical `MODEL TFLOP/s/GPU`
+and derived `tok/s = global_batch × seq_len / iter_time`.
+
+There are **two campaigns**: the **primary** 8-node EP32-at-PP2 run (cleaner regime, below) and a
+**secondary** 4-node reference (capacity-constrained, near the bottom). Read the primary; the
+secondary is retained to show how the regime (PP depth + recompute) changes the conclusion.
+
+---
+
+## Primary — 8 nodes, EP32 @ PP2 (recompute=selective)
 
 | Field | Value |
 |---|---|
-| Date | 2026-06-21 |
-| Hardware | **4 × `p6-b300.48xlarge`** (32× B300, 8 GPU + 16 EFA / node), EKS `ml-shared` (us-west-2) |
-| Model | Qwen3-235B-A22B — 128 experts, top-8, 94 layers, hidden 4096, MoE FFN 1536, bf16 |
-| World | 32 ranks, TP8, ETP1, balanced routing, `RECOMPUTE=full`, overlap=off |
-| EP sweep | EP16 (PP2/DP2) · EP32 (PP1/DP4) — `PP = WORLD/EP`, WORLD=32 |
-| Global batch | 128 (12 iters/run, 8 steady) |
-| UCCL image | `megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb` (UCCL `0dc87eb`) |
-| NVSHMEM image | `megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13` (DeepEP `567632d`, NVSHMEM v3.7.0-0, libfabric/EFA) |
-| Bridge / Core | megatron-bridge 0.4.2 / megatron-core 0.17.1 (nemo:26.04.01) |
-| Campaign | `qwen3final-20260621T0215Z` (raw per-run `index.csv` is regenerated locally by `../bench/parse-runs.py`; `*.csv` is gitignored repo-wide) |
+| Hardware | **8 × `p6-b300.48xlarge`** (64× B300, 8 GPU + 16 EFA / node), EKS `ml-shared` (us-west-2) |
+| World | 64 ranks, TP8, ETP1, balanced routing, **`RECOMPUTE=selective`** |
+| Parallelism | **EP32 = TP8/PP2/DP4** · EP16 = TP8/PP4/DP2 (`PP = WORLD/EP`, WORLD=64) |
+| Global batch | 256 (12 iters/run, 8 steady) |
+| Images | `…-uccl-0dc87eb` (UCCL) · `…-deepep-nvshmem-567632d-cu13` (NVSHMEM v3.7.0-0, DeepEP 567632d, libfabric/EFA) |
+| Campaign | `qwen3-8n-ep32pp2-20260621` |
 
-> **Why 4 nodes, not 8.** The plan targeted 8× p6-b300 (EP32 at TP8/PP2/DP4). At run time
-> the shared `ml-shared` cluster had only 6 of its 8 B300 nodes free (2 held by another
-> team), and EP32 cannot tile 6 nodes with integer PP. The whole sweep was therefore run on
-> **4 nodes (32 GPU)**, where both EP16 (PP2/DP2) and EP32 (PP1/DP4) tile cleanly and the
-> EP degree — the variable the all-to-all turns on — is preserved. EP32 at PP1 needs
-> `RECOMPUTE=full` to fit; that recompute is applied to **all** arms and **both** EPs so the
-> per-cell 3-way comparison stays clean (see caveats).
-
-## Measured result — mean iter time (lower = better), overlap=off, recompute=full
-
-`Δ` = vs the NCCL all-to-all baseline (negative = DeepEP faster). Each cell: mean iter s ·
-MODEL TFLOP/s/GPU · derived tok/s.
-
-### EP16 (TP8/PP2/DP2) — internode EP across 2 nodes
+### EP32 @ PP2, overlap=off (dispatcher-isolation) — mean iter s · TFLOP/s/GPU · tok/s
 
 | mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
 |---:|----------------:|------------:|---------------:|-------:|----------:|
-| 4 | 15.18 s · 159.8 · 34.5k | 17.85 s · 135.9 · 29.4k | **14.91 s · 162.7 · 35.2k** | +17.6% | **−1.8%** |
-| 1 | **46.81 s · 51.8 · 11.2k** | 56.00 s · 43.5 · 9.4k | 50.09 s · 48.4 · 10.5k | +19.6% | +7.0% |
+| 4 | **15.91 s · 152.4 · 65.9k** | 18.43 s · 134.5 · 56.9k | 20.41 s · 120.9 · 51.4k | +15.9% | +28.3% |
+| 1 | **33.41 s · 72.6 · 31.4k** | 46.90 s · 52.4 · 22.4k | 45.39 s · 54.2 · 23.1k | +40.4% | +35.9% |
 
-### EP32 (TP8/PP1/DP4) — internode EP across all 4 nodes
+### EP32 @ PP2, overlap=on (1F1B, deployment regime) — mean iter s
 
-| mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
-|---:|----------------:|------------:|---------------:|-------:|----------:|
-| 4 | 22.20 s · 109.3 · 23.6k | **20.96 s · 117.2 · 25.0k** | 23.76 s · 103.1 · 22.1k | **−5.6%** | +7.1% |
-| 1 | **45.45 s · 53.4 · 11.5k** | 57.94 s · 42.2 · 9.0k | 55.35 s · 44.2 · 9.5k | +27.5% | +21.8% |
+| mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM |
+|---:|----------------:|------------:|---------------:|
+| 4 | **11.01 s · 225.0 · 95.3k** | _re-running_ | _re-running_ |
 
-## What the numbers say
+### EP16 @ PP4, overlap off/on
 
-1. **At the efficient operating point (mb=4) all three dispatchers are close — within ~±18%.**
-   Read the magnitudes, not a fine ranking: this is **n=1 per cell** (caveat 7), so deltas
-   below roughly **±6%** are within plausible run-to-run variance and are **not resolved**
-   here. What *is* robust: at **EP16** DeepEP+UCCL is clearly the slowest (**+17.6%** vs NCCL),
-   while NCCL and DeepEP+NVSHMEM are statistically tied (NVSHMEM −1.8%, inside the noise
-   floor). At **EP32** the three converge further (UCCL −5.6%, NVSHMEM +7.1% vs NCCL) — a
-   possible reordering, but at this n and with `RECOMPUTE=full` compressing the deltas (point 3)
-   it should be treated as *indicative*, not established. Any cross-EP scaling read (EP16→EP32)
-   is further confounded because PP also changes with EP (caveat 3). To turn the sub-±6%
-   gaps into claims, re-run with n≥3 per cell and report spread.
-2. **At mb=1 NCCL all-to-all wins at both EP degrees** (+7–28% over the DeepEP arms). This is
-   the smallest per-dispatch granularity (64/EP16 and 32/EP32 microbatches per iter), where
-   DeepEP's per-dispatch proxy/kernel-launch overhead is unamortized — the same crossover the
-   DSV3 A/B found. A throughput-tuned run uses mb≥4.
-3. **The deltas are far smaller than the DSV3 256-GPU result (−36% for UCCL at mb4).** The
-   dominant reason is `RECOMPUTE=full` (forced to fit EP32 on 4 nodes): recomputation roughly
-   doubles compute per step, so the all-to-all becomes a smaller fraction of the iteration and
-   any dispatcher delta is compressed. These numbers are therefore a **conservative,
-   recompute-on** comparison, not the dispatcher-isolation upper bound.
+| mb · overlap | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM |
+|---|----------------:|------------:|---------------:|
+| 4 · off | _re-running_ | _re-running_ | _re-running_ |
+| 1 · off | _re-running_ | _re-running_ | _re-running_ |
+| 4 · on  | _re-running_ | _re-running_ | _re-running_ |
 
-## Validity gates (every run)
+> The first 8-node campaign lost a node to another team mid-run (rendezvous 7/8); the EP32
+> overlap=off cells completed before that, the EP16 cells and the two EP32 overlap=on DeepEP
+> cells are being re-run into the same campaign dir. This section is updated when they land.
 
-- **EFA active on all 32 ranks**: every run logged `NET/OFI Selected provider is efa`
-  (`efa_ok=True`, 4/4 node logs) — true EFA RDMA, no socket fallback. ✓ all 12 runs.
-- **Transport-active per arm**: UCCL arms logged the UCCL-EP proxy banner (`uccl_ok=True`);
-  NVSHMEM arms logged `NVSHMEM v3.7.0` init (`nvshmem_ok=True`); NCCL arms neither. ✓
-- **No stalls**: 0/8 steady iters > 3× median in every run (balanced routing held).
-- **Work-equivalence (no token dropping)** — verified on a 2-node smoke (NUM_LAYERS=8) with
-  `LOSS_PROBE=1`: iteration-1 mean loss **deepep-nvshmem 12.701515 vs alltoall 12.702237**
-  (identical num_tokens=2048; agree to ~4 sig figs, relative diff 5.7e-5 = bf16 round-off). The NVSHMEM arm's
-  IBGDA→host-proxy + put_signal patches dispatch/combine the same tokens to numerically
-  equivalent output as NCCL.
+### What the numbers say (primary)
 
-## Caveats
+1. **At the clean EP32 @ PP2 regime, NCCL all-to-all is the fastest dispatcher and both DeepEP
+   backends are slower** — and these are **large, robust deltas** (not n=1 noise): at mb=4,
+   DeepEP+UCCL **+15.9%** and DeepEP+NVSHMEM **+28.3%** slower than NCCL; at mb=1, **+40%** and
+   **+36%**. NCCL all-to-all also scales fine into the `overlap=on` deployment regime (11.0 s,
+   **95k tok/s**, 225 TFLOP/s/GPU at mb=4).
+2. **This overturns the 4-node EP32 result** (secondary table), where DeepEP+UCCL *looked* 5.6%
+   *faster* than NCCL at EP32. That apparent win was an artifact of the 4-node **PP1 +
+   `RECOMPUTE=full`** regime (recompute roughly doubles compute and shrinks the all-to-all's
+   share of the step, compressing/distorting the dispatcher delta). At PP2 with lighter
+   `selective` recompute the all-to-all is a larger share of the step and the true ordering
+   shows: **NCCL > UCCL > NVSHMEM** at EP32 on this 6.4 Tbps/node B300 fabric.
+3. Consistent with the DSV3 "honest bottom line": there is no published EFA *training* win for
+   the DeepEP/UCCL path over NCCL all-to-all, and p6-b300's per-node bandwidth makes NCCL's
+   all-to-all very strong. (DeepEP/UCCL wins in the literature are inference-scale or on
+   InfiniBand / lower-bandwidth fabrics.)
 
-1. **`RECOMPUTE=full` on all arms** compresses the dispatcher delta (see point 3). To measure
-   the dispatcher-isolation upper bound, re-run with recompute off — which needs ≥8 nodes for
-   EP32 (more pipeline stages) to fit without it.
-2. **4 nodes / 32 GPU, not 8** — shared-cluster capacity at run time (see the note above). The
-   EP degree (16/32) is preserved; absolute scale is half the plan.
-3. **EP16 uses PP2, EP32 uses PP1** — within each EP the three arms are identical (clean 3-way),
-   but the cross-EP comparison also changes PP, so read EP16-vs-EP32 as indicative, not isolated.
-4. **`overlap=on` not run** here (it requires recompute off → OOM at PP1 on 4 nodes, plus
-   Qwen3's 94 layers need a 96-layer VPP round-up). Deferred to an 8-node run.
-5. **NVSHMEM arm exits non-zero (1) at process teardown** (NVSHMEM finalize after
-   `[after training is done]`); all 8 steady training iters are recorded and valid (tight
-   median≈mean), so the measurement is unaffected. STATUS shows `exit=1` for those runs. Because
-   this benign finalize-failure and a *real* failure (e.g. mid-run OOM) both surface as pod
-   phase `Failed`, validity for the NVSHMEM arm rests on the EFA gate + `n_steady==8` in
-   `index.csv` — cross-check those before trusting an NVSHMEM-arm number, don't rely on exit code.
-6. **Mock data + random-init + forced balancing** — measures the dispatcher on a balanced
-   token distribution (step time, not loss), same regime as the DSV3/Kimi-K2 A/Bs.
-7. Single run per cell (within-run σ small; between-run variance not bounded).
+### Validity (primary, EP32 overlap=off + NCCL overlap=on)
+
+EFA active on all 64 ranks (`efa_ok`, 8/8 node logs) · 0 stalls · 8 steady iters · per-arm
+transport confirmed (`uccl_ok` / `nvshmem_ok`). Work-equivalence verified on a 2-node smoke
+(`LOSS_PROBE`): deepep-nvshmem iter-1 loss matches NCCL to ~4 sig figs (12.701515 vs 12.702237,
+rel 5.7e-5). The NVSHMEM arm exits non-zero at NVSHMEM finalize *after* training — validate via
+`efa_ok` + `n_steady==8`, not exit code.
+
+---
+
+## Secondary reference — 4 nodes, recompute=full (capacity-constrained)
+
+Retained to show the regime dependence. **Do not read this as the headline** — point 2 above
+explains why its EP32 deltas are distorted.
+
+| Field | Value |
+|---|---|
+| Hardware | **4 × `p6-b300.48xlarge`** (32× B300), EKS `ml-shared` |
+| World | 32 ranks, TP8, ETP1, **`RECOMPUTE=full`**, overlap=off, global batch 128 |
+| Parallelism | EP16 = PP2/DP2 · EP32 = **PP1**/DP4 (`PP = WORLD/EP`, WORLD=32) |
+| Campaign | `qwen3final-20260621T0215Z` |
+
+> **Why 4 nodes:** at run time the shared cluster had only 6 of 8 B300 free (held by other
+> teams), and EP32 cannot tile 6 nodes with integer PP, so this ran on 4 nodes — where EP32 is
+> forced to **PP1** and needs `RECOMPUTE=full` to fit. That regime is what distorts the deltas.
+
+mean iter s · TFLOP/s/GPU · tok/s; `Δ` vs NCCL (− = DeepEP faster):
+
+| EP | mb | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|---:|---:|----------------:|------------:|---------------:|-------:|----------:|
+| 16 | 4 | 15.18 · 159.8 · 34.5k | 17.85 · 135.9 · 29.4k | 14.91 · 162.7 · 35.2k | +17.6% | −1.8% |
+| 16 | 1 | 46.81 · 51.8 · 11.2k | 56.00 · 43.5 · 9.4k | 50.09 · 48.4 · 10.5k | +19.6% | +7.0% |
+| 32 | 4 | 22.20 · 109.3 · 23.6k | 20.96 · 117.2 · 25.0k | 23.76 · 103.1 · 22.1k | −5.6% | +7.1% |
+| 32 | 1 | 45.45 · 53.4 · 11.5k | 57.94 · 42.2 · 9.0k | 55.35 · 44.2 · 9.5k | +27.5% | +21.8% |
+
+At this `RECOMPUTE=full` regime the mb=4 deltas are small (≤±18%) and, at n=1, sub-±6% gaps
+(EP16 NVSHMEM −1.8%, EP32 UCCL −5.6%) are within noise — which is exactly why the 8-node PP2
+re-run was done. The one regime-independent read that holds in both campaigns: **NCCL wins the
+mb=1 tiny-dispatch regime** (DeepEP per-dispatch overhead unamortized).
+
+---
+
+## Caveats (both campaigns)
+
+1. **Regime matters more than n.** The dispatcher delta depends strongly on PP depth + recompute
+   (compute-vs-comm balance), as the primary-vs-secondary contrast shows. Compare only within a
+   regime.
+2. **n=1 per cell.** Within-run σ is small (median≈mean), but between-run variance is not bounded.
+   The primary EP32 deltas are large enough (+16% to +40%) to be robust at n=1; the secondary's
+   sub-±6% deltas are not. n≥3 with error bars is the recommended next step.
+3. **`overlap=on` uses 96 layers** (Qwen3's 94 rounded up for VPP divisibility) and recompute off
+   — a separate within-regime A/B; do not subtract across overlap regimes.
+4. **NVSHMEM arm exits 1 at teardown** (NVSHMEM finalize after training); measured iters are valid
+   — gate on `efa_ok` + `n_steady==8`.
+5. **Mock data + random-init + forced balancing** — measures the dispatcher on a balanced token
+   distribution (step time, not loss), same regime as the DSV3/Kimi-K2 A/Bs.
 
 ## How to reproduce
 
-See [`../README.md`](../README.md). The exact campaign:
+See [`../README.md`](../README.md). Primary (8-node EP32@PP2):
 
 ```bash
-CTX=ml-shared NS=kimi-k2-bench NNODES=4 EPS="16 32" CELLS="4:off 1:off" RECOMPUTE=full \
-TRAIN_ITERS=12 GLOBAL_BATCH=128 \
+CTX=ml-shared NS=kimi-k2-bench NNODES=8 EPS="32 16" CELLS="4:off 1:off 4:on" RECOMPUTE=selective \
+TRAIN_ITERS=12 GLOBAL_BATCH=256 \
 UCCL_IMG=<…>:nemo-26.04.01-uccl-0dc87eb \
 NVSHMEM_IMG=<…>:nemo-26.04.01-deepep-nvshmem-567632d-cu13 \
   bash run-qwen3-campaign.sh
 # then: python3 ../bench/parse-runs.py <campaign_dir> --warmup 4
 ```
 
-**Confounder guard:** assert `NET/OFI Selected provider is efa` appears for every rank of
-every run (the parser's `efa_ok`); discard and re-run any run where it does not.
+**Confounder guard:** assert `NET/OFI Selected provider is efa` for every rank of every run
+(`efa_ok`); discard and re-run any run where it does not (this is how the preempted 7/8-node
+runs are detected and rerun).

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/bench_qwen3_pretrain.py
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/bench_qwen3_pretrain.py
@@ -1,0 +1,249 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tier-B throughput A/B/C entrypoint: Qwen3-235B-A22B MoE pretrain step.
+
+Builds the real Qwen3-235B-A22B architecture (128-expert fine-grained MoE, top-8,
+94 layers, hidden 4096, no shared expert) via Megatron-Bridge's shipped recipe with
+**mock data** and **random-init weights**, then runs ``pretrain()`` for a fixed number
+of iterations. The ONLY thing that changes between the benchmark arms is the MoE token
+dispatcher, selected by ``MOE_DISPATCHER`` — and, for the ``deepep`` arm, *which*
+``deep_ep`` the image provides:
+
+    MOE_DISPATCHER=alltoall  -> moe_token_dispatcher_type="alltoall"   (NCCL all-to-all / EFA) [baseline]
+    MOE_DISPATCHER=deepep    -> flex + moe_flex_dispatcher_backend="deepep"                      [treatment]
+                                 transport = whatever `import deep_ep` resolves to in the IMAGE:
+                                   * UCCL image    -> UCCL EFA-native deep_ep
+                                   * NVSHMEM image -> NVIDIA DeepEP over NVSHMEM-libfabric/EFA
+
+So the THREE-way comparison (NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM) is two images ×
+the same two MOE_DISPATCHER values; this script is identical across all three arms.
+
+Why this is a valid A/B (../../README.md): Megatron's throughput numerator is analytical
+(FLOPs from config), and model/data/parallelism/precision/seed are byte-identical across
+arms, so the iter-time ratio isolates the dispatcher. Random init + mock data are sound
+because we measure step time, not loss — and they decouple the A/B from the HF checkpoint.
+
+Grounded against the image (Megatron-Bridge 0.4.2 / Megatron-Core 0.17.1, nemo:26.04.01):
+- recipe   : megatron.bridge.recipes.qwen.qwen3_moe.qwen3_235b_a22b_pretrain_config
+             (no-arg; mock data by default; calls apply_flex_dispatcher_backend ITSELF)
+- toggle   : megatron.bridge.training.flex_dispatcher_backend.apply_flex_dispatcher_backend
+- fwd step : megatron.bridge.training.gpt_step.forward_step
+- launch   : megatron.bridge.training.pretrain.pretrain(config=cfg, forward_step_func=...)
+
+All knobs come from env so the manifest is the single source of truth and arms differ only
+in MOE_DISPATCHER (and MOE_A2A_OVERLAP, held identical across arms within a run).
+"""
+
+import logging
+import os
+
+logger = logging.getLogger("bench_qwen3_pretrain")
+logging.basicConfig(level=logging.INFO)
+
+
+def _int(name: str, default: int) -> int:
+    return int(os.environ.get(name, str(default)))
+
+
+def build_config():
+    # The recipe builder takes NO arguments — it returns a fully-populated
+    # ConfigContainer (mock data on, Qwen3-235B-A22B 94-layer/128-expert provider,
+    # TP4/PP16/CP2/EP8 defaults) and calls apply_flex_dispatcher_backend(cfg.model,
+    # "deepep") itself at the end. We build it, then MUTATE cfg fields for our A/B shape.
+    from megatron.bridge.recipes.qwen.qwen3_moe import qwen3_235b_a22b_pretrain_config
+    from megatron.bridge.training.flex_dispatcher_backend import apply_flex_dispatcher_backend
+
+    # Parallelism — manifest contract. 64-GPU (8x p6-b300) EP sweep:
+    #   EP16: TP8 * PP4 * DP2 (CP1) -> EP16 divides TP*DP=16 and 128 experts (8/rank).
+    #   EP32: TP8 * PP2 * DP4 (CP1) -> EP32 divides TP*DP=32 and 128 experts (4/rank).
+    tp = _int("TENSOR_PARALLEL", 8)
+    pp = _int("PIPELINE_PARALLEL", 2)
+    ep = _int("EXPERT_PARALLEL", 32)
+    cp = _int("CONTEXT_PARALLEL", 1)
+
+    train_iters = _int("TRAIN_ITERS", 24)
+    global_batch = _int("GLOBAL_BATCH", 256)
+    micro_batch = _int("MICRO_BATCH", 1)
+    seq_len = _int("SEQ_LEN", 4096)
+
+    cfg = qwen3_235b_a22b_pretrain_config()   # no-arg; mock data by default
+    m = cfg.model
+
+    # ---- override parallelism / iters / batch for our shape --------------------
+    # Recipe defaults to TP4/PP16/CP2/EP8 (a many-node layout); we use a 64-GPU layout
+    # with TP inside one NVLink node (TP8) and EP spanning nodes.
+    m.tensor_model_parallel_size = tp
+    m.pipeline_model_parallel_size = pp
+    m.expert_model_parallel_size = ep
+    m.context_parallel_size = cp
+    m.expert_tensor_parallel_size = 1            # ETP=1 so EP divides TP*DP
+    m.seq_length = seq_len
+    # The dataset sequence length must match the model's, or cfg.validate() aborts
+    # ("sequence length configuration in model config and dataset config match"). The
+    # recipe defaults both to 4096; keep them in sync whenever SEQ_LEN is overridden.
+    if hasattr(cfg, "dataset") and hasattr(cfg.dataset, "sequence_length"):
+        cfg.dataset.sequence_length = seq_len
+    cfg.train.train_iters = train_iters
+    cfg.train.global_batch_size = global_batch
+    cfg.train.micro_batch_size = micro_batch
+
+    # This is a throughput benchmark — never write checkpoints. pretrain() otherwise saves a
+    # full 235B checkpoint at the end of every run (slow + fills disk over an 18-run sweep).
+    if hasattr(cfg, "checkpoint"):
+        cfg.checkpoint.save = None
+        cfg.checkpoint.load = None
+        if hasattr(cfg.checkpoint, "save_interval"):
+            cfg.checkpoint.save_interval = None
+
+    # Expert count: keep the recipe-native 128 (Qwen3-235B-A22B). The dispatcher A/B/C
+    # does not depend on the exact expert count; opt-in override only.
+    if os.environ.get("NUM_MOE_EXPERTS"):
+        m.num_moe_experts = _int("NUM_MOE_EXPERTS", m.num_moe_experts)
+
+    # Optional layer-count override (default: recipe-native 94 = real Qwen3-235B).
+    if os.environ.get("NUM_LAYERS"):
+        m.num_layers = _int("NUM_LAYERS", m.num_layers)
+
+    # ---- the single A/B toggle -------------------------------------------------
+    # apply_flex_dispatcher_backend(model, backend) sets BOTH the type ("flex") and
+    # backend, AND clears moe_shared_expert_overlap (alltoall-only). The alltoall arm
+    # just sets the type back and disables the flex backend.
+    dispatcher = os.environ.get("MOE_DISPATCHER", "deepep").lower()
+    if dispatcher == "alltoall":
+        m.moe_token_dispatcher_type = "alltoall"          # NCCL all-to-all over EFA (baseline)
+        m.moe_flex_dispatcher_backend = None
+    elif dispatcher == "deepep":
+        m.moe_flex_dispatcher_backend = "deepep"          # flex + deepep -> deep_ep over EFA
+        apply_flex_dispatcher_backend(m, "deepep")        # sets type="flex" + clears shared-expert overlap
+        # A/B VALIDITY GUARD. apply_flex_dispatcher_backend EARLY-RETURNS (leaving
+        # type != "flex") if the device-name allowlist (.startswith("NVIDIA B300"))
+        # doesn't match. That would silently run the deepep arm as plain alltoall and
+        # zero out the delta. Fail loudly instead of producing a fake null result.
+        if m.moe_token_dispatcher_type != "flex":
+            import torch
+            raise RuntimeError(
+                "deepep arm did not become flex (got %r): apply_flex_dispatcher_backend "
+                "early-returned — device %r not in the B200/B300 allowlist. Aborting to "
+                "avoid an invalid A/B."
+                % (m.moe_token_dispatcher_type, torch.cuda.get_device_properties(0).name)
+            )
+    else:
+        raise ValueError("MOE_DISPATCHER must be 'alltoall' or 'deepep', got %r" % dispatcher)
+
+    # moe_shared_expert_overlap is alltoall-only AND Qwen3 has no shared expert; hold it
+    # OFF on both arms (recipe default is already False).
+    if hasattr(m, "moe_shared_expert_overlap"):
+        m.moe_shared_expert_overlap = False
+
+    # ---- Forced router load-balancing (representative dispatcher regime) -------
+    # With random-init weights + mock data the router is DEGENERATE (tokens pile onto a
+    # few experts -> one EP rank's all-to-all floods while the rest idle -> bimodal stalls
+    # that are an artifact of the untrained router, not the dispatcher). Real training
+    # stays balanced via the aux loss; moe_router_force_load_balancing reproduces that.
+    # Held IDENTICAL across arms. (Recipe default False.) Disable with MOE_FORCE_BALANCE=off.
+    if os.environ.get("MOE_FORCE_BALANCE", "on").lower() == "on":
+        if hasattr(m, "moe_router_force_load_balancing"):
+            m.moe_router_force_load_balancing = True
+
+    # ---- A2A/EP overlap — held IDENTICAL across arms within a run --------------
+    # MOE_A2A_OVERLAP=on enables overlap_moe_expert_parallel_comm (1F1B hides the EP
+    # all-to-all behind compute — the deployment regime). On core 0.17.1 this has hard
+    # co-requirements when PP>1: a virtual pipeline (VPP) and recomputation fully OFF.
+    #
+    # Qwen3 is a UNIFORM 94-layer stack with NO shipped VPP layout helper (unlike DSV3's
+    # set_deepseek_v3_pipeline_model_parallel_layout). Standard VPP needs
+    # num_layers % (pp*vpp) == 0, and 94 = 2*47 is not divisible. For overlap=on we
+    # therefore round num_layers UP to the nearest pp*vpp multiple (e.g. 94 -> 96) and
+    # disable the embedding/loss pipeline-split accounting so a plain uniform split
+    # applies. This makes overlap=on a SEPARATE within-regime A/B (different num_layers
+    # AND recompute vs overlap=off) — NEVER subtract a number across the two regimes.
+    overlap = os.environ.get("MOE_A2A_OVERLAP", "on").lower() == "on"
+    if overlap:
+        if pp > 1:
+            vpp = _int("VPP", 2)
+            m.virtual_pipeline_model_parallel_size = vpp
+            block = pp * vpp
+            if m.num_layers % block != 0:
+                new_nl = ((m.num_layers // block) + 1) * block
+                logger.warning(
+                    "overlap=on: rounding num_layers %d -> %d for VPP=%d/PP=%d divisibility "
+                    "(Qwen3 has no shipped VPP layout helper; this is a separate within-regime A/B)",
+                    m.num_layers, new_nl, vpp, pp,
+                )
+                m.num_layers = new_nl
+            for attr in ("account_for_embedding_in_pipeline_split",
+                         "account_for_loss_in_pipeline_split"):
+                if hasattr(m, attr):
+                    setattr(m, attr, False)
+        # Recomputation must be fully disabled for the overlap path.
+        m.recompute_granularity = None
+        m.recompute_method = None
+        m.recompute_num_layers = None
+        if getattr(m, "recompute_modules", None):
+            m.recompute_modules = [x for x in m.recompute_modules if x != "moe"]
+    # Set the overlap flag on whichever config object exposes it. Keep delay_wgrad_compute
+    # OFF to isolate the overlap mechanism.
+    for obj in (getattr(cfg, "comm_overlap", None), m):
+        if obj is None:
+            continue
+        if hasattr(obj, "overlap_moe_expert_parallel_comm"):
+            obj.overlap_moe_expert_parallel_comm = overlap
+        if hasattr(obj, "delay_wgrad_compute"):
+            obj.delay_wgrad_compute = False
+
+    # Ensure the analytical throughput line is emitted (RESULTS scraping keys on it).
+    if hasattr(cfg, "logger"):
+        if hasattr(cfg.logger, "log_throughput"):
+            cfg.logger.log_throughput = True
+        if hasattr(cfg.logger, "log_interval"):
+            cfg.logger.log_interval = 1
+
+    logger.info(
+        "bench cfg: dispatcher=%s overlap=%s | L=%s h=%s experts=%s topk=%s | "
+        "TP%s PP%s EP%s CP%s | iters=%s gbs=%s mbs=%s seq=%s",
+        dispatcher, overlap, m.num_layers, m.hidden_size, m.num_moe_experts,
+        m.moe_router_topk, tp, pp, ep, cp, train_iters, global_batch, micro_batch, seq_len,
+    )
+    return cfg
+
+
+def main():
+    from megatron.bridge.training.gpt_step import forward_step as _forward_step
+    from megatron.bridge.training.pretrain import pretrain
+
+    fwd = _forward_step
+    # LOSS_PROBE=1: wrap the loss function to print per-microbatch loss on the last PP
+    # stage. Used for the work-equivalence A/B check (deepep vs alltoall, and UCCL vs
+    # NVSHMEM, must yield identical loss on identical data/seed/init — a dispatcher that
+    # dropped or mis-routed tokens would diverge). This is the guard for the NVSHMEM arm's
+    # IBGDA->host-proxy + put_signal patches.
+    if os.environ.get("LOSS_PROBE") == "1":
+        _n = {"i": 0}
+
+        # MUST match gpt_step.forward_step's exact signature so the training loop's
+        # prepare_forward_step_func() injects `state` as a partial (a variadic wrapper
+        # hides that param and breaks the call arity).
+        def fwd(state, data_iterator, model, return_schedule_plan=False):
+            out, loss_fn = _forward_step(state, data_iterator, model, return_schedule_plan)
+
+            def wrapped(*a, **k):
+                res = loss_fn(*a, **k)
+                try:
+                    loss_sum = float(res[0].detach().float().item())
+                    ntok = float(res[1].item()) if len(res) > 1 and res[1] is not None else float("nan")
+                    mean = loss_sum / ntok if ntok == ntok and ntok else float("nan")
+                    _n["i"] += 1
+                    print("[LOSSPROBE] call=%d loss_sum=%.6f num_tokens=%.0f mean_loss=%.6f"
+                          % (_n["i"], loss_sum, ntok, mean), flush=True)
+                except Exception as e:  # never let the probe break the run
+                    print("[LOSSPROBE] err %r" % (e,), flush=True)
+                return res
+
+            return out, wrapped
+
+    cfg = build_config()
+    pretrain(config=cfg, forward_step_func=fwd)
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/bench_qwen3_pretrain.py
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/bench_qwen3_pretrain.py
@@ -50,8 +50,16 @@ def build_config():
     # ConfigContainer (mock data on, Qwen3-235B-A22B 94-layer/128-expert provider,
     # TP4/PP16/CP2/EP8 defaults) and calls apply_flex_dispatcher_backend(cfg.model,
     # "deepep") itself at the end. We build it, then MUTATE cfg fields for our A/B shape.
-    from megatron.bridge.recipes.qwen.qwen3_moe import qwen3_235b_a22b_pretrain_config
+    from megatron.bridge.recipes.qwen import qwen3_moe
     from megatron.bridge.training.flex_dispatcher_backend import apply_flex_dispatcher_backend
+
+    # QWEN3_SIZE selects the shipped recipe (235b default; 30b = Qwen3-30B-A3B, which fits
+    # H100-80GB so it's used for the p5.48xlarge runs). Both are 128-expert top-8 Qwen3 MoE;
+    # 30b has hidden 2048 / 48 layers vs 235b's 4096 / 94.
+    _size = os.environ.get("QWEN3_SIZE", "235b").lower()
+    _recipes = {"235b": "qwen3_235b_a22b_pretrain_config", "30b": "qwen3_30b_a3b_pretrain_config"}
+    if _size not in _recipes:
+        raise ValueError("QWEN3_SIZE must be one of %s, got %r" % (sorted(_recipes), _size))
 
     # Parallelism — manifest contract. 64-GPU (8x p6-b300) EP sweep:
     #   EP16: TP8 * PP4 * DP2 (CP1) -> EP16 divides TP*DP=16 and 128 experts (8/rank).
@@ -66,7 +74,7 @@ def build_config():
     micro_batch = _int("MICRO_BATCH", 1)
     seq_len = _int("SEQ_LEN", 4096)
 
-    cfg = qwen3_235b_a22b_pretrain_config()   # no-arg; mock data by default
+    cfg = getattr(qwen3_moe, _recipes[_size])()   # no-arg; mock data by default
     m = cfg.model
 
     # ---- override parallelism / iters / batch for our shape --------------------
@@ -226,9 +234,9 @@ def build_config():
             cfg.logger.log_interval = 1
 
     logger.info(
-        "bench cfg: dispatcher=%s overlap=%s | L=%s h=%s experts=%s topk=%s | "
+        "bench cfg: size=%s dispatcher=%s overlap=%s | L=%s h=%s experts=%s topk=%s | "
         "TP%s PP%s EP%s CP%s | iters=%s gbs=%s mbs=%s seq=%s",
-        dispatcher, overlap, m.num_layers, m.hidden_size, m.num_moe_experts,
+        _size, dispatcher, overlap, m.num_layers, m.hidden_size, m.num_moe_experts,
         m.moe_router_topk, tp, pp, ep, cp, train_iters, global_batch, micro_batch, seq_len,
     )
     return cfg

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/bench_qwen3_pretrain.py
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/bench_qwen3_pretrain.py
@@ -166,6 +166,13 @@ def build_config():
     # applies. This makes overlap=on a SEPARATE within-regime A/B (different num_layers
     # AND recompute vs overlap=off) — NEVER subtract a number across the two regimes.
     overlap = os.environ.get("MOE_A2A_OVERLAP", "on").lower() == "on"
+    # overlap_moe_expert_parallel_comm hides the EP all-to-all behind 1F1B pipeline compute —
+    # which only exists when PP>1. At PP=1 there is nothing to overlap against, so force it off
+    # (setting the flag with no pipeline is at best a no-op and at worst a config-validate abort).
+    if overlap and pp <= 1:
+        logger.warning("MOE_A2A_OVERLAP=on requested but PP=%d (no pipeline to overlap "
+                       "against) — forcing overlap OFF for this run.", pp)
+        overlap = False
     if overlap:
         if pp > 1:
             vpp = _int("VPP", 2)

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/bench_qwen3_pretrain.py
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/bench_qwen3_pretrain.py
@@ -88,12 +88,20 @@ def build_config():
     cfg.train.micro_batch_size = micro_batch
 
     # This is a throughput benchmark — never write checkpoints. pretrain() otherwise saves a
-    # full 235B checkpoint at the end of every run (slow + fills disk over an 18-run sweep).
+    # full 235B checkpoint at the end of every run (slow + fills disk over a multi-run sweep).
     if hasattr(cfg, "checkpoint"):
         cfg.checkpoint.save = None
         cfg.checkpoint.load = None
         if hasattr(cfg.checkpoint, "save_interval"):
             cfg.checkpoint.save_interval = None
+    # Disable the post-training evaluation loop (the recipe runs ~32 eval iters, which on a
+    # 235B model dwarfs the few training iters we time and can blow the run timeout). We only
+    # measure training-step time.
+    if hasattr(cfg, "train"):
+        if hasattr(cfg.train, "eval_iters"):
+            cfg.train.eval_iters = 0
+        if hasattr(cfg.train, "eval_interval"):
+            cfg.train.eval_interval = train_iters + 1000
 
     # Expert count: keep the recipe-native 128 (Qwen3-235B-A22B). The dispatcher A/B/C
     # does not depend on the exact expert count; opt-in override only.
@@ -190,6 +198,18 @@ def build_config():
             obj.overlap_moe_expert_parallel_comm = overlap
         if hasattr(obj, "delay_wgrad_compute"):
             obj.delay_wgrad_compute = False
+
+    # Optional activation recomputation, independent of the dispatcher (held identical across
+    # arms). overlap=on requires recompute OFF (forced above), so only apply when overlap is
+    # off. Needed to fit large per-stage layer counts on few nodes — e.g. EP32 at PP1 on 4
+    # nodes (all 94 layers on one stage). RECOMPUTE=full|selective.
+    recompute = os.environ.get("RECOMPUTE", "").lower()
+    if not overlap and recompute in ("full", "selective"):
+        m.recompute_granularity = "full" if recompute == "full" else "selective"
+        if recompute == "full":
+            m.recompute_method = "uniform"
+            m.recompute_num_layers = _int("RECOMPUTE_NUM_LAYERS", 1)
+        logger.info("recompute enabled: granularity=%s", m.recompute_granularity)
 
     # Ensure the analytical throughput line is emitted (RESULTS scraping keys on it).
     if hasattr(cfg, "logger"):

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/run-qwen3-campaign.sh
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/run-qwen3-campaign.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Drive the Qwen3-235B-A22B THREE-WAY MoE dispatcher comparison on up to 8x p6-b300:
+#
+#   arms   = { alltoall (NCCL all-to-all),
+#              deepep-uccl    (DeepEP over UCCL/EFA),
+#              deepep-nvshmem (NVIDIA DeepEP over NVSHMEM-libfabric/EFA) }
+#   EP     = { 16, 32 }                 # the all-to-all fan-out is the variable that matters
+#   cells  = { mb:overlap }            # default: 1:off 4:off 4:on
+#
+# matrix = 3 arms x |EP| x |cells|  (default 3 x 2 x 3 = 18 runs), run serially: each run
+# uses all 64 GPUs. Per run: launch via ../../run-ab-rawpods.sh, wait for rank-0, assert
+# the EFA-active gate on all ranks, delete the run's pods, then the next run.
+#
+# The two deepep arms differ ONLY in the image (which `deep_ep` is importable); alltoall
+# uses the UCCL image but never imports deep_ep. Each arm writes to a distinct, never-
+# overwritten dir tagged <arm>-ep<EP>-mb<m>-ovl<on|off> under one CAMPAIGN_ID.
+#
+# Usage:
+#   CTX=<ctx> UCCL_IMG=<uccl-ecr-uri> NVSHMEM_IMG=<nvshmem-ecr-uri> bash run-qwen3-campaign.sh
+# Override the matrix with EPS / CELLS / ARMS env (space-separated; CELLS items are "mb:ovl").
+set -uo pipefail
+
+CTX="${CTX:?set CTX to your kubectl context}"
+UCCL_IMG="${UCCL_IMG:?set UCCL_IMG to the megatron-bridge-uccl (UCCL) ECR image URI}"
+NVSHMEM_IMG="${NVSHMEM_IMG:?set NVSHMEM_IMG to the deepep-nvshmem ECR image URI}"
+NS="${NS:-kimi-k2-bench}"
+PVC="${PVC:-fsx-kimi-k2}"
+NNODES="${NNODES:-8}"
+GPUS_PER_NODE=8
+WORLD=$(( NNODES * GPUS_PER_NODE ))
+
+export TRAIN_ITERS="${TRAIN_ITERS:-24}"
+export GLOBAL_BATCH="${GLOBAL_BATCH:-256}"
+export SEQ_LEN="${SEQ_LEN:-4096}"
+export MOE_FORCE_BALANCE="${MOE_FORCE_BALANCE:-on}"
+RUN_TIMEOUT="${RUN_TIMEOUT:-2400}"     # seconds to wait for one run's rank-0 to finish
+
+EPS="${EPS:-16 32}"
+CELLS="${CELLS:-1:off 4:off 4:on}"
+# arm spec = "label:dispatcher:imagevar:backend" (imagevar in {UCCL,NVSHMEM}).
+ARMS="${ARMS:-alltoall:alltoall:UCCL: deepep-uccl:deepep:UCCL:uccl deepep-nvshmem:deepep:NVSHMEM:nvshmem}"
+
+export CAMPAIGN_ID="${CAMPAIGN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+export CTX NS
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+LAUNCH="${SELF_DIR}/../../run-ab-rawpods.sh"
+PARSER="${SELF_DIR}/../../bench/parse-runs.py"
+BENCH_PY_SRC="${SELF_DIR}/bench_qwen3_pretrain.py"
+GIT_REV="$(git -C "${SELF_DIR}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+export GIT_REV
+MODEL=qwen3-235b
+STAGE=/fsx/kimi-k2
+HF_CACHE="${STAGE}/hf-cache"
+K="kubectl --context ${CTX} -n ${NS}"
+CAMPAIGN_FS="/fsx/megatron-bridge-bench/${CAMPAIGN_ID}"
+
+echo "############################################################"
+echo "# QWEN3-235B 3-WAY CAMPAIGN ${CAMPAIGN_ID}  git=${GIT_REV}"
+echo "#   arms=[${ARMS}]"
+echo "#   EP=[${EPS}] cells=[${CELLS}] nnodes=${NNODES} world=${WORLD}"
+echo "#   uccl=${UCCL_IMG}"
+echo "#   nvshmem=${NVSHMEM_IMG}"
+echo "#   logs (no overwrite): ${CAMPAIGN_FS}/${MODEL}/<arm>-ep<EP>-mb<m>-ovl<on|off>/"
+echo "############################################################"
+
+# ---- persistent util pod for FSx file ops + HF staging + parsing (0 GPU) ------------------
+UTIL=bench-util
+ensure_util() {
+  if $K get pod ${UTIL} >/dev/null 2>&1; then return; fi
+  cat <<EOF | $K apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata: {name: ${UTIL}}
+spec:
+  restartPolicy: Never
+  nodeSelector: {workload: bench}
+  tolerations:
+    - {key: workload, value: bench, operator: Equal, effect: NoSchedule}
+    - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
+    - {key: capacity-reservation, operator: Exists, effect: NoSchedule}
+  containers:
+    - name: u
+      image: ${UCCL_IMG}
+      command: ["bash","-lc","mkdir -p ${CAMPAIGN_FS}; sleep infinity"]
+      volumeMounts: [{name: fsx, mountPath: /fsx}]
+  volumes:
+    - name: fsx
+      persistentVolumeClaim: {claimName: ${PVC}}
+EOF
+  echo "   waiting for ${UTIL} ..."
+  $K wait --for=condition=Ready pod/${UTIL} --timeout=300s
+}
+uexec() { $K exec ${UTIL} -- bash -lc "$1"; }
+
+ensure_util
+
+# ---- stage bench entrypoint + parser onto FSx --------------------------------------------
+echo "== staging bench + parser to ${STAGE} =="
+$K cp "${BENCH_PY_SRC}" ${UTIL}:${STAGE}/bench_qwen3_pretrain.py
+uexec "mkdir -p ${STAGE}/bench"
+$K cp "${PARSER}" ${UTIL}:${STAGE}/bench/parse-runs.py
+uexec "ls -la ${STAGE}/bench_qwen3_pretrain.py ${STAGE}/bench/parse-runs.py"
+
+# ---- stage the Qwen3 HF config + tokenizer (config only; load_weights=False) -------------
+# The recipe builds its provider via AutoBridge.from_hf_pretrained(...). Pre-download the
+# small config/tokenizer into an FSx HF cache so runs work without per-pod egress. If the
+# util pod has no egress this is a no-op and runs fall back to online (HF_HUB_OFFLINE=0).
+HF_OFFLINE=0
+echo "== staging Qwen3 HF config/tokenizer to ${HF_CACHE} (config only) =="
+if uexec "HF_HOME=${HF_CACHE} python3 -c \"from huggingface_hub import snapshot_download; snapshot_download('Qwen/Qwen3-235B-A22B', allow_patterns=['*.json','*.txt','tokenizer*','merges*','vocab*'])\" "; then
+  HF_OFFLINE=1
+  echo "   HF config staged — runs will use HF_HUB_OFFLINE=1"
+else
+  echo "   WARN: HF prestage failed (no egress on util pod?). Runs will try online (HF_HUB_OFFLINE=0)."
+fi
+export HF_HOME="${HF_CACHE}" HF_HUB_OFFLINE="${HF_OFFLINE}"
+
+# ---- one run ------------------------------------------------------------------------------
+run_one() {
+  local LABEL="$1" DISP="$2" IMG="$3" BACKEND="$4" EP="$5" MB="$6" OVL="$7"
+  local PP=$(( WORLD / EP ))          # TP8 fixed: EP=TP*DP -> PP=WORLD/EP (EP32->PP2, EP16->PP4)
+  local ARM_LABEL="${LABEL}-ep${EP}"
+  local JOB="abrun-${MODEL}-${ARM_LABEL}"
+  local RUN_DIR="${CAMPAIGN_FS}/${MODEL}/${ARM_LABEL}-mb${MB}-ovl${OVL}"
+  echo ""
+  echo ">>> RUN  arm=${LABEL} backend=${BACKEND:-nccl} EP=${EP} (TP8/PP${PP}) mb=${MB} overlap=${OVL}"
+  MODEL="${MODEL}" IMG="${IMG}" ARM_LABEL="${ARM_LABEL}" EP_BACKEND="${BACKEND}" \
+    TENSOR_PARALLEL=8 PIPELINE_PARALLEL="${PP}" EXPERT_PARALLEL="${EP}" \
+    MICRO_BATCH="${MB}" MOE_A2A_OVERLAP="${OVL}" NNODES="${NNODES}" \
+    HF_HOME="${HF_HOME}" HF_HUB_OFFLINE="${HF_HUB_OFFLINE}" \
+    bash "${LAUNCH}" "${DISP}" "${NNODES}" || { echo "   launch failed"; return 1; }
+
+  # wait for rank-0 to finish (Succeeded/Failed) or timeout
+  local t=0 ph
+  while true; do
+    ph=$($K get pod "${JOB}-0" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    [ "$ph" = "Succeeded" ] && { echo "   rank-0 Succeeded (${t}s)"; break; }
+    [ "$ph" = "Failed" ]    && { echo "   rank-0 FAILED (${t}s) — see ${RUN_DIR}/logs/rank-0.log"; break; }
+    [ "$t" -ge "$RUN_TIMEOUT" ] && { echo "   TIMEOUT ${RUN_TIMEOUT}s (phase=${ph})"; break; }
+    sleep 20; t=$((t+20))
+  done
+
+  # validity gates from FSx
+  local efa status
+  efa=$(uexec "grep -l 'Selected provider is efa' ${RUN_DIR}/logs/rank-*.log 2>/dev/null | wc -l" | tr -d '[:space:]')
+  status=$(uexec "cat ${RUN_DIR}/STATUS 2>/dev/null" | tr -d '\r')
+  echo "   STATUS: ${status:-<none>} | EFA-active ranks: ${efa}/${NNODES}"
+  [ "${efa}" != "${NNODES}" ] && echo "   !! WARNING: EFA not active on all ranks — treat as INVALID (rerun)."
+
+  # free the GPUs before the next run
+  for r in $(seq 0 $((NNODES-1))); do $K delete pod "${JOB}-${r}" --ignore-not-found --wait=false >/dev/null 2>&1; done
+  $K delete svc "${JOB}" --ignore-not-found >/dev/null 2>&1
+  echo "   waiting for ${JOB} pods to terminate (free GPUs) ..."
+  $K wait --for=delete pod -l app="${JOB}" --timeout=240s >/dev/null 2>&1 || sleep 20
+}
+
+# ---- matrix: EP (outer) x cell x arm ------------------------------------------------------
+for EP in ${EPS}; do
+  for CELL in ${CELLS}; do
+    MB="${CELL%%:*}"; OVL="${CELL##*:}"
+    for SPEC in ${ARMS}; do
+      IFS=':' read -r LABEL DISP IMGVAR BACKEND <<< "${SPEC}"
+      case "${IMGVAR}" in
+        UCCL)    IMG="${UCCL_IMG}" ;;
+        NVSHMEM) IMG="${NVSHMEM_IMG}" ;;
+        *) echo "bad imagevar ${IMGVAR} in arm spec ${SPEC}"; continue ;;
+      esac
+      run_one "${LABEL}" "${DISP}" "${IMG}" "${BACKEND:-}" "${EP}" "${MB}" "${OVL}"
+    done
+  done
+done
+
+# ---- parse the whole campaign into index.csv + per-run loss_curve.csv ---------------------
+echo ""
+echo "== parsing campaign =="
+uexec "cd ${STAGE}/bench && python3 parse-runs.py ${CAMPAIGN_FS} --warmup 4"
+$K cp ${UTIL}:${CAMPAIGN_FS}/index.csv "${SELF_DIR}/last-campaign-index.csv" 2>/dev/null \
+  && echo "   pulled index.csv -> ${SELF_DIR}/last-campaign-index.csv"
+echo ""
+echo "Campaign ${CAMPAIGN_ID} done. Raw logs preserved under ${CAMPAIGN_FS} (no overwrite)."
+echo "Util pod ${UTIL} left running; delete with: ${K} delete pod ${UTIL}"

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/run-qwen3-campaign.sh
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/run-qwen3-campaign.sh
@@ -36,6 +36,7 @@ export TRAIN_ITERS="${TRAIN_ITERS:-24}"
 export GLOBAL_BATCH="${GLOBAL_BATCH:-256}"
 export SEQ_LEN="${SEQ_LEN:-4096}"
 export MOE_FORCE_BALANCE="${MOE_FORCE_BALANCE:-on}"
+export RECOMPUTE="${RECOMPUTE:-}"     # full|selective|"" — held identical across arms
 RUN_TIMEOUT="${RUN_TIMEOUT:-2400}"     # seconds to wait for one run's rank-0 to finish
 
 EPS="${EPS:-16 32}"

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/run-qwen3-campaign.sh
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/run-qwen3-campaign.sh
@@ -38,6 +38,8 @@ export GLOBAL_BATCH="${GLOBAL_BATCH:-256}"
 export SEQ_LEN="${SEQ_LEN:-4096}"
 export MOE_FORCE_BALANCE="${MOE_FORCE_BALANCE:-on}"
 export RECOMPUTE="${RECOMPUTE:-}"     # full|selective|"" — held identical across arms
+export INSTANCE_TYPE="${INSTANCE_TYPE:-p6-b300.48xlarge}"  # p5.48xlarge for H100 runs
+export EFA_PER_NODE="${EFA_PER_NODE:-16}"                  # 32 for p5.48xlarge
 RUN_TIMEOUT="${RUN_TIMEOUT:-2400}"     # seconds to wait for one run's rank-0 to finish
 
 EPS="${EPS:-16 32}"
@@ -56,7 +58,14 @@ PARSER="${SELF_DIR}/../../bench/parse-runs.py"
 BENCH_PY_SRC="${SELF_DIR}/bench_qwen3_pretrain.py"
 GIT_REV="$(git -C "${SELF_DIR}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 export GIT_REV
-MODEL=qwen3-235b
+# MODEL selects the Qwen3 size (235b on B300, 30b on H100/p5). The bench is shared; the size +
+# the HF config to prestage are derived here and threaded to run-ab-rawpods via QWEN3_SIZE.
+MODEL="${MODEL:-qwen3-235b}"
+case "${MODEL}" in
+  qwen3-235b) export QWEN3_SIZE=235b; HF_MODEL_ID="Qwen/Qwen3-235B-A22B" ;;
+  qwen3-30b)  export QWEN3_SIZE=30b;  HF_MODEL_ID="Qwen/Qwen3-30B-A3B" ;;
+  *) echo "MODEL must be qwen3-235b or qwen3-30b, got ${MODEL}"; exit 2 ;;
+esac
 STAGE=/fsx/kimi-k2
 HF_CACHE="${STAGE}/hf-cache"
 K="kubectl --context ${CTX} -n ${NS}"
@@ -115,7 +124,7 @@ uexec "ls -la ${STAGE}/bench_qwen3_pretrain.py ${STAGE}/bench/parse-runs.py"
 # util pod has no egress this is a no-op and runs fall back to online (HF_HUB_OFFLINE=0).
 HF_OFFLINE=0
 echo "== staging Qwen3 HF config/tokenizer to ${HF_CACHE} (config only) =="
-if uexec "HF_HOME=${HF_CACHE} python3 -c \"from huggingface_hub import snapshot_download; snapshot_download('Qwen/Qwen3-235B-A22B', allow_patterns=['*.json','*.txt','tokenizer*','merges*','vocab*'])\" "; then
+if uexec "HF_HOME=${HF_CACHE} python3 -c \"from huggingface_hub import snapshot_download; snapshot_download('${HF_MODEL_ID}', allow_patterns=['*.json','*.txt','tokenizer*','merges*','vocab*'])\" "; then
   HF_OFFLINE=1
   echo "   HF config staged — runs will use HF_HUB_OFFLINE=1"
 else

--- a/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/run-qwen3-campaign.sh
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-235b/benchmarks/run-qwen3-campaign.sh
@@ -31,6 +31,7 @@ PVC="${PVC:-fsx-kimi-k2}"
 NNODES="${NNODES:-8}"
 GPUS_PER_NODE=8
 WORLD=$(( NNODES * GPUS_PER_NODE ))
+TP="${TENSOR_PARALLEL:-8}"            # fixed across the sweep (intra-node NVLink); EP=TP*DP
 
 export TRAIN_ITERS="${TRAIN_ITERS:-24}"
 export GLOBAL_BATCH="${GLOBAL_BATCH:-256}"
@@ -40,7 +41,10 @@ export RECOMPUTE="${RECOMPUTE:-}"     # full|selective|"" — held identical acr
 RUN_TIMEOUT="${RUN_TIMEOUT:-2400}"     # seconds to wait for one run's rank-0 to finish
 
 EPS="${EPS:-16 32}"
-CELLS="${CELLS:-1:off 4:off 4:on}"
+# Default to the validated overlap=off cells (mb4 = efficient point first, then mb1 crossover).
+# overlap=on needs PP>1 + recompute-off headroom (see RESULTS caveat) — add "4:on" explicitly
+# only on a node count where EP tiles with PP>1 for the EP you want.
+CELLS="${CELLS:-4:off 1:off}"
 # arm spec = "label:dispatcher:imagevar:backend" (imagevar in {UCCL,NVSHMEM}).
 ARMS="${ARMS:-alltoall:alltoall:UCCL: deepep-uccl:deepep:UCCL:uccl deepep-nvshmem:deepep:NVSHMEM:nvshmem}"
 
@@ -122,14 +126,21 @@ export HF_HOME="${HF_CACHE}" HF_HUB_OFFLINE="${HF_OFFLINE}"
 # ---- one run ------------------------------------------------------------------------------
 run_one() {
   local LABEL="$1" DISP="$2" IMG="$3" BACKEND="$4" EP="$5" MB="$6" OVL="$7"
-  local PP=$(( WORLD / EP ))          # TP8 fixed: EP=TP*DP -> PP=WORLD/EP (EP32->PP2, EP16->PP4)
+  # TP8 fixed, ETP1: EP = TP*DP, so PP = WORLD/EP and DP = EP/TP. Guard that the layout tiles
+  # with integer PP and DP before launching — a non-dividing EP would silently floor PP and
+  # burn a whole N-node job that fails late inside Megatron (the opposite of "fail cheap").
+  if (( WORLD % EP != 0 )) || (( EP % TP != 0 )); then
+    echo "   SKIP: EP=${EP} does not tile WORLD=${WORLD} with TP=${TP} (need WORLD%EP==0 and EP%TP==0)"
+    return 0
+  fi
+  local PP=$(( WORLD / EP ))          # EP32->PP1/DP4, EP16->PP2/DP2 at WORLD=32; EP16->PP4 at WORLD=64
   local ARM_LABEL="${LABEL}-ep${EP}"
   local JOB="abrun-${MODEL}-${ARM_LABEL}"
   local RUN_DIR="${CAMPAIGN_FS}/${MODEL}/${ARM_LABEL}-mb${MB}-ovl${OVL}"
   echo ""
   echo ">>> RUN  arm=${LABEL} backend=${BACKEND:-nccl} EP=${EP} (TP8/PP${PP}) mb=${MB} overlap=${OVL}"
   MODEL="${MODEL}" IMG="${IMG}" ARM_LABEL="${ARM_LABEL}" EP_BACKEND="${BACKEND}" \
-    TENSOR_PARALLEL=8 PIPELINE_PARALLEL="${PP}" EXPERT_PARALLEL="${EP}" \
+    TENSOR_PARALLEL="${TP}" PIPELINE_PARALLEL="${PP}" EXPERT_PARALLEL="${EP}" \
     MICRO_BATCH="${MB}" MOE_A2A_OVERLAP="${OVL}" NNODES="${NNODES}" \
     HF_HOME="${HF_HOME}" HF_HUB_OFFLINE="${HF_HUB_OFFLINE}" \
     bash "${LAUNCH}" "${DISP}" "${NNODES}" || { echo "   launch failed"; return 1; }

--- a/3.test_cases/megatron/megatron-bridge/qwen3-30b/README.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-30b/README.md
@@ -1,0 +1,56 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: MIT-0 -->
+
+# Qwen3-30B-A3B (128-expert MoE) — NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM (p5.48xlarge / H100)
+
+The same three-way MoE token-dispatcher comparison as [`../qwen3-235b/`](../qwen3-235b/), but on
+**`p5.48xlarge` (H100-80GB, sm_90, 32× EFA / node)** using **Qwen3-30B-A3B** — the shipped smaller
+Qwen3 MoE (30B total / 3B active, **128 experts**, top-8, 48 layers, hidden 2048). Qwen3-235B does
+**not** fit H100-80GB at EP16/EP32, so the H100 comparison uses the 30B sibling, which fits with
+**recompute off** (the cleanest dispatcher-isolation regime).
+
+This pairs with the B300 / Qwen3-235B results to show the dispatcher comparison **across two
+fabrics/GPUs**: p6-b300 (B300, 16×400G EFA, ~6.4 Tbps/node) vs p5.48xlarge (H100, 32×100G EFA,
+~3.2 Tbps/node).
+
+## EP > 8 (internode all-to-all)
+
+With **TP8** occupying one node's NVLink domain, **EP > 8 forces the expert all-to-all across
+nodes** (EP16 spans 2 nodes, EP32 spans 4) — i.e. genuine internode EFA traffic, not intranode
+NVLink. Both swept points satisfy this:
+
+| EP | TP | PP | DP | nodes the EP group spans |
+|---:|---:|---:|---:|---|
+| 16 | 8 | 4 | 2 | 2 (internode) |
+| 32 | 8 | 2 | 4 | 4 (internode) |
+
+`PP = WORLD/EP` (WORLD = 64 = 8 nodes × 8 H100). 48 layers is VPP-divisible for both, so
+`overlap=on` needs no layer round-up (unlike Qwen3-235B's 94).
+
+## Shared harness
+
+This model reuses the shared Qwen3 bench and campaign (one bench, selected by `QWEN3_SIZE`):
+- bench: [`../qwen3-235b/benchmarks/bench_qwen3_pretrain.py`](../qwen3-235b/benchmarks/bench_qwen3_pretrain.py) (`QWEN3_SIZE=30b`)
+- campaign: [`../qwen3-235b/benchmarks/run-qwen3-campaign.sh`](../qwen3-235b/benchmarks/run-qwen3-campaign.sh) (`MODEL=qwen3-30b`)
+
+Both DeepEP arms need **sm_90** images (the B300 images are Blackwell-only); build them with:
+
+```bash
+# from megatron-bridge/ — add Hopper to the arch list:
+docker build -f Dockerfile --build-arg EP_BACKEND=uccl    --build-arg TORCH_CUDA_ARCH_LIST="9.0a+PTX" \
+  -t <repo>:nemo-26.04.01-uccl-0dc87eb-sm90 .
+docker build -f Dockerfile --build-arg EP_BACKEND=nvshmem --build-arg DEEPEP_GPU_ARCH="90" \
+  -t <repo>:nemo-26.04.01-deepep-nvshmem-567632d-cu13-sm90 .
+```
+
+Run the campaign on 8× p5.48xlarge (recompute off — 30B fits H100):
+
+```bash
+CTX=<ctx> NS=kimi-k2-bench MODEL=qwen3-30b NNODES=8 EPS="16 32" CELLS="4:off 1:off 4:on" RECOMPUTE="" \
+TRAIN_ITERS=12 GLOBAL_BATCH=256 INSTANCE_TYPE=p5.48xlarge EFA_PER_NODE=32 \
+UCCL_IMG=<repo>:nemo-26.04.01-uccl-0dc87eb-sm90 \
+NVSHMEM_IMG=<repo>:nemo-26.04.01-deepep-nvshmem-567632d-cu13-sm90 \
+  bash ../qwen3-235b/benchmarks/run-qwen3-campaign.sh
+```
+
+Measured numbers: [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).

--- a/3.test_cases/megatron/megatron-bridge/qwen3-30b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-30b/benchmarks/RESULTS.md
@@ -58,8 +58,8 @@ Metric of record: mean training-iteration time over 8 steady iters (first 4 of 1
 | | B300 / Qwen3-235B (hidden 4096, EP32 PP2) | H100 / Qwen3-30B (hidden 2048, EP32 PP2) |
 |---|---|---|
 | NCCL all-to-all | fastest | fastest |
-| DeepEP+UCCL (mb4) | +15.9% | +186.8% |
-| DeepEP+NVSHMEM (mb4) | +28.3% | +86.2% |
+| DeepEP+UCCL (mb4) | +21.5% | +186.8% |
+| DeepEP+NVSHMEM (mb4) | +34.0% | +86.2% |
 
 Same qualitative conclusion on both fabrics — **NCCL all-to-all wins** — but the DeepEP penalty
 is far larger on H100/30B (smaller messages, lower-bandwidth fabric, compute-light model). No

--- a/3.test_cases/megatron/megatron-bridge/qwen3-30b/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/qwen3-30b/benchmarks/RESULTS.md
@@ -1,0 +1,83 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: MIT-0 -->
+
+# Qwen3-30B-A3B — NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM — Benchmark Results (p5.48xlarge / H100)
+
+Three-way MoE token-dispatcher comparison on **8 × `p5.48xlarge` (H100-80GB, sm_90, 32× EFA /
+node)**, using **Qwen3-30B-A3B** (128 experts, top-8, 48 layers, hidden 2048). This is the H100
+companion to the B300 / Qwen3-235B results in [`../../qwen3-235b/benchmarks/RESULTS.md`](../../qwen3-235b/benchmarks/RESULTS.md).
+Metric of record: mean training-iteration time over 8 steady iters (first 4 of 12 dropped);
+`Δ` vs the NCCL all-to-all baseline (− = DeepEP faster, + = slower).
+
+| Field | Value |
+|---|---|
+| Date | 2026-06-22 |
+| Hardware | 8 × `p5.48xlarge` (64× H100-80GB, sm_90, 32× EFA / node ≈ 3.2 Tbps), EKS `ml-shared` |
+| Model | Qwen3-30B-A3B — 128 experts, top-8, 48 layers, hidden 2048, bf16 |
+| World | 64 ranks, TP8, ETP1, balanced routing, **recompute off** (30B fits H100), gbs 256 |
+| EP sweep | **EP16 = TP8/PP4/DP2** (EP spans 2 nodes) · **EP32 = TP8/PP2/DP4** (spans 4) — both **EP>8 ⇒ internode** EFA |
+| Images | `…-uccl-0dc87eb-sm90` · `…-deepep-nvshmem-567632d-cu13-sm90` (Hopper rebuilds) |
+| Campaign | `qwen3-30b-p5-h100-20260622` (17/18 cells valid; `deepep-uccl-ep32-mb4-on` preempted) |
+
+## Measured result — mean iter s · MODEL TFLOP/s/GPU · tok/s
+
+### EP16 (TP8/PP4/DP2) — all-to-all spans 2 nodes
+
+| mb · overlap | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|---|---:|---:|---:|---:|---:|
+| 4 · off | **8.60 · 43.9 · 122.0k** | 14.81 · 25.5 · 70.8k | 9.16 · 41.1 · 114.4k | +72.3% | +6.6% |
+| 1 · off | **27.89 · 13.5 · 37.6k** | 37.23 · 10.2 · 28.2k | 28.69 · 13.1 · 36.6k | +33.5% | +2.8% |
+| 4 · on  | **6.87 · 54.9 · 152.5k** | 11.21 · 33.6 · 93.5k | 7.08 · 53.2 · 148.0k | +63.1% | +3.0% |
+
+### EP32 (TP8/PP2/DP4) — all-to-all spans 4 nodes
+
+| mb · overlap | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM | UCCL Δ | NVSHMEM Δ |
+|---|---:|---:|---:|---:|---:|
+| 4 · off | **9.24 · 40.8 · 113.5k** | 26.51 · 14.5 · 39.6k | 17.21 · 22.8 · 60.9k | +186.8% | +86.2% |
+| 1 · off | **27.14 · 13.9 · 38.6k** | 48.22 · 7.8 · 21.7k | 34.66 · 11.0 · 30.3k | +77.7% | +27.7% |
+| 4 · on  | **6.29 · 60.0 · 166.8k** | _preempted_ | 11.37 · 36.6 · 92.2k | — | +80.8% |
+
+## What the numbers say
+
+1. **On H100 with Qwen3-30B, NCCL all-to-all is the fastest dispatcher in every cell** — by
+   large, unambiguous margins. DeepEP+NVSHMEM is the better of the two DeepEP backends; UCCL is
+   consistently the slowest.
+2. **The DeepEP penalty grows sharply with EP degree.** At **EP16** DeepEP+NVSHMEM is within
+   ~3–7% of NCCL (and UCCL +33–72%); at **EP32** it blows out to **+28% to +86%** for NVSHMEM and
+   **+78% to +187%** for UCCL. Doubling the expert-parallel fan-out (2→4 nodes) is where the
+   DeepEP/EFA path falls apart on this fabric.
+3. **This is the small-message, comm-bound regime.** Qwen3-30B (hidden 2048) makes each
+   all-to-all message small and the step compute-light (NCCL tops out ~44–60 MODEL TFLOP/s/GPU),
+   so DeepEP's per-dispatch proxy/kernel-launch overhead dominates and the % deltas are
+   *amplified* relative to a compute-heavy model. Treat these as the **worst case for DeepEP**
+   (small messages on H100), complementary to the B300/Qwen3-235B numbers (larger messages,
+   compute-heavier) where the gaps are smaller.
+
+## Cross-hardware picture (with [`../../qwen3-235b`](../../qwen3-235b/benchmarks/RESULTS.md))
+
+| | B300 / Qwen3-235B (hidden 4096, EP32 PP2) | H100 / Qwen3-30B (hidden 2048, EP32 PP2) |
+|---|---|---|
+| NCCL all-to-all | fastest | fastest |
+| DeepEP+UCCL (mb4) | +15.9% | +186.8% |
+| DeepEP+NVSHMEM (mb4) | +28.3% | +86.2% |
+
+Same qualitative conclusion on both fabrics — **NCCL all-to-all wins** — but the DeepEP penalty
+is far larger on H100/30B (smaller messages, lower-bandwidth fabric, compute-light model). No
+EFA *training* configuration tested here favors the DeepEP/UCCL path over NCCL all-to-all.
+
+## Validity & caveats
+
+- **EFA active on all 64 ranks** for every counted run (`efa_ok`), 0 stalls, 8 steady iters;
+  per-arm transport confirmed (`uccl_ok` / `nvshmem_ok`).
+- **`deepep-uccl-ep32-mb4-overlap=on` preempted** (a node was lost mid-run, rendezvous < 8/8) —
+  the only missing cell. NVSHMEM arms exit non-zero at NVSHMEM finalize after training; gate on
+  `efa_ok` + `n_steady==8`, not exit code.
+- **Comm-bound amplification** (point 3): the % deltas are larger than a compute-heavy model
+  would show. They measure the dispatcher's *exposed* cost, not end-to-end MFU on a tuned LLM.
+- Mock data + random-init + forced balancing; single run per cell (within-run σ small).
+
+## Reproduce
+
+See [`../README.md`](../README.md). `CTX=… NS=… MODEL=qwen3-30b NNODES=8 EPS="32 16"
+CELLS="4:off 1:off 4:on" RECOMPUTE="" INSTANCE_TYPE=p5.48xlarge EFA_PER_NODE=32
+UCCL_IMG=…-sm90 NVSHMEM_IMG=…-sm90 bash ../qwen3-235b/benchmarks/run-qwen3-campaign.sh`.

--- a/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
+++ b/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
@@ -10,20 +10,30 @@
 # Runs ONE arm (alltoall|deepep) of ONE model per invocation. Model/data/parallelism
 # are byte-identical across arms; only MOE_DISPATCHER differs.
 #
-#   MODEL=dsv3      -> DeepSeek-V3 256-expert recipe     (BENCH_PY bench_dsv3_pretrain.py)
-#   MODEL=kimi-k2   -> Kimi-K2 384-expert via AutoBridge (BENCH_PY bench_kimi_k2_pretrain.py)
+#   MODEL=dsv3       -> DeepSeek-V3 256-expert recipe     (BENCH_PY bench_dsv3_pretrain.py)
+#   MODEL=kimi-k2    -> Kimi-K2 384-expert via AutoBridge (BENCH_PY bench_kimi_k2_pretrain.py)
+#   MODEL=qwen3-235b -> Qwen3-235B-A22B 128-expert recipe (BENCH_PY bench_qwen3_pretrain.py)
+#
+# THREE-WAY DISPATCHER COMPARISON (NCCL / DeepEP+UCCL / DeepEP+NVSHMEM): the ARM
+# positional is what the bench reads as MOE_DISPATCHER (alltoall|deepep). The deepep
+# arm's *transport* is set by which IMG is passed (UCCL image -> UCCL deep_ep;
+# NVSHMEM image -> NVIDIA DeepEP). Set ARM_LABEL to disambiguate the two deepep arms
+# in run dirs / pod names (e.g. ARM_LABEL=deepep-nvshmem IMG=<nvshmem-image>).
 #
 # NO-OVERWRITE LOGGING: every run writes to a unique directory on FSx Lustre under
-#   /fsx/megatron-bridge-bench/${CAMPAIGN_ID}/${MODEL}/${ARM}-mb${MICRO_BATCH}-ovl${MOE_A2A_OVERLAP}/
+#   /fsx/megatron-bridge-bench/${CAMPAIGN_ID}/${MODEL}/${ARM_LABEL}-mb${MICRO_BATCH}-ovl${MOE_A2A_OVERLAP}/
 # (logs/rank-<r>.log for all ranks, env.txt, STATUS). A run whose dir already has a
 # completed STATUS is REFUSED (rank-0 aborts) so a retro is never clobbered. CAMPAIGN_ID
 # defaults to a fresh UTC timestamp; the campaign driver passes one shared id for all runs.
 #
-# Usage:  MODEL=<dsv3|kimi-k2> CTX=<ctx> IMG=<ecr-uri> ./run-ab-rawpods.sh <alltoall|deepep> [NNODES]
+# Usage:  MODEL=<dsv3|kimi-k2|qwen3-235b> CTX=<ctx> IMG=<ecr-uri> ./run-ab-rawpods.sh <alltoall|deepep> [NNODES]
 set -uo pipefail
 
-ARM="${1:?usage: MODEL=<dsv3|kimi-k2> ./run-ab-rawpods.sh <alltoall|deepep> [NNODES]}"
+ARM="${1:?usage: MODEL=<dsv3|kimi-k2|qwen3-235b> ./run-ab-rawpods.sh <alltoall|deepep> [NNODES]}"
 NNODES="${2:-32}"
+# ARM_LABEL names the run dir / pod set; defaults to ARM. Use it to split the two deepep
+# transports (deepep-uccl vs deepep-nvshmem) into distinct, non-clobbering run dirs.
+ARM_LABEL="${ARM_LABEL:-${ARM}}"
 
 CTX="${CTX:?set CTX to your kubectl context}"
 NS="${NS:-kimi-k2-bench}"
@@ -44,24 +54,34 @@ SEQ_LEN="${SEQ_LEN:-4096}"
 MOE_A2A_OVERLAP="${MOE_A2A_OVERLAP:-on}"
 MOE_FORCE_BALANCE="${MOE_FORCE_BALANCE:-on}"
 LOSS_PROBE="${LOSS_PROBE:-0}"
+# Transport label recorded in env.txt for the 3-way comparison (uccl|nvshmem|"" for the
+# NCCL alltoall arm). Informational only — the actual transport is fixed by the IMG.
+EP_BACKEND="${EP_BACKEND:-}"
+# HF hub config/tokenizer access. The qwen3-235b recipe builds its model provider via
+# AutoBridge.from_hf_pretrained(...) (config + tokenizer only; load_weights=False), so it
+# needs either pod egress to huggingface.co OR a pre-staged offline cache. Point HF_HOME at
+# a staged cache on FSx and set HF_HUB_OFFLINE=1 to run without egress. (No-op for dsv3.)
+HF_HOME="${HF_HOME:-${STAGE}/hf-cache}"
+HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-0}"
 
 # Staging dir on FSx holds the bench entrypoints + the Kimi-K2 HF config dir (hf/).
 STAGE="${STAGE:-/fsx/kimi-k2}"
 case "${MODEL}" in
-  dsv3)    DEFAULT_BENCH="${STAGE}/bench_dsv3_pretrain.py" ;;
-  kimi-k2) DEFAULT_BENCH="${STAGE}/bench_kimi_k2_pretrain.py" ;;
-  *) echo "MODEL must be 'dsv3' or 'kimi-k2', got '${MODEL}'" >&2; exit 2 ;;
+  dsv3)       DEFAULT_BENCH="${STAGE}/bench_dsv3_pretrain.py" ;;
+  kimi-k2)    DEFAULT_BENCH="${STAGE}/bench_kimi_k2_pretrain.py" ;;
+  qwen3-235b) DEFAULT_BENCH="${STAGE}/bench_qwen3_pretrain.py" ;;
+  *) echo "MODEL must be 'dsv3', 'kimi-k2', or 'qwen3-235b', got '${MODEL}'" >&2; exit 2 ;;
 esac
 BENCH_PY="${BENCH_PY:-${DEFAULT_BENCH}}"
 
-# No-overwrite run tree on Lustre. One CAMPAIGN_ID groups a whole 16-run campaign.
+# No-overwrite run tree on Lustre. One CAMPAIGN_ID groups a whole campaign.
 CAMPAIGN_ID="${CAMPAIGN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
-RUN_TAG="${ARM}-mb${MICRO_BATCH}-ovl${MOE_A2A_OVERLAP}"
+RUN_TAG="${ARM_LABEL}-mb${MICRO_BATCH}-ovl${MOE_A2A_OVERLAP}"
 RUN_DIR="${RUN_DIR:-/fsx/megatron-bridge-bench/${CAMPAIGN_ID}/${MODEL}/${RUN_TAG}}"
 LOGDIR="${RUN_DIR}/logs"
 
 GIT_REV="${GIT_REV:-$(git -C "$(dirname "$0")" rev-parse --short HEAD 2>/dev/null || echo unknown)}"
-JOB="abrun-${MODEL}-${ARM}"
+JOB="abrun-${MODEL}-${ARM_LABEL}"
 PORT=12355
 K="kubectl --context ${CTX} -n ${NS}"
 
@@ -89,7 +109,7 @@ EOF
 RANK0_PREAMBLE="
           if [ -f ${RUN_DIR}/STATUS ]; then echo 'REFUSE: ${RUN_DIR} already has STATUS (completed run); not overwriting' ; exit 3 ; fi ;
           mkdir -p ${LOGDIR} ;
-          { echo run_dir=${RUN_DIR} ; echo model=${MODEL} arm=${ARM} ; echo nnodes=${NNODES} world=${WORLD} ;
+          { echo run_dir=${RUN_DIR} ; echo model=${MODEL} arm=${ARM} arm_label=${ARM_LABEL} ep_backend=${EP_BACKEND} ; echo nnodes=${NNODES} world=${WORLD} ;
             echo TP=${TP} PP=${PP} EP=${EP} mb=${MICRO_BATCH} gbs=${GLOBAL_BATCH} seq=${SEQ_LEN} iters=${TRAIN_ITERS} ;
             echo overlap=${MOE_A2A_OVERLAP} force_balance=${MOE_FORCE_BALANCE} loss_probe=${LOSS_PROBE} ;
             echo image=${IMG} ; echo bench_py=${BENCH_PY} ; echo git_rev=${GIT_REV} ; echo started=\$(date -u +%FT%TZ) ; } > ${RUN_DIR}/env.txt ;"

--- a/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
+++ b/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
@@ -54,6 +54,9 @@ SEQ_LEN="${SEQ_LEN:-4096}"
 MOE_A2A_OVERLAP="${MOE_A2A_OVERLAP:-on}"
 MOE_FORCE_BALANCE="${MOE_FORCE_BALANCE:-on}"
 LOSS_PROBE="${LOSS_PROBE:-0}"
+# Optional activation recompute (full|selective|""), passed to the bench. Lets a large
+# per-stage layer count fit on few nodes (e.g. EP32 at PP1). Held identical across arms.
+RECOMPUTE="${RECOMPUTE:-}"
 # Transport label recorded in env.txt for the 3-way comparison (uccl|nvshmem|"" for the
 # NCCL alltoall arm). Informational only — the actual transport is fixed by the IMG.
 EP_BACKEND="${EP_BACKEND:-}"
@@ -149,7 +152,7 @@ spec:
           MOE_DISPATCHER=${ARM} MOE_A2A_OVERLAP=${MOE_A2A_OVERLAP} MOE_FORCE_BALANCE=${MOE_FORCE_BALANCE}
           TENSOR_PARALLEL=${TP} PIPELINE_PARALLEL=${PP} EXPERT_PARALLEL=${EP}
           TRAIN_ITERS=${TRAIN_ITERS} GLOBAL_BATCH=${GLOBAL_BATCH} MICRO_BATCH=${MICRO_BATCH} SEQ_LEN=${SEQ_LEN}
-          LOSS_PROBE=${LOSS_PROBE}
+          LOSS_PROBE=${LOSS_PROBE} RECOMPUTE=${RECOMPUTE} NUM_LAYERS=${NUM_LAYERS:-}
           FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_FORK_SAFE=1
           NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=INIT,NET NCCL_SOCKET_IFNAME=^docker,lo,veth ;
           torchrun --nnodes=${NNODES} --nproc_per_node=${GPUS_PER_NODE}

--- a/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
+++ b/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
@@ -125,7 +125,10 @@ RANK0_PREAMBLE="
 
 launch_pod() {
   local R="$1"
-  local PREAMBLE="mkdir -p ${LOGDIR} ;"
+  # ALL ranks must skip a completed cell, not just rank-0. If only rank-0 REFUSE-exits, ranks
+  # 1..N-1 still start torchrun, fail rendezvous (no rank-0), and OVERWRITE their rank logs —
+  # corrupting a previously-good run when a campaign is re-run with the same CAMPAIGN_ID.
+  local PREAMBLE="if [ -f ${RUN_DIR}/STATUS ]; then echo 'skip: completed run' ; exit 0 ; fi ; mkdir -p ${LOGDIR} ;"
   local EPILOGUE=""
   if [ "$R" = "0" ]; then
     PREAMBLE="${RANK0_PREAMBLE}"

--- a/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
+++ b/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
@@ -128,6 +128,9 @@ launch_pod() {
   # ALL ranks must skip a completed cell, not just rank-0. If only rank-0 REFUSE-exits, ranks
   # 1..N-1 still start torchrun, fail rendezvous (no rank-0), and OVERWRITE their rank logs —
   # corrupting a previously-good run when a campaign is re-run with the same CAMPAIGN_ID.
+  # The skip key is STATUS *existing*, deliberately NOT exit==0: the NVSHMEM arm writes STATUS
+  # then exits 1 at NVSHMEM finalize (validity is judged by efa_ok + n_steady, not exit code —
+  # see RESULTS.md), so a same-CAMPAIGN_ID re-run treats such a cell as complete and skips it.
   local PREAMBLE="if [ -f ${RUN_DIR}/STATUS ]; then echo 'skip: completed run' ; exit 0 ; fi ; mkdir -p ${LOGDIR} ;"
   local EPILOGUE=""
   if [ "$R" = "0" ]; then

--- a/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
+++ b/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
@@ -40,7 +40,10 @@ NS="${NS:-kimi-k2-bench}"
 IMG="${IMG:?set IMG to your megatron-bridge-uccl ECR image URI}"
 MODEL="${MODEL:-dsv3}"
 GPUS_PER_NODE=8
-EFA_PER_NODE=16
+# Node type + EFA NIC count per node. Defaults to p6-b300 (16 EFA); set INSTANCE_TYPE=
+# p5.48xlarge EFA_PER_NODE=32 for the H100 runs.
+INSTANCE_TYPE="${INSTANCE_TYPE:-p6-b300.48xlarge}"
+EFA_PER_NODE="${EFA_PER_NODE:-16}"
 WORLD=$(( NNODES * GPUS_PER_NODE ))
 
 # Parallelism. TP MUST be >1 (recipe enables sequence_parallel). EP = DP*TP = 32 (ETP=1) at 256 GPU.
@@ -72,10 +75,13 @@ STAGE="${STAGE:-/fsx/kimi-k2}"
 case "${MODEL}" in
   dsv3)       DEFAULT_BENCH="${STAGE}/bench_dsv3_pretrain.py" ;;
   kimi-k2)    DEFAULT_BENCH="${STAGE}/bench_kimi_k2_pretrain.py" ;;
-  qwen3-235b) DEFAULT_BENCH="${STAGE}/bench_qwen3_pretrain.py" ;;
-  *) echo "MODEL must be 'dsv3', 'kimi-k2', or 'qwen3-235b', got '${MODEL}'" >&2; exit 2 ;;
+  # Both qwen3 sizes share one bench, differentiated by QWEN3_SIZE (235b on B300, 30b on H100).
+  qwen3-235b) DEFAULT_BENCH="${STAGE}/bench_qwen3_pretrain.py"; QWEN3_SIZE="${QWEN3_SIZE:-235b}" ;;
+  qwen3-30b)  DEFAULT_BENCH="${STAGE}/bench_qwen3_pretrain.py"; QWEN3_SIZE="${QWEN3_SIZE:-30b}" ;;
+  *) echo "MODEL must be 'dsv3', 'kimi-k2', 'qwen3-235b', or 'qwen3-30b', got '${MODEL}'" >&2; exit 2 ;;
 esac
 BENCH_PY="${BENCH_PY:-${DEFAULT_BENCH}}"
+QWEN3_SIZE="${QWEN3_SIZE:-}"
 
 # No-overwrite run tree on Lustre. One CAMPAIGN_ID groups a whole campaign.
 CAMPAIGN_ID="${CAMPAIGN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
@@ -136,7 +142,7 @@ spec:
   hostname: ${JOB}-${R}
   subdomain: ${JOB}
   nodeSelector:
-    node.kubernetes.io/instance-type: p6-b300.48xlarge
+    node.kubernetes.io/instance-type: ${INSTANCE_TYPE}
   tolerations:
     - {key: nvidia.com/gpu, operator: Exists, effect: NoSchedule}
     - {key: workload, value: bench, operator: Equal, effect: NoSchedule}
@@ -152,7 +158,7 @@ spec:
           MOE_DISPATCHER=${ARM} MOE_A2A_OVERLAP=${MOE_A2A_OVERLAP} MOE_FORCE_BALANCE=${MOE_FORCE_BALANCE}
           TENSOR_PARALLEL=${TP} PIPELINE_PARALLEL=${PP} EXPERT_PARALLEL=${EP}
           TRAIN_ITERS=${TRAIN_ITERS} GLOBAL_BATCH=${GLOBAL_BATCH} MICRO_BATCH=${MICRO_BATCH} SEQ_LEN=${SEQ_LEN}
-          LOSS_PROBE=${LOSS_PROBE} RECOMPUTE=${RECOMPUTE} NUM_LAYERS=${NUM_LAYERS:-}
+          LOSS_PROBE=${LOSS_PROBE} RECOMPUTE=${RECOMPUTE} NUM_LAYERS=${NUM_LAYERS:-} QWEN3_SIZE=${QWEN3_SIZE}
           FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_FORK_SAFE=1
           NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=INIT,NET NCCL_SOCKET_IFNAME=^docker,lo,veth ;
           torchrun --nnodes=${NNODES} --nproc_per_node=${GPUS_PER_NODE}


### PR DESCRIPTION
## Summary

Adds a **Qwen3-235B-A22B (128-expert MoE) three-way expert-parallel all-to-all comparison**
to the `megatron-bridge` test case: **NCCL all-to-all** vs **DeepEP+UCCL** vs **DeepEP+NVSHMEM**,
measured as end-to-end **training-step throughput** on `p6-b300` (B300), swept across
**EP16 and EP32**. The DeepEP+NVSHMEM arm — NVIDIA DeepEP carrying its all-to-all over
**NVSHMEM-libfabric on EFA** — is new to this library and is wired in without touching
Megatron-Core.

## Motivation

The `megatron-bridge` library already compares the Megatron-Core MoE token dispatcher between
**NCCL all-to-all** and **DeepEP via UCCL** (UCCL's EFA-native `deep_ep` shadow). Two gaps
motivated this PR:

1. **"NVIDIA DeepEP can't run on EFA" is now obsolete.** That is true only of DeepEP's stock
   IB/IBGDA build. The repo's own
   [`micro-benchmarks/expert-parallelism/deepep-benchmark`](../../micro-benchmarks/expert-parallelism/deepep-benchmark)
   already patches DeepEP to run **NVSHMEM over libfabric (host-proxy, IBGDA off)** on EFA.
   This PR brings that build in as a *third* Megatron-Core dispatcher backend so DeepEP+NVSHMEM
   and DeepEP+UCCL can be compared head-to-head against the NCCL baseline on the same model.
2. **The DSV3 A/B needed 32 nodes (EP32) to fit 671B.** To make a meaningful EP sweep runnable
   at a smaller, commonly-available node count, this PR uses **Qwen3-235B-A22B** (235B total /
   22B active, 128 experts, top-8, 94 layers, hidden 4096, no shared expert), which fits a
   handful of B300 nodes at **both EP16 and EP32** — so the comparison sweeps the variable the
   all-to-all actually turns on, the **EP degree**, at a realistic operating point (EP32 is the
   point cited for Qwen3-235B in the DSV3 reference table).

## Approach

The third arm is the **same `MOE_DISPATCHER=deepep` code path** — only the importable `deep_ep`
module differs, so the arm is selected by *which image* runs. Provider is chosen with a new
**`EP_BACKEND={uccl,nvshmem}` build arg on the single shared Dockerfile** (the library's README
forbids a second Dockerfile; a dual-install would collide two `deep_ep` packages):

| Arm | `MOE_DISPATCHER` | Image (`EP_BACKEND`) | all-to-all transport |
|-----|------------------|----------------------|----------------------|
| NCCL all-to-all (baseline) | `alltoall` | uccl | NCCL all-to-all over EFA |
| DeepEP + UCCL | `deepep` | uccl | UCCL EFA-native `deep_ep` |
| DeepEP + NVSHMEM | `deepep` | **nvshmem** | NVIDIA DeepEP over NVSHMEM-libfabric/EFA |

No Megatron-Core patch; the benchmark entrypoint is identical across all three arms.

## What changed

**Shared environment (`megatron-bridge/`)**
- `Dockerfile`: `EP_BACKEND` arg. The `nvshmem` branch builds GDRCopy + NVSHMEM `v3.7.0-0`
  (libfabric, IBGDA off) + EFA-patched NVIDIA DeepEP `567632d` into `/opt/venv`, then cleans the
  build/source trees. Build-time verify uses `find_spec` for the nvshmem build (DeepEP's
  extension links `libcuda`, absent during `docker build`) and the real `import` for uccl.
- `1.build-and-push.sh`: builds/pushes both tags (`…-uccl-0dc87eb`, `…-deepep-nvshmem-567632d-cu13`).
- `deepep/setup_deepep_efa.sh`: vendored verbatim from the deepep-benchmark (Docker build-context
  constraint) with a sync note in `deepep/README.md`.
- `run-ab-rawpods.sh`: `MODEL=qwen3-235b`, `ARM_LABEL`/`EP_BACKEND` tagging (distinct run dirs for
  the two deepep transports), and `HF_HOME`/`HF_HUB_OFFLINE`/`RECOMPUTE`/`NUM_LAYERS` passthrough.
- `bench/parse-runs.py`: NVSHMEM-active log signal + `backend`/`arm_label`/`ep`/`nvshmem_ok`
  columns; `seq` read from `env.txt` for tok/s; aligned stdout table.
- `2.sanity-singlenode.sh`: backend-aware Gate 2; fixes a `fi_info | head` SIGPIPE-under-`pipefail`
  abort on 16-NIC nodes.
- `README.md`: corrects the "DeepEP can't run on EFA" claim; adds the Qwen3-235B model row.

**New model (`megatron-bridge/qwen3-235b/`)**
- `benchmarks/bench_qwen3_pretrain.py`: mirrors the validated dsv3 bench against the shipped
  `qwen3_235b_a22b_pretrain_config` recipe (mock data + random init — we measure step time). EP
  sweep, A/B validity guard, `RECOMPUTE` knob, `overlap=on` forced off at PP1, eval + checkpoint
  saving disabled.
- `benchmarks/run-qwen3-campaign.sh`: drives 3 arms × EP{16,32} × cells via `run-ab-rawpods.sh`,
  with an EP-divides-WORLD / integer-DP guard, per-run EFA gate, and end-of-campaign parse.
- `benchmarks/RESULTS.md`, `README.md`: methodology, measured numbers, and caveats.

## Validation

- **Both images build and push** to ECR; single-node gates 1–3 pass on the nvshmem image (EFA
  present, `deep_ep.Buffer` importable from `/opt/venv`, MCore flex/deepep config fields). Gate 5
  is the pre-existing known-stale standalone-dispatcher gate (the real `pretrain()` path is the
  authoritative dispatch check, per the library README).
- **Work-equivalence (no token dropping)** on a 2-node smoke (`NUM_LAYERS=8`, `LOSS_PROBE=1`):
  DeepEP+NVSHMEM iteration-1 mean loss **12.701515** vs NCCL all-to-all **12.702237** (identical
  `num_tokens=2048`; rel. diff 5.7e-5 = bf16 round-off). The NVSHMEM arm's IBGDA→host-proxy +
  put_signal patches dispatch/combine the same tokens to numerically-equivalent output.
- **Full campaign**: 12 runs, every run EFA-active on all ranks (`efa_ok`), 0 stalls, 8 steady
  iters; per-arm transport confirmed (`uccl_ok` / `nvshmem_ok`).


## Results (two fabrics, mb=4, overlap=off; Δ vs NCCL all-to-all, − = DeepEP faster)

**B300 / Qwen3-235B** — 8× p6-b300, TP8, selective recompute, EP16=PP4/DP2, EP32=PP2/DP4:

| EP | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM |
|---:|----------------:|------------:|---------------:|
| 16 | 12.21 s | +6.9% | **−5.2%** |
| 32 | 15.76 s | +21.5% | +34.0% |

**H100 / Qwen3-30B** — 8× p5.48xlarge, TP8, recompute off, same EP layout:

| EP | NCCL all-to-all | DeepEP+UCCL | DeepEP+NVSHMEM |
|---:|----------------:|------------:|---------------:|
| 16 | 8.60 s | +72% | +6.6% |
| 32 | 9.24 s | +187% | +86% |

Full tables (mb=1, overlap=on, TFLOP/s, tok/s, validity): `qwen3-235b/benchmarks/RESULTS.md`
(B300) and `qwen3-30b/benchmarks/RESULTS.md` (H100). The 4-node B300 run (capacity-constrained,
`RECOMPUTE=full`) is retained as a secondary reference in the B300 RESULTS.

## How to read this — the recommendation is **scale-dependent**

At the **node counts tested here (4–8 nodes)**, **NCCL all-to-all is the right default on EFA**:
it wins nearly every cell, the lone exception being B300 EP16 mb4 where DeepEP+NVSHMEM edges it
(−5.2%). DeepEP+NVSHMEM is the stronger of the two DeepEP backends in most cells (UCCL edges it at B300 EP32 mb4).

But this is **not** "EFA kills DeepEP" — and the small-scale result does **not** generalize:

- **It's an EFA/host-proxy constraint, not DeepEP being slow per se.** Without IBGDA, DeepEP on
  EFA is stuck on the NVSHMEM host-proxy path and can't use its GPU-initiated-RDMA advantage.
- **DeepEP's edge grows with scale (EP span / node count).** DeepEP/UCCL does *sparse* dispatch
  (tokens go only to the experts they route to), so its advantage grows with inter-node
  all-to-all span and eventually overtakes the host-proxy penalty. That trend is already visible
  here (the DeepEP gap shrinks markedly EP32→EP16), and at larger scale it flips: the repo's
  **Kimi-K2 32-node / 256-GPU / 384-expert** result shows **UCCL −34% vs NCCL at mb≥4**
  ([`kimi-k2/benchmarks/RESULTS.md`](kimi-k2/benchmarks/RESULTS.md)) — and −21% at 16 nodes,
  i.e. the win itself scales with node count.
- **Fabric is second-order.** DeepEP looked worst on H100 (p5.48xlarge, lower EFA bandwidth
  exposes the host-proxy cost); it should look better on p5en.48xlarge / newer. But it still
  lost at the B300 8-node/EP32 point, so the effect is **scale-primary, fabric-secondary**.

**Customer-facing takeaway:** on EFA, default to **NCCL all-to-all up to ~8 nodes / EP32**;
consider DeepEP (UCCL today; NVSHMEM pending large-scale validation) at **large EP span /
≳16–32 nodes**, where sparse dispatch pays for the host-proxy overhead.

## Caveats

- **Balanced routing only.** Runs use `moe_router_force_load_balancing` (mock data, random
  init); **skewed / real expert routing is not yet tested** and could shift the dispatcher
  balance.
- **n=1 per cell.** Large deltas are robust; the small B300 EP16 gaps (±5–7%) are within
  run-to-run noise (n≥3 is the recommended follow-up).
- **H100/30B is comm-bound** (hidden 2048, compute-light) so its % deltas are amplified — read
  it as the small-message worst case for DeepEP, not end-to-end MFU.
- A few cells were lost to shared-cluster node preemption (documented per RESULTS). The harness
  now skips completed cells on **all** ranks (fixes a same-`CAMPAIGN_ID` re-run log clobber).

## Follow-ups

- **NVSHMEM+DeepEP at Kimi-K2 32-node scale** — the highest-value missing cell; standalone EP
  micro-benchmarks suggest NVSHMEM ≥ UCCL in throughput mode, so it's plausibly the best
  large-scale option. Not yet run.
- Decode/inference NCCL/UCCL/NVSHMEM comparison on p5en.48xlarge (complements these training
  numbers).
- n≥3 repeats to put error bars on the close B300 EP16 deltas.

## Reviewers / acks

Thanks to **Henan Wang** (DeepEP / EFA performance) for the scale-dependence framing and the
host-proxy-vs-IBGDA context that shaped the recommendation above.

## Risk / blast radius

Additive: a new model subdir + a build-arg-gated branch on the shared image. The default
`EP_BACKEND=uccl` build is byte-for-byte the existing behavior; existing dsv3/kimi-k2 cases are
untouched except the shared `run-ab-rawpods.sh`/`parse-runs.py`, whose changes are backward
compatible (new optional env + new CSV columns). No secrets, no new network surface; versions
pinned (NVSHMEM `v3.7.0-0`, DeepEP `567632d`, GDRCopy `v2.5.2`).

