### PR TITLE
Automate architecture template publishing

### DIFF
--- a/.github/scripts/stage-template-publish.py
+++ b/.github/scripts/stage-template-publish.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Validate and stage architecture assets for S3 template publishing."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class CfnTagLoader(yaml.SafeLoader):
+    """YAML loader that preserves structure while tolerating CloudFormation tags."""
+
+
+def _construct_unknown(loader: CfnTagLoader, node: yaml.Node) -> Any:
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    raise TypeError(f"Unsupported YAML node: {type(node).__name__}")
+
+
+CfnTagLoader.add_multi_constructor("", lambda loader, _tag, node: _construct_unknown(loader, node))
+
+
+S3_KEY_RE = re.compile(r"^[A-Za-z0-9!_.*'()/.-]+$")
+PREFIX_REF_RE = re.compile(r"\$\{S3KeyPrefix\}([A-Za-z0-9._/-]+\.(?:ya?ml|sh))")
+PUBLIC_URL_RE = re.compile(
+    r"(?:https://awsome-distributed-ai\.s3\.amazonaws\.com/templates/|"
+    r"s3://awsome-distributed-ai/templates/)"
+    r"([A-Za-z0-9._/-]+\.(?:ya?ml|sh))"
+)
+
+
+def load_yaml(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.load(handle, Loader=CfnTagLoader)
+
+
+def is_cloudformation_template(path: Path) -> bool:
+    try:
+        document = load_yaml(path)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: invalid YAML: {exc}") from exc
+    return isinstance(document, dict) and isinstance(document.get("Resources"), dict)
+
+
+def normalize_key(key: str) -> str:
+    key = key.strip().lstrip("/")
+    if not key:
+        raise ValueError("empty S3 key")
+    if ".." in Path(key).parts:
+        raise ValueError(f"destination key must not contain '..': {key}")
+    if not S3_KEY_RE.match(key):
+        raise ValueError(f"destination key contains unsupported characters: {key}")
+    return key
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    data = load_yaml(path)
+    if not isinstance(data, dict):
+        raise ValueError("manifest must be a YAML mapping")
+    entries = data.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("manifest must contain a non-empty entries list")
+    obsolete_keys = data.get("obsolete_keys", [])
+    if not isinstance(obsolete_keys, list):
+        raise ValueError("manifest obsolete_keys must be a list when present")
+    return data
+
+
+def architecture_namespace(source: Path) -> str | None:
+    parts = source.parts
+    try:
+        architecture_index = parts.index("architectures")
+    except ValueError:
+        return None
+    namespace_index = architecture_index + 1
+    if namespace_index >= len(parts):
+        return None
+    return parts[namespace_index]
+
+
+def validate_references(cfn_sources: list[Path], destination_keys: set[str]) -> list[str]:
+    errors: list[str] = []
+    for source in cfn_sources:
+        text = source.read_text(encoding="utf-8")
+        refs = set(PREFIX_REF_RE.findall(text)) | set(PUBLIC_URL_RE.findall(text))
+        namespace = architecture_namespace(source)
+        for ref in sorted(refs):
+            namespaced_ref = f"{namespace}/{ref}" if namespace else None
+            if ref not in destination_keys and namespaced_ref not in destination_keys:
+                errors.append(f"{source}: references '{ref}', but no manifest entry publishes that key")
+    return errors
+
+
+def write_list(path: Path, files: list[Path]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"{file}\n" for file in files), encoding="utf-8")
+
+
+def write_key_list(path: Path, keys: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"{key}\n" for key in keys), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--stage-dir", required=True, type=Path)
+    parser.add_argument("--cfn-list", required=True, type=Path)
+    parser.add_argument("--shell-list", required=True, type=Path)
+    parser.add_argument("--obsolete-list", required=True, type=Path)
+    parser.add_argument("--repo-root", default=Path.cwd(), type=Path)
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    manifest = load_manifest(args.manifest)
+    stage_dir = args.stage_dir.resolve()
+    destination_to_source: dict[str, Path] = {}
+    cfn_sources: list[Path] = []
+    shell_sources: list[Path] = []
+    obsolete_keys: list[str] = []
+    errors: list[str] = []
+
+    shutil.rmtree(stage_dir, ignore_errors=True)
+    stage_dir.mkdir(parents=True, exist_ok=True)
+
+    for index, entry in enumerate(manifest["entries"], start=1):
+        if not isinstance(entry, dict):
+            errors.append(f"entry {index}: must be a mapping")
+            continue
+        source_value = entry.get("source")
+        key_value = entry.get("key")
+        if not isinstance(source_value, str) or not isinstance(key_value, str):
+            errors.append(f"entry {index}: source and key must be strings")
+            continue
+
+        try:
+            key = normalize_key(key_value)
+        except ValueError as exc:
+            errors.append(f"entry {index}: {exc}")
+            continue
+
+        source = (repo_root / source_value).resolve()
+        try:
+            source.relative_to(repo_root)
+        except ValueError:
+            errors.append(f"entry {index}: source is outside repository: {source_value}")
+            continue
+        if not source_value.startswith("architectures/"):
+            errors.append(f"entry {index}: source must be under architectures/: {source_value}")
+            continue
+        if not source.is_file():
+            errors.append(f"entry {index}: source file does not exist: {source_value}")
+            continue
+        if key in destination_to_source:
+            errors.append(
+                f"entry {index}: duplicate destination key '{key}' also used by "
+                f"{destination_to_source[key].relative_to(repo_root)}"
+            )
+            continue
+
+        destination_to_source[key] = source
+
+        if source.suffix in {".yaml", ".yml"} and is_cloudformation_template(source):
+            cfn_sources.append(source)
+        if source.suffix == ".sh":
+            shell_sources.append(source)
+
+        destination = stage_dir / key
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+    for index, key_value in enumerate(manifest.get("obsolete_keys", []), start=1):
+        if not isinstance(key_value, str):
+            errors.append(f"obsolete key {index}: key must be a string")
+            continue
+        try:
+            key = normalize_key(key_value)
+        except ValueError as exc:
+            errors.append(f"obsolete key {index}: {exc}")
+            continue
+        if key in destination_to_source:
+            errors.append(f"obsolete key {index}: key is still published by entries: {key}")
+            continue
+        obsolete_keys.append(key)
+
+    errors.extend(validate_references(cfn_sources, set(destination_to_source)))
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    write_list(args.cfn_list, cfn_sources)
+    write_list(args.shell_list, shell_sources)
+    write_key_list(args.obsolete_list, obsolete_keys)
+    print(f"Staged {len(destination_to_source)} files in {stage_dir}")
+    print(f"Detected {len(cfn_sources)} CloudFormation templates")
+    print(f"Detected {len(shell_sources)} shell scripts")
+    print(f"Marked {len(obsolete_keys)} obsolete keys for deletion")
+    print(f"Bucket: {manifest.get('bucket', 'awsome-distributed-ai')}")
+    print(f"Prefix: {manifest.get('prefix', 'templates/')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/template-publish-manifest.yml
+++ b/.github/template-publish-manifest.yml
@@ -1,0 +1,50 @@
+# Files published to s3://awsome-distributed-ai/templates by
+# .github/workflows/publish-architecture-templates.yml.
+#
+# Publish architecture assets under an architecture namespace. Add new migrated
+# architecture assets with namespaced keys, for example:
+#   - source: architectures/example/path/template.yaml
+#     key: example/path/template.yaml
+bucket: awsome-distributed-ai
+prefix: templates/
+obsolete_keys:
+  - add-cng.yaml
+  - add-cng-p5.yaml
+  - add-cng-p6-b200.yaml
+  - add-cng-p6-b300.yaml
+  - cluster.yaml
+  - cluster-admin-iam.yaml
+  - cluster-user-iam.yaml
+  - ml-cluster-prerequisites.yaml
+  - pcs-ml-cluster-deploy-all.yaml
+  - pcs-ready-dlami-with-enroot-pyxis.yaml
+  - scripts/install-enroot-pyxis.sh
+  - scripts/ldap-add-user.sh
+  - scripts/setup-directory.sh
+entries:
+  - source: architectures/aws-pcs/assets/add-cng.yaml
+    key: aws-pcs/add-cng.yaml
+  - source: architectures/aws-pcs/assets/add-cng-p5.yaml
+    key: aws-pcs/add-cng-p5.yaml
+  - source: architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+    key: aws-pcs/add-cng-p6-b200.yaml
+  - source: architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+    key: aws-pcs/add-cng-p6-b300.yaml
+  - source: architectures/aws-pcs/assets/cluster.yaml
+    key: aws-pcs/cluster.yaml
+  - source: architectures/aws-pcs/assets/cluster-admin-iam.yaml
+    key: aws-pcs/cluster-admin-iam.yaml
+  - source: architectures/aws-pcs/assets/cluster-user-iam.yaml
+    key: aws-pcs/cluster-user-iam.yaml
+  - source: architectures/aws-pcs/assets/ml-cluster-prerequisites.yaml
+    key: aws-pcs/ml-cluster-prerequisites.yaml
+  - source: architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+    key: aws-pcs/pcs-ml-cluster-deploy-all.yaml
+  - source: architectures/aws-pcs/assets/pcs-ready-dlami-with-enroot-pyxis.yaml
+    key: aws-pcs/pcs-ready-dlami-with-enroot-pyxis.yaml
+  - source: architectures/aws-pcs/assets/scripts/install-enroot-pyxis.sh
+    key: aws-pcs/scripts/install-enroot-pyxis.sh
+  - source: architectures/aws-pcs/assets/scripts/ldap-add-user.sh
+    key: aws-pcs/scripts/ldap-add-user.sh
+  - source: architectures/aws-pcs/assets/scripts/setup-directory.sh
+    key: aws-pcs/scripts/setup-directory.sh

--- a/.github/template-publish-manifest.yml
+++ b/.github/template-publish-manifest.yml
@@ -7,20 +7,13 @@
 #     key: example/path/template.yaml
 bucket: awsome-distributed-ai
 prefix: templates/
-obsolete_keys:
-  - add-cng.yaml
-  - add-cng-p5.yaml
-  - add-cng-p6-b200.yaml
-  - add-cng-p6-b300.yaml
-  - cluster.yaml
-  - cluster-admin-iam.yaml
-  - cluster-user-iam.yaml
-  - ml-cluster-prerequisites.yaml
-  - pcs-ml-cluster-deploy-all.yaml
-  - pcs-ready-dlami-with-enroot-pyxis.yaml
-  - scripts/install-enroot-pyxis.sh
-  - scripts/ldap-add-user.sh
-  - scripts/setup-directory.sh
+# Legacy flat keys are intentionally retained, not deleted. Deployed stacks
+# stored S3KeyPrefix=templates/ and resolve nested templates + bootstrap scripts
+# (e.g. ${S3KeyPrefix}scripts/install-enroot-pyxis.sh) against the flat layout;
+# deleting these keys would break stack updates and node-replacement bootstrap,
+# plus any external/bookmarked launch URLs. Add a flat key here to delete it only
+# once no deployed stack references the flat prefix.
+obsolete_keys: []
 entries:
   - source: architectures/aws-pcs/assets/add-cng.yaml
     key: aws-pcs/add-cng.yaml

--- a/.github/workflows/publish-architecture-templates.yml
+++ b/.github/workflows/publish-architecture-templates.yml
@@ -12,7 +12,10 @@ on:
 
 env:
   AWS_REGION: us-east-1
-  AWS_ROLE_ARN: arn:aws:iam::159553542841:role/awslabs-AOSH-GitHubActionsRole
+  # Dedicated, least-privilege template-publishing role (S3 publish + ValidateTemplate),
+  # provisioned in gitlab.aws.dev/ml-frameworks/projects/container-release-pipeline.
+  # Isolated from the shared awslabs-AOSH-GitHubActionsRole used by other workflows.
+  AWS_ROLE_ARN: arn:aws:iam::159553542841:role/adai-template-publisher
   TEMPLATE_BUCKET: awsome-distributed-ai
   TEMPLATE_PREFIX: templates/
   PUBLISH_MANIFEST: .github/template-publish-manifest.yml

--- a/.github/workflows/publish-architecture-templates.yml
+++ b/.github/workflows/publish-architecture-templates.yml
@@ -101,7 +101,11 @@ jobs:
           fi
 
       - name: Publish to S3
-        run: aws s3 sync "$STAGE_DIR/" "s3://${TEMPLATE_BUCKET}/${TEMPLATE_PREFIX}" --no-progress
+        # --acl public-read: the bucket serves templates via per-object ACL, not a
+        # bucket policy, so objects must carry AllUsers:READ to be anonymously
+        # fetchable by the launch URLs and nested-stack TemplateURLs. Requires
+        # s3:PutObjectAcl on the OIDC role.
+        run: aws s3 sync "$STAGE_DIR/" "s3://${TEMPLATE_BUCKET}/${TEMPLATE_PREFIX}" --acl public-read --no-progress
 
       - name: Remove obsolete flat S3 keys
         run: |

--- a/.github/workflows/publish-architecture-templates.yml
+++ b/.github/workflows/publish-architecture-templates.yml
@@ -1,0 +1,112 @@
+name: Publish Architecture Templates
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'architectures/**'
+      - '.github/template-publish-manifest.yml'
+      - '.github/scripts/stage-template-publish.py'
+      - '.github/workflows/publish-architecture-templates.yml'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-east-1
+  AWS_ROLE_ARN: arn:aws:iam::159553542841:role/awslabs-AOSH-GitHubActionsRole
+  TEMPLATE_BUCKET: awsome-distributed-ai
+  TEMPLATE_PREFIX: templates/
+  PUBLISH_MANIFEST: .github/template-publish-manifest.yml
+  STAGE_DIR: .template-publish-stage
+  CFN_LIST: .template-publish-cfn-files.txt
+  SHELL_LIST: .template-publish-shell-files.txt
+  OBSOLETE_LIST: .template-publish-obsolete-keys.txt
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    name: Validate and publish templates
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: publish-architecture-templates
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install validation dependencies
+        run: python -m pip install --upgrade pyyaml
+
+      - name: Stage publish manifest
+        run: |
+          python .github/scripts/stage-template-publish.py \
+            --manifest "$PUBLISH_MANIFEST" \
+            --stage-dir "$STAGE_DIR" \
+            --cfn-list "$CFN_LIST" \
+            --shell-list "$SHELL_LIST" \
+            --obsolete-list "$OBSOLETE_LIST"
+
+      - name: Validate shell scripts
+        run: |
+          if [ -s "$SHELL_LIST" ]; then
+            while IFS= read -r script; do
+              bash -n "$script"
+            done < "$SHELL_LIST"
+          fi
+
+      - name: Detect AWS PCS changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "aws_pcs_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          before="${{ github.event.before }}"
+          if [[ "$before" =~ ^0+$ ]]; then
+            echo "aws_pcs_changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$before" "${{ github.sha }}" -- architectures/aws-pcs/ | grep -q .; then
+            echo "aws_pcs_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "aws_pcs_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run AWS PCS docs lint
+        if: ${{ steps.changes.outputs.aws_pcs_changed == 'true' && hashFiles('architectures/aws-pcs/tests/lint-docs.sh') != '' }}
+        run: bash architectures/aws-pcs/tests/lint-docs.sh
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Validate CloudFormation templates
+        run: |
+          if [ -s "$CFN_LIST" ]; then
+            while IFS= read -r template; do
+              aws cloudformation validate-template --template-body "file://$template" >/dev/null
+            done < "$CFN_LIST"
+          fi
+
+      - name: Publish to S3
+        run: aws s3 sync "$STAGE_DIR/" "s3://${TEMPLATE_BUCKET}/${TEMPLATE_PREFIX}" --no-progress
+
+      - name: Remove obsolete flat S3 keys
+        run: |
+          if [ -s "$OBSOLETE_LIST" ]; then
+            while IFS= read -r key; do
+              aws s3 rm "s3://${TEMPLATE_BUCKET}/${TEMPLATE_PREFIX}${key}"
+            done < "$OBSOLETE_LIST"
+          fi

--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -45,7 +45,7 @@ optional pre-bake path for faster scaling.
 
 Deploy a complete cluster with one nested CloudFormation stack:
 
-[![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml&stackName=pcs-ml-cluster)
+[![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml&stackName=pcs-ml-cluster)
 
 **The only decision you must make is which Availability Zone to deploy into**
 (`PrimarySubnetAZ`) — everything else has a sensible default. The minimal CLI
@@ -56,7 +56,7 @@ AZ_ID=us-east-1a   # <-- the one required choice: your target Availability Zone
 
 aws cloudformation create-stack \
   --stack-name pcs-ml-cluster \
-  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml \
+  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml \
   --parameters ParameterKey=PrimarySubnetAZ,ParameterValue=${AZ_ID} \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
 ```
@@ -198,7 +198,7 @@ AZ_ID=us-east-1a   # your target Availability Zone
 
 aws cloudformation create-stack \
   --stack-name gpu-cluster \
-  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml \
+  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml \
   --parameters \
     ParameterKey=PrimarySubnetAZ,ParameterValue=${AZ_ID} \
     ParameterKey=OnDemandCngName,ParameterValue=gpu-g6 \
@@ -217,7 +217,7 @@ CAPACITY_RESERVATION_ID="cr-0a1b2c3d4e5f67890"
 
 aws cloudformation create-stack \
   --stack-name p6-b300-cb-cluster \
-  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml \
+  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml \
   --parameters \
     ParameterKey=PrimarySubnetAZ,ParameterValue=${AZ_ID} \
     ParameterKey=DeployPseriesCNG,ParameterValue=true \
@@ -242,7 +242,7 @@ AZ_ID=us-east-2b   # check your target type's AZ availability first
 
 aws cloudformation create-stack \
   --stack-name hpc7a-cluster \
-  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml \
+  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml \
   --parameters \
     ParameterKey=PrimarySubnetAZ,ParameterValue=${AZ_ID} \
     ParameterKey=OnDemandCngName,ParameterValue=hpc7a \
@@ -508,8 +508,8 @@ The cluster has two human roles, each with a ready-to-deploy IAM policy stack:
 
 | Role | What they can do | Deploy |
 |---|---|---|
-| **Cluster admin** ([`cluster-admin-iam.yaml`](./assets/cluster-admin-iam.yaml)) | deploy / update / delete the cluster (CloudFormation, PCS, EC2, FSx, scoped IAM) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
-| **Cluster user** ([`cluster-user-iam.yaml`](./assets/cluster-user-iam.yaml)) | SSM session to the **login node only** + read-only status; cannot create, modify, or delete anything | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
+| **Cluster admin** ([`cluster-admin-iam.yaml`](./assets/cluster-admin-iam.yaml)) | deploy / update / delete the cluster (CloudFormation, PCS, EC2, FSx, scoped IAM) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
+| **Cluster user** ([`cluster-user-iam.yaml`](./assets/cluster-user-iam.yaml)) | SSM session to the **login node only** + read-only status; cannot create, modify, or delete anything | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
 
 Each template creates the customer-managed policies and an IAM group, and can
 attach existing users at deploy time. See the **[IAM Permissions Guide](./docs/IAM.md)**
@@ -524,7 +524,7 @@ pins every node to a deterministic state. It's a standalone path: build the AMI 
 [`pcs-ready-dlami-with-enroot-pyxis.yaml`](./assets/pcs-ready-dlami-with-enroot-pyxis.yaml)
 (single-Slurm-version by design), then pass the resulting `ami-xxx` as `AmiId`.
 
-[![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ready-dlami-with-enroot-pyxis.yaml&stackName=pcs-dlami)
+[![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ready-dlami-with-enroot-pyxis.yaml&stackName=pcs-dlami)
 
 See **[docs/CUSTOM-AMI.md](./docs/CUSTOM-AMI.md)** for the full build → read AMI ID →
 deploy procedure and the optional scheduled-rebuild / lifecycle / SSM-publish features.
@@ -587,14 +587,14 @@ parameter and default, see [PARAMETERS.md](./docs/PARAMETERS.md).
 
 | Template | Purpose | Deploy |
 |---|---|---|
-| [`pcs-ml-cluster-deploy-all.yaml`](./assets/pcs-ml-cluster-deploy-all.yaml) | All-in-one: Prerequisites + (optional AMI) + Cluster + login/CPU/GPU CNGs | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml&stackName=pcs-ml-cluster) |
-| [`ml-cluster-prerequisites.yaml`](./assets/ml-cluster-prerequisites.yaml) | VPC, subnets, security groups, FSx for Lustre + OpenZFS | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/ml-cluster-prerequisites.yaml&stackName=pcs-prerequisites) |
-| [`cluster.yaml`](./assets/cluster.yaml) | PCS cluster core (Slurm scheduler only, no nodes) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/cluster.yaml&stackName=pcs-cluster) |
-| [`add-cng.yaml`](./assets/add-cng.yaml) | Compute node group — login nodes, CPU / single-NIC-GPU queues (C6i, G5, G6); switches to a multi-NIC EFA `NetworkInterfaces` block when `EfaInterfaceCount > 0` (HPC types: hpc6a/hpc7a/hpc6id/hpc8a …) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/add-cng.yaml&stackName=pcs-add-cng) |
-| [`add-cng-p5.yaml`](./assets/add-cng-p5.yaml) | P5/P5e/P5en nodes (16/32 EFA interfaces, by type) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/add-cng-p5.yaml&stackName=pcs-add-cng-p5) |
-| [`add-cng-p6-b200.yaml`](./assets/add-cng-p6-b200.yaml) | P6-B200 nodes (8 EFA interfaces) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/add-cng-p6-b200.yaml&stackName=pcs-add-cng-p6-b200) |
-| [`add-cng-p6-b300.yaml`](./assets/add-cng-p6-b300.yaml) | P6-B300 nodes (17 interfaces: 16 EFA + 1 ENA) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/add-cng-p6-b300.yaml&stackName=pcs-add-cng-p6-b300) |
-| [`pcs-ready-dlami-with-enroot-pyxis.yaml`](./assets/pcs-ready-dlami-with-enroot-pyxis.yaml) | EC2 Image Builder: bake Enroot 3.5.0 + Pyxis 0.20.0 into the PCS-Ready DLAMI | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ready-dlami-with-enroot-pyxis.yaml&stackName=pcs-dlami) |
+| [`pcs-ml-cluster-deploy-all.yaml`](./assets/pcs-ml-cluster-deploy-all.yaml) | All-in-one: Prerequisites + (optional AMI) + Cluster + login/CPU/GPU CNGs | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml&stackName=pcs-ml-cluster) |
+| [`ml-cluster-prerequisites.yaml`](./assets/ml-cluster-prerequisites.yaml) | VPC, subnets, security groups, FSx for Lustre + OpenZFS | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/ml-cluster-prerequisites.yaml&stackName=pcs-prerequisites) |
+| [`cluster.yaml`](./assets/cluster.yaml) | PCS cluster core (Slurm scheduler only, no nodes) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster.yaml&stackName=pcs-cluster) |
+| [`add-cng.yaml`](./assets/add-cng.yaml) | Compute node group — login nodes, CPU / single-NIC-GPU queues (C6i, G5, G6); switches to a multi-NIC EFA `NetworkInterfaces` block when `EfaInterfaceCount > 0` (HPC types: hpc6a/hpc7a/hpc6id/hpc8a …) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng.yaml&stackName=pcs-add-cng) |
+| [`add-cng-p5.yaml`](./assets/add-cng-p5.yaml) | P5/P5e/P5en nodes (16/32 EFA interfaces, by type) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng-p5.yaml&stackName=pcs-add-cng-p5) |
+| [`add-cng-p6-b200.yaml`](./assets/add-cng-p6-b200.yaml) | P6-B200 nodes (8 EFA interfaces) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng-p6-b200.yaml&stackName=pcs-add-cng-p6-b200) |
+| [`add-cng-p6-b300.yaml`](./assets/add-cng-p6-b300.yaml) | P6-B300 nodes (17 interfaces: 16 EFA + 1 ENA) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng-p6-b300.yaml&stackName=pcs-add-cng-p6-b300) |
+| [`pcs-ready-dlami-with-enroot-pyxis.yaml`](./assets/pcs-ready-dlami-with-enroot-pyxis.yaml) | EC2 Image Builder: bake Enroot 3.5.0 + Pyxis 0.20.0 into the PCS-Ready DLAMI | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ready-dlami-with-enroot-pyxis.yaml&stackName=pcs-dlami) |
 
 `add-cng*` templates create a Slurm queue only when `QueueName` is set (leave it empty
 for login nodes). The P-series templates need a `CapacityReservationId` when using a

--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -252,8 +252,8 @@ Parameters:
 
   S3KeyPrefix:
     Type: String
-    Description: S3 key prefix for scripts (e.g. templates/)
-    Default: 'templates/'
+    Description: S3 key prefix for scripts (e.g. templates/aws-pcs/)
+    Default: 'templates/aws-pcs/'
 
 Conditions:
   # EFA interface count is derived from the instance type: p5en.48xlarge has 16

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -243,8 +243,8 @@ Parameters:
 
   S3KeyPrefix:
     Type: String
-    Description: S3 key prefix for scripts (e.g. templates/)
-    Default: 'templates/'
+    Description: S3 key prefix for scripts (e.g. templates/aws-pcs/)
+    Default: 'templates/aws-pcs/'
 
 Conditions:
   UseCapacityBlock: !Not [!Equals [!Ref CapacityReservationId, ""]]

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -246,8 +246,8 @@ Parameters:
 
   S3KeyPrefix:
     Type: String
-    Description: S3 key prefix for scripts (e.g. templates/)
-    Default: 'templates/'
+    Description: S3 key prefix for scripts (e.g. templates/aws-pcs/)
+    Default: 'templates/aws-pcs/'
 
 Conditions:
   UseCapacityBlock: !Not [!Equals [!Ref CapacityReservationId, ""]]

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -245,8 +245,8 @@ Parameters:
 
   S3KeyPrefix:
     Type: String
-    Description: S3 key prefix for scripts (e.g. templates/)
-    Default: 'templates/'
+    Description: S3 key prefix for scripts (e.g. templates/aws-pcs/)
+    Default: 'templates/aws-pcs/'
 
   EfaInterfaceCount:
     Type: Number

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -180,8 +180,8 @@ Parameters:
 
   S3KeyPrefix:
     Type: String
-    Description: S3 key prefix for nested templates (e.g., templates/)
-    Default: "templates/"
+    Description: S3 key prefix for nested templates (e.g., templates/aws-pcs/)
+    Default: "templates/aws-pcs/"
 
   # Network Configuration
   PrimarySubnetAZ:

--- a/architectures/aws-pcs/assets/scripts/setup-directory.sh
+++ b/architectures/aws-pcs/assets/scripts/setup-directory.sh
@@ -29,7 +29,7 @@
 #   DIRECTORY_DNS_IPS   — comma-separated DNS IPs (future SimpleAD; empty = discover login IP)
 #   S3_BUCKET           — bucket holding the scripts (server role; to install the
 #                         ldap-add-user.sh helper onto /usr/local/bin)
-#   S3_KEY_PREFIX       — key prefix for the scripts (default "templates/")
+#   S3_KEY_PREFIX       — key prefix for the scripts (default "templates/aws-pcs/")
 
 set -euo pipefail
 
@@ -190,12 +190,12 @@ EOF
     # location this script came from (S3_BUCKET/S3_KEY_PREFIX passed by UserData);
     # falls back to a no-op with a hint if those are unset.
     if [ -n "${S3_BUCKET:-}" ]; then
-        if aws s3 cp "s3://${S3_BUCKET}/${S3_KEY_PREFIX:-templates/}scripts/ldap-add-user.sh" \
+        if aws s3 cp "s3://${S3_BUCKET}/${S3_KEY_PREFIX:-templates/aws-pcs/}scripts/ldap-add-user.sh" \
              /usr/local/bin/ldap-add-user.sh 2>/dev/null; then
             chmod 755 /usr/local/bin/ldap-add-user.sh
             echo "[directory-server] Installed helper: /usr/local/bin/ldap-add-user.sh"
         else
-            echo "[directory-server] WARNING: could not fetch ldap-add-user.sh from s3://${S3_BUCKET}/${S3_KEY_PREFIX:-templates/}scripts/ — add users with raw ldapadd (see USER-MANAGEMENT.md)."
+            echo "[directory-server] WARNING: could not fetch ldap-add-user.sh from s3://${S3_BUCKET}/${S3_KEY_PREFIX:-templates/aws-pcs/}scripts/ — add users with raw ldapadd (see USER-MANAGEMENT.md)."
         fi
     else
         echo "[directory-server] NOTE: S3_BUCKET unset; skipping ldap-add-user.sh install. Add users with raw ldapadd (see USER-MANAGEMENT.md)."

--- a/architectures/aws-pcs/docs/CUSTOM-AMI.md
+++ b/architectures/aws-pcs/docs/CUSTOM-AMI.md
@@ -11,12 +11,12 @@ then pass the resulting `ami-xxx` as `AmiId` to the cluster.
 
 ## Step 1: Build the AMI (~30 min one-time, separate stack)
 
-[![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ready-dlami-with-enroot-pyxis.yaml&stackName=pcs-dlami)
+[![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ready-dlami-with-enroot-pyxis.yaml&stackName=pcs-dlami)
 
 ```bash
 aws cloudformation create-stack \
   --stack-name pcs-dlami \
-  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ready-dlami-with-enroot-pyxis.yaml \
+  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ready-dlami-with-enroot-pyxis.yaml \
   --parameters ParameterKey=SlurmVersion,ParameterValue=25.11 \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
 ```
@@ -45,7 +45,7 @@ Optionally skip the boot-time Enroot/Pyxis install (it's already baked in) by se
 ```bash
 aws cloudformation create-stack \
   --stack-name pcs-ml-cluster \
-  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml \
+  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml \
   --parameters \
     ParameterKey=PrimarySubnetAZ,ParameterValue=us-east-1a \
     ParameterKey=AmiId,ParameterValue=$AMI_ID \

--- a/architectures/aws-pcs/docs/DEPLOY-TESTING.md
+++ b/architectures/aws-pcs/docs/DEPLOY-TESTING.md
@@ -25,7 +25,7 @@ This guide uses these placeholders — substitute your own:
 
 ```bash
 BUCKET=my-pcs-templates       # an S3 bucket you control
-PREFIX=templates/             # key prefix (keep the trailing slash)
+PREFIX=templates/aws-pcs/             # key prefix (keep the trailing slash)
 REGION=us-east-1              # the Region to deploy the cluster into
 AZ=us-east-1a                 # an Availability Zone in $REGION
 ```
@@ -47,7 +47,7 @@ Re-run this sync after every change you want to test.
 
 ## 3. Deploy pointing at your bucket
 
-Pass `S3BucketName` (and `S3KeyPrefix` if you changed it from the `templates/` default).
+Pass `S3BucketName` (and `S3KeyPrefix` if you changed it from the `templates/aws-pcs/` default).
 That single override is what makes the nested stacks **and** the first-boot Enroot/Pyxis
 installer come from your copy instead of the public bucket:
 

--- a/architectures/aws-pcs/docs/IAM.md
+++ b/architectures/aws-pcs/docs/IAM.md
@@ -23,8 +23,8 @@ as CloudFormation stacks:
 
 | Stack | Creates | Deploy |
 |---|---|---|
-| **Cluster admin** | `<stack>-PCSClusterAdmin-core` (always) + `<stack>-PCSClusterAdmin-imagebuilder` (if opted in) managed policies + an IAM group | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
-| **Cluster user** | `<stack>-PCSClusterUser` managed policy + an IAM group | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
+| **Cluster admin** | `<stack>-PCSClusterAdmin-core` (always) + `<stack>-PCSClusterAdmin-imagebuilder` (if opted in) managed policies + an IAM group | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
+| **Cluster user** | `<stack>-PCSClusterUser` managed policy + an IAM group | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
 
 Or from the CLI (use `--template-body` against a local checkout for a pre-merge
 sandbox test):

--- a/architectures/aws-pcs/docs/PARAMETERS.md
+++ b/architectures/aws-pcs/docs/PARAMETERS.md
@@ -103,4 +103,4 @@ availability and the "deploy small, expand after" tip.
 | Parameter | Default | Purpose |
 |---|---|---|
 | `S3BucketName` | `awsome-distributed-ai` | S3 bucket the nested templates are fetched from |
-| `S3KeyPrefix` | `templates/` | S3 key prefix for the nested templates |
+| `S3KeyPrefix` | `templates/aws-pcs/` | S3 key prefix for the nested templates |

--- a/architectures/aws-pcs/docs/USER-MANAGEMENT.md
+++ b/architectures/aws-pcs/docs/USER-MANAGEMENT.md
@@ -139,7 +139,7 @@ Implications to be aware of:
 ```bash
 aws cloudformation create-stack \
   --stack-name my-cluster \
-  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml \
+  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml \
   --parameters \
     ParameterKey=PrimarySubnetAZ,ParameterValue=us-east-2b \
     ParameterKey=DirectoryService,ParameterValue=OpenLDAP-LoginNode \

--- a/architectures/aws-pcs/tests/hpc-efa-test.md
+++ b/architectures/aws-pcs/tests/hpc-efa-test.md
@@ -36,7 +36,7 @@ AWS_AZ=us-east-2b
 aws cloudformation create-stack \
   --stack-name pcs-hpc-efa \
   --region us-east-2 \
-  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/pcs-ml-cluster-deploy-all.yaml \
+  --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml \
   --parameters \
     ParameterKey=PrimarySubnetAZ,ParameterValue=$AWS_AZ \
     ParameterKey=DeployOnDemandCNG,ParameterValue=true \


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow that publishes manifest-listed architecture templates after merges to `main`
- publish current PCS assets under `s3://awsome-distributed-ai/templates/aws-pcs/...` instead of flat `templates/...` keys
- update PCS launch URLs and `S3KeyPrefix` defaults to `templates/aws-pcs/` so nested stacks and scripts resolve inside the namespace
- add manifest-driven deletion of the legacy flat PCS objects after the namespaced upload succeeds
- add a staging/validation helper that detects CloudFormation templates structurally, tolerates CloudFormation YAML tags, checks duplicate destinations, and validates nested references against the architecture namespace

## Validation

- `python3 .github/scripts/stage-template-publish.py --manifest .github/template-publish-manifest.yml --stage-dir /tmp/template-publish-stage --cfn-list /tmp/template-publish-cfn-files.txt --shell-list /tmp/template-publish-shell-files.txt --obsolete-list /tmp/template-publish-obsolete-keys.txt`
- `python3 -m py_compile .github/scripts/stage-template-publish.py`
- `bash architectures/aws-pcs/tests/lint-docs.sh`
- staged shell scripts validated with `bash -n`
- verified staged output is under `/tmp/template-publish-stage/aws-pcs/...` and obsolete key list contains the old flat PCS keys

Note: local `aws cloudformation validate-template` was not run because this workspace has no default AWS credentials. The workflow runs it after GitHub OIDC role assumption.

## IAM note

The GitHub Actions role now needs `s3:DeleteObject` on `arn:aws:s3:::awsome-distributed-ai/templates/*` in addition to upload/list permissions, because this migration removes the legacy flat PCS keys.
