### PR TITLE
fix(eks-observability): non-existed custom-dcgm-metrics.csv cause failure in deploy-obs.sh

### DIFF
--- a/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/README.md
+++ b/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/README.md
@@ -19,6 +19,7 @@ Monitor EKS GPU workloads using Amazon Managed Prometheus (AMP) and Amazon Manag
 
 - EKS cluster with GPU nodes
 - AWS CLI and `kubectl` configured
+- Helm >= 3.14
 - AWS IAM Identity Center configured (for Grafana authentication)
 
 ## Installing DCGM Exporter

--- a/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/README.md
+++ b/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/README.md
@@ -113,6 +113,12 @@ Use the provided script for automated setup:
 
 ```bash
 cd awsome-distributed-training/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability
+
+# (Optional) Provide custom DCGM metrics. If a custom-dcgm-metrics.csv file
+# exists in this directory, the script builds those metrics into DCGM Exporter.
+# A reference file is provided at ../dcgm-metrics.csv:
+# cp ../dcgm-metrics.csv custom-dcgm-metrics.csv
+
 ./deploy-obs.sh
 ```
 
@@ -121,6 +127,8 @@ The script will prompt for:
 - AMP/AMG region (must support Amazon Managed Grafana)
 - Cluster name
 - CloudFormation stack name
+
+**Note:** Custom DCGM metrics are optional. If a `custom-dcgm-metrics.csv` file exists in this directory, the script creates a `custom-dcgm-metrics` ConfigMap and points DCGM Exporter at it. If the file is absent, the script clears any custom override and leaves DCGM Exporter on the GPU Operator's built-in default metrics.
 
 ### Manual Deployment
 
@@ -296,9 +304,15 @@ kubectl logs -n adot-col -l app.kubernetes.io/component=opentelemetry-collector 
 - Metrics are scraped every 30 seconds by default
 - SigV4 authentication is used for AMP remote write
 
-### 7. Configure Custom DCGM Metrics
+### 7. Configure Custom DCGM Metrics (Optional)
 
-Enable advanced GPU metrics including XID errors, power violations, thermal violations, and profiling metrics.
+Enable advanced GPU metrics including XID errors, power violations, thermal violations, and profiling metrics. This step is optional — if you skip it, DCGM Exporter uses the GPU Operator's built-in default metrics.
+
+A reference metrics file is provided at [`../dcgm-metrics.csv`](../dcgm-metrics.csv). Copy it into this directory as `custom-dcgm-metrics.csv` and edit as needed:
+
+```bash
+cp ../dcgm-metrics.csv custom-dcgm-metrics.csv
+```
 
 #### For GPU Operator Installation:
 
@@ -311,7 +325,7 @@ kubectl create configmap custom-dcgm-metrics \
 # Update GPU Operator to use custom metrics
 helm upgrade gpu-operator nvidia/gpu-operator \
   -n gpu-operator \
-  --reuse-values \
+  --reset-then-reuse-values \
   --set dcgmExporter.config.name=custom-dcgm-metrics
 
 # Restart DCGM Exporter to apply changes
@@ -330,7 +344,7 @@ kubectl create configmap custom-dcgm-metrics \
 # Upgrade DCGM Exporter to use custom metrics
 helm upgrade dcgm-exporter gpu-helm-charts/dcgm-exporter \
   -n dcgm-exporter \
-  --reuse-values \
+  --reset-then-reuse-values \
   --set-file arguments.configMap.data=custom-dcgm-metrics.csv
 
 # Restart DCGM Exporter

--- a/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/deploy-obs.sh
+++ b/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/deploy-obs.sh
@@ -358,24 +358,37 @@ echo ""
 echo -e "${YELLOW}Step 7: Configure Custom DCGM Metrics${NC}"
 echo ""
 
-# Create ConfigMap
-kubectl create configmap custom-dcgm-metrics \
-  --from-file=dcgm-metrics.csv=custom-dcgm-metrics.csv \
-  -n gpu-operator 2>/dev/null || echo "ConfigMap already exists, deleting and recreating..."
+# If a local custom-dcgm-metrics.csv exists, create a ConfigMap from it and
+# point DCGM Exporter at it. Otherwise leave the exporter on the GPU Operator's
+# built-in default metrics rather than pointing it at a non-existent ConfigMap
+# (which would wedge the pod in Init:0/1 on a failed mount).
+if [ -f "custom-dcgm-metrics.csv" ]; then
+    echo "Using custom DCGM metrics from: custom-dcgm-metrics.csv"
 
-if [ $? -ne 0 ]; then
-    kubectl delete configmap custom-dcgm-metrics -n gpu-operator
+    # Recreate the ConfigMap. The key must be exactly dcgm-metrics.csv for the
+    # exporter to pick it up.
+    kubectl delete configmap custom-dcgm-metrics -n gpu-operator --ignore-not-found
     kubectl create configmap custom-dcgm-metrics \
       --from-file=dcgm-metrics.csv=custom-dcgm-metrics.csv \
       -n gpu-operator
-fi
 
-# Update GPU Operator
-echo "Updating GPU Operator..."
-helm upgrade gpu-operator nvidia/gpu-operator \
-  -n gpu-operator \
-  --reuse-values \
-  --set dcgmExporter.config.name=custom-dcgm-metrics
+    echo "Updating GPU Operator to use custom metrics ConfigMap..."
+    helm upgrade gpu-operator nvidia/gpu-operator \
+      -n gpu-operator \
+      --reset-then-reuse-values \
+      --set dcgmExporter.config.name=custom-dcgm-metrics
+else
+    echo -e "${YELLOW}No custom-dcgm-metrics.csv found; using GPU Operator default DCGM metrics.${NC}"
+
+    # Drop any stale custom ConfigMap and clear the override (=null removes the
+    # key) so the exporter reverts to the operator's built-in default metrics.
+    kubectl delete configmap custom-dcgm-metrics -n gpu-operator --ignore-not-found
+    echo "Updating GPU Operator to use default metrics..."
+    helm upgrade gpu-operator nvidia/gpu-operator \
+      -n gpu-operator \
+      --reset-then-reuse-values \
+      --set dcgmExporter.config.name=null
+fi
 
 # Restart DCGM Exporter
 echo "Restarting DCGM Exporter..."

--- a/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/deploy-obs.sh
+++ b/4.validation_and_observability/4.prometheus-grafana/eks-managed-observability/deploy-obs.sh
@@ -12,6 +12,15 @@ echo -e "${GREEN}EKS GPU Observability Setup${NC}"
 echo -e "${GREEN}========================================${NC}"
 echo ""
 
+# Helm >= 3.14 is required for `--reset-then-reuse-values` (introduced in
+# v3.14.0) used by the GPU Operator upgrades in Step 7. Fail loudly up front
+# rather than aborting mid-deploy with `unknown flag`.
+if ! helm version --short 2>/dev/null | grep -qE 'v3\.(1[4-9]|[2-9][0-9])'; then
+    echo -e "${RED}Helm >= 3.14 is required (for --reset-then-reuse-values).${NC}"
+    echo -e "${RED}Current version: $(helm version --short 2>/dev/null || echo 'helm not found')${NC}"
+    exit 1
+fi
+
 # Function to prompt for input with default value
 prompt_with_default() {
     local prompt="$1"
@@ -380,14 +389,14 @@ if [ -f "custom-dcgm-metrics.csv" ]; then
 else
     echo -e "${YELLOW}No custom-dcgm-metrics.csv found; using GPU Operator default DCGM metrics.${NC}"
 
-    # Drop any stale custom ConfigMap and clear the override (=null removes the
-    # key) so the exporter reverts to the operator's built-in default metrics.
-    kubectl delete configmap custom-dcgm-metrics -n gpu-operator --ignore-not-found
     echo "Updating GPU Operator to use default metrics..."
     helm upgrade gpu-operator nvidia/gpu-operator \
       -n gpu-operator \
       --reset-then-reuse-values \
       --set dcgmExporter.config.name=null
+
+    # Now that the release no longer references it, drop any stale ConfigMap.
+    kubectl delete configmap custom-dcgm-metrics -n gpu-operator --ignore-not-found
 fi
 
 # Restart DCGM Exporter


### PR DESCRIPTION

## Purpose

- Use default dcgm metrics if custom-dcgm-metrics.csv doesn't exist.


## Changes

- Document custom metrics as optional in README and reference ../dcgm-metrics.csv as the template to copy.
- Switch `helm upgrade` to `--reset-then-reuse-values` so cleared overrides actually take effect.

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:  AMG + AMP
- Instance type:  g6.2xlarge
- Number of nodes: 1

**Test commands:**
Verified it by Manual Test

## Test Results
<img width="3590" height="1940" alt="5" src="https://github.com/user-attachments/assets/431164d5-635c-4c87-a97a-2d8388a7590c" />



## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
