### PR TITLE
Fix EFA install on CUDA-13 base: disable NGC-build auto-detect

### DIFF
--- a/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
+++ b/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
@@ -79,11 +79,16 @@ ENV PATH=/opt/gdrcopy/bin:$PATH
 
 #################################################
 ## Install EFA installer
+# --disable-build-ngc: on an nvcr.io/nvidia/cuda base the installer auto-detects
+# "NGC build image" mode and skips rdma-core/deps, but this image removes the
+# distro rdma-core above and relies on the EFA bundle to provide libibverbs1 /
+# ibverbs-providers (>=59, newer than jammy's apt). Disabling NGC-build mode
+# forces a full install so libfabric1-aws's deps are satisfied.
 RUN cd $HOME \
     && curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
     && tar -xf $HOME/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
     && cd aws-efa-installer \
-    && ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify \
+    && ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify --disable-build-ngc \
     && rm -rf $HOME/aws-efa-installer
 
 RUN echo "Verifying AWS OFI NCCL plugin installation..." && \


### PR DESCRIPTION
The EFA 1.48.0 installer auto-detects an "NGC build image" on the nvcr.io/nvidia/cuda base and skips installing rdma-core/dependencies. Since this Dockerfile removes the distro rdma-core (libibverbs1, ibverbs-providers, ...) and relies on the EFA bundle to provide them, libfabric1-aws then fails its dpkg dependency check (ibverbs-providers >= 59, libibverbs1 >= 36 not installed) and the build aborts. jammy's apt only offers rdma-core 39, so the distro cannot satisfy it either.

Add --disable-build-ngc so the installer performs a full install, laying down its bundled rdma-core (>= 59) and OpenMPI. First surfaced by the new GitHub Actions image pipeline (the CUDA-13 image was never built by the old CodePipeline).

Claude-Session: https://claude.ai/code/session_01XfRhr7k57MK7GrSgouVGUS

## Purpose

<!-- Link related issues using "Fixes #123" or "Relates to #123" -->

## Changes

<!-- Summarize the changes made in this PR -->

-

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:
- Instance type:
- Number of nodes:

**Test commands:**
```bash

```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
