### PR TITLE
Add NVIDIA Model Optimizer FP8 quantization recipe (single-GPU EC2)

### DIFF
--- a/3.test_cases/pytorch/model-optimizer/README.md
+++ b/3.test_cases/pytorch/model-optimizer/README.md
@@ -1,0 +1,158 @@
+# NVIDIA Model Optimizer — FP8 Quantization on a Single GPU Instance
+
+This test case demonstrates how to evaluate [NVIDIA Model Optimizer](https://github.com/NVIDIA/Model-Optimizer)
+(ModelOpt) — a library of inference optimization techniques (quantization, pruning, distillation,
+speculative decoding, sparsity) — on a **single GPU EC2 instance**. It runs **FP8 post-training
+quantization (PTQ)** on a Hugging Face LLM and serves the compressed checkpoint with
+[vLLM](https://github.com/vllm-project/vllm).
+
+Unlike the distributed-training test cases in this repo, ModelOpt PTQ is a single-process,
+single-GPU workload — so a single EC2 instance (provisioned here with Terraform) is the right
+tool for evaluation. Graduate the proven workflow to EKS/HyperPod when you need repeatable,
+multi-node, or production `train -> optimize -> serve` pipelines.
+
+## Repository Structure
+
+```text
+3.test_cases/pytorch/model-optimizer/
+├── README.md                 # This file
+├── terraform/                # Single-GPU EC2 instance + SSM access
+│   ├── versions.tf
+│   ├── providers.tf
+│   ├── variables.tf
+│   ├── main.tf
+│   ├── outputs.tf
+│   └── README.md
+└── src/
+    ├── requirements.txt      # Pinned: nvidia-modelopt==0.44.0 + example deps
+    ├── setup.sh              # venv + install + repo checkout pinned to the matching tag
+    ├── quantize_fp8.sh       # FP8 PTQ via examples/llm_ptq/hf_ptq.py
+    └── smoke_test_vllm.py    # vLLM offline generation to verify the checkpoint
+```
+
+## Compatible Instance Types
+
+The quantization **format** is gated by the GPU **architecture**:
+
+| Format | GPU architecture | Example instance |
+|--------|------------------|------------------|
+| INT8 / INT4-AWQ | Ampere+ | p4d, g5, g6e |
+| **FP8** | Ada / Hopper | **g6e.xlarge** (L40S), p5.48xlarge (H100) |
+| **NVFP4** | Blackwell only | p6-b200.48xlarge |
+
+This recipe defaults to **`g6e.xlarge`** (1x L40S, 48 GB) — the cheapest viable single-GPU box
+for FP8 (~$1.86/hr on-demand in us-west-2). NVFP4 cannot be exercised on g6e/p5.
+
+> [!NOTE]
+> ModelOpt is CUDA/TensorRT-centric. On Trainium/Inferentia (`trn`/`inf`) the analogous
+> toolchain is the Neuron SDK, not this library.
+
+## Prerequisites
+
+- Terraform `>= 1.14.0` and AWS credentials (EC2/IAM/SG create permissions)
+- The [SSM Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+- EC2 quota for the chosen GPU instance family
+
+## Step 1 — Provision the instance
+
+```bash
+cd terraform
+terraform init
+terraform apply        # creates IAM role, egress-only SG, GPU instance (default VPC)
+
+# Connect via SSM (no SSH, no key pair):
+$(terraform output -raw ssm_start_session_command)
+```
+
+Verify the GPU:
+
+```bash
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv
+# e.g.  NVIDIA L40S, 46068 MiB, 595.71.05
+```
+
+See [`terraform/README.md`](terraform/README.md) for variables and overrides.
+
+## Step 2 — Install ModelOpt
+
+Copy `src/` to the instance (or `git clone` this repo on the box), then:
+
+```bash
+cd src
+bash setup.sh        # ~90s: venv + nvidia-modelopt==0.44.0 + repo checkout @ 0.44.0
+```
+
+## Step 3 — Run FP8 PTQ
+
+```bash
+bash quantize_fp8.sh    # defaults to Qwen/Qwen2.5-7B-Instruct (non-gated)
+```
+
+Override the model or calibration size via environment variables:
+
+```bash
+MODEL=Qwen/Qwen2.5-7B-Instruct CALIB_SIZE=512 bash quantize_fp8.sh
+```
+
+## Step 4 — Serve & verify with vLLM
+
+vLLM pins specific torch versions, so install it in a **separate venv**:
+
+```bash
+python3.12 -m venv ~/model-optimizer-recipe/vllm-venv
+. ~/model-optimizer-recipe/vllm-venv/bin/activate
+pip install 'vllm==0.23.0'
+python smoke_test_vllm.py --model ~/qwen2.5-7b-fp8
+```
+
+## Step 5 — Teardown (cost-critical)
+
+```bash
+cd terraform
+terraform destroy
+```
+
+> [!WARNING]
+> The instance bills until destroyed. Run `terraform destroy` as soon as you are done.
+
+## Results (reference run)
+
+Live run on a single `g6e.xlarge` (L40S, driver 595.71.05) in us-west-2:
+
+| Metric | Value |
+|--------|-------|
+| ModelOpt version | 0.44.0 |
+| Install time | ~90 s |
+| Calibration + export (Qwen2.5-7B, after model cached) | ~45 s |
+| Peak GPU memory during PTQ | ~16.5 GB |
+| Checkpoint size | 15 GB BF16 -> **8.2 GB FP8** (~1.8x) |
+| vLLM kernel selected | `CutlassFP8ScaledMMLinearKernel` |
+
+Sample generation from the FP8 checkpoint:
+
+```text
+PROMPT:  What is the capital of France? Answer in one sentence.
+OUTPUT:  The capital of France is Paris.
+```
+
+## Known Issues
+
+- **FP8 KV-cache produces garbled output on Ada (L40S).** Quantize **weights only**
+  (`--kv_cache_qformat none`, the default in `quantize_fp8.sh`). vLLM warns
+  `Using KV cache scaling factor 1.0 for fp8_e4m3` and emits gibberish if FP8 KV-cache is on
+  without validated scales. Enable FP8 KV-cache only with explicit accuracy validation.
+- **Repo/wheel version skew.** The example scripts are not in the pip wheel; `main` may
+  reference internals not in the release. `setup.sh` checks out the tag matching the pinned
+  wheel (`0.44.0`) to avoid `ModuleNotFoundError`.
+- **The default calibration dataset is gated.** `hf_ptq.py` defaults to a gated Nemotron
+  dataset; this recipe passes `--dataset cnn_dailymail` (non-gated) so it is self-contained.
+- **`transformers>=5.0` is experimental** in ModelOpt 0.44.0 (emits a `UserWarning`). It works
+  for Qwen2.5; pin `transformers` if you hit export issues on other models.
+
+## References
+
+- [NVIDIA Model Optimizer](https://github.com/NVIDIA/Model-Optimizer)
+- [ModelOpt documentation](https://nvidia.github.io/Model-Optimizer)
+- [LLM PTQ example](https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/llm_ptq)
+- [Introducing NVFP4](https://developer.nvidia.com/blog/introducing-nvfp4-for-efficient-and-accurate-low-precision-inference/)
+- [vLLM](https://github.com/vllm-project/vllm)

--- a/3.test_cases/pytorch/model-optimizer/src/quantize_fp8.sh
+++ b/3.test_cases/pytorch/model-optimizer/src/quantize_fp8.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Run FP8 post-training quantization (PTQ) on a Hugging Face model with NVIDIA Model Optimizer,
+# exporting a vLLM/TensorRT-LLM-ready checkpoint.
+#
+# Defaults to Qwen/Qwen2.5-7B-Instruct (non-gated - no Hugging Face token required).
+# Run after setup.sh, as the ec2-user.
+set -euo pipefail
+
+MODEL="${MODEL:-Qwen/Qwen2.5-7B-Instruct}"
+EXPORT_PATH="${EXPORT_PATH:-${HOME}/qwen2.5-7b-fp8}"
+CALIB_SIZE="${CALIB_SIZE:-512}"
+WORKDIR="${HOME}/model-optimizer-recipe"
+REPO_DIR="${HOME}/Model-Optimizer"
+
+# shellcheck disable=SC1091
+. "${WORKDIR}/modelopt-venv/bin/activate"
+cd "${REPO_DIR}/examples/llm_ptq"
+
+# Notes on the flags (each one matters):
+#   --qformat fp8            FP8 weights. Works on Ada (L40S) and Hopper (H100). Use nvfp4 on Blackwell.
+#   --export_fmt hf          Hugging Face / compressed-tensors checkpoint vLLM can load directly.
+#   --dataset cnn_dailymail  Non-gated calibration set. The default Nemotron set is GATED and fails.
+#   --kv_cache_qformat none  Quantize WEIGHTS ONLY. FP8 KV-cache is fragile on Ada (garbled output);
+#                            enable it only with explicit accuracy validation.
+#   --attn_implementation eager  Avoids a slow flash-attn source build; fine for calibration.
+python hf_ptq.py \
+  --pyt_ckpt_path "${MODEL}" \
+  --qformat fp8 \
+  --export_fmt hf \
+  --dataset cnn_dailymail \
+  --calib_size "${CALIB_SIZE}" \
+  --batch_size 4 \
+  --kv_cache_qformat none \
+  --attn_implementation eager \
+  --trust_remote_code \
+  --export_path "${EXPORT_PATH}"
+
+echo "==> FP8 checkpoint exported to: ${EXPORT_PATH}"
+du -sh "${EXPORT_PATH}" || true
+echo "==> next: python smoke_test_vllm.py --model ${EXPORT_PATH}"

--- a/3.test_cases/pytorch/model-optimizer/src/requirements.txt
+++ b/3.test_cases/pytorch/model-optimizer/src/requirements.txt
@@ -1,0 +1,10 @@
+# ModelOpt FP8 quantization recipe — pinned dependencies.
+# Installed into a dedicated venv by setup.sh.
+nvidia-modelopt[hf]==0.44.0
+
+# Example-script dependencies (examples/llm_ptq) needed for hf_ptq.py.
+# We use --attn_implementation eager, so flash-attn is intentionally NOT required.
+fire
+compressed-tensors
+zstandard
+transformers_stream_generator

--- a/3.test_cases/pytorch/model-optimizer/src/setup.sh
+++ b/3.test_cases/pytorch/model-optimizer/src/setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Set up the ModelOpt environment on the GPU Deep Learning AMI (Amazon Linux 2023).
+#
+# The base OSS NVIDIA-driver DLAMI ships the driver + Docker but no conda/frameworks and no
+# CUDA toolkit. That is fine: the nvidia-modelopt and vllm pip wheels bring their own CUDA.
+# We use the DLAMI's Python 3.12 (ModelOpt requires Python >= 3.10).
+#
+# Run as the ec2-user, from the user's home directory.
+set -euo pipefail
+
+MODELOPT_VERSION="0.44.0"
+WORKDIR="${HOME}/model-optimizer-recipe"
+REPO_DIR="${HOME}/Model-Optimizer"
+
+echo "==> Python: $(python3.12 --version)"
+
+echo "==> Creating ModelOpt venv"
+python3.12 -m venv "${WORKDIR}/modelopt-venv"
+# shellcheck disable=SC1091
+. "${WORKDIR}/modelopt-venv/bin/activate"
+pip install --upgrade pip -q
+
+echo "==> Installing nvidia-modelopt + example deps (pinned)"
+# requirements.txt lives next to this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pip install -q -r "${SCRIPT_DIR}/requirements.txt"
+python -c 'import modelopt; print("modelopt", modelopt.__version__)'
+
+echo "==> Cloning Model-Optimizer examples, pinned to the matching tag ${MODELOPT_VERSION}"
+# The example scripts (hf_ptq.py) are NOT in the pip wheel. Check out the tag that matches the
+# installed wheel to avoid version skew (main can reference internals not in the release).
+if [ ! -d "${REPO_DIR}" ]; then
+  git clone https://github.com/NVIDIA/Model-Optimizer.git "${REPO_DIR}"
+fi
+cd "${REPO_DIR}"
+git checkout "${MODELOPT_VERSION}"
+
+echo "==> Setup complete."
+echo "    venv:  ${WORKDIR}/modelopt-venv"
+echo "    repo:  ${REPO_DIR} (tag ${MODELOPT_VERSION})"
+echo "    next:  bash quantize_fp8.sh"

--- a/3.test_cases/pytorch/model-optimizer/src/smoke_test_vllm.py
+++ b/3.test_cases/pytorch/model-optimizer/src/smoke_test_vllm.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""Smoke-test a ModelOpt FP8 checkpoint by serving it with vLLM (offline API).
+
+Loads the quantized checkpoint, runs a couple of greedy generations, and prints them so you
+can confirm the FP8 weights round-trip to coherent output.
+
+Install vLLM in a SEPARATE venv (it pins specific torch versions):
+
+    python3.12 -m venv ~/model-optimizer-recipe/vllm-venv
+    . ~/model-optimizer-recipe/vllm-venv/bin/activate
+    pip install 'vllm==0.23.0'
+    python smoke_test_vllm.py --model ~/qwen2.5-7b-fp8
+"""
+
+import argparse
+
+from vllm import LLM, SamplingParams
+
+DEFAULT_PROMPTS = [
+    "What is the capital of France? Answer in one sentence.",
+    "In one sentence, what is FP8 quantization and why does it speed up inference?",
+]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Path to the exported FP8 checkpoint.")
+    parser.add_argument("--max-model-len", type=int, default=2048)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+    parser.add_argument("--max-tokens", type=int, default=100)
+    args = parser.parse_args()
+
+    # quantization="modelopt" matches the ModelOpt-native hf_quant_config.json.
+    # vLLM also auto-detects if you omit it.
+    llm = LLM(
+        model=args.model,
+        quantization="modelopt",
+        max_model_len=args.max_model_len,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        enforce_eager=True,
+    )
+    sampling = SamplingParams(temperature=0.0, max_tokens=args.max_tokens)
+
+    for out in llm.generate(DEFAULT_PROMPTS, sampling):
+        print("=== PROMPT ===")
+        print(out.prompt)
+        print("=== GENERATION ===")
+        print(out.outputs[0].text.strip())
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/3.test_cases/pytorch/model-optimizer/terraform/README.md
+++ b/3.test_cases/pytorch/model-optimizer/terraform/README.md
@@ -1,0 +1,61 @@
+# Terraform — Single GPU EC2 Instance for ModelOpt
+
+Provisions a single GPU EC2 instance for evaluating NVIDIA Model Optimizer, connected via
+**SSM Session Manager** (no inbound SSH, no key pair). Creates:
+
+- An IAM role + instance profile with `AmazonSSMManagedInstanceCore`
+- An **egress-only** security group (SSM needs no inbound)
+- One GPU instance from the GPU Deep Learning AMI (resolved via SSM Parameter Store), with a
+  200 GiB gp3 root volume and IMDSv2 enforced, in your default VPC
+
+## Prerequisites
+
+- Terraform `>= 1.14.0`
+- AWS credentials with permission to create EC2/IAM/SG resources
+- The [Session Manager plugin][ssm-plugin] for `aws ssm start-session`
+- Sufficient EC2 quota for the chosen instance family (G or P on-demand vCPUs)
+
+[ssm-plugin]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+
+## Usage
+
+```bash
+terraform init
+terraform plan
+terraform apply
+
+# Connect (use the emitted output):
+$(terraform output -raw ssm_start_session_command)
+```
+
+Verify the GPU once connected:
+
+```bash
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv
+```
+
+Then follow the [recipe README](../README.md) to install ModelOpt and run FP8 quantization.
+
+## Variables
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `aws_region` | `us-west-2` | Region to deploy into |
+| `instance_type` | `g6e.xlarge` | 1x L40S (Ada), FP8/INT8. Override to `p5` (H100) or `p6-b200` (NVFP4) |
+| `root_volume_size_gb` | `200` | Root gp3 volume |
+| `project_tag` | `modelopt-runbook` | Applied to all resources via `default_tags` |
+| `name_prefix` | `modelopt-runbook` | Resource name prefix |
+| `dlami_ssm_parameter` | base OSS NVIDIA-driver AL2023 | SSM path to the AMI ID |
+
+## Teardown (cost-critical)
+
+```bash
+terraform destroy
+```
+
+This terminates the instance (root volume has `delete_on_termination = true`) and removes the
+security group and IAM role/instance profile. Confirm `destroy` completes with no errors.
+
+> [!WARNING]
+> A `g6e.xlarge` is ~$1.86/hr on-demand in us-west-2. Run `terraform destroy` as soon as you
+> are done — the instance bills until destroyed.

--- a/3.test_cases/pytorch/model-optimizer/terraform/main.tf
+++ b/3.test_cases/pytorch/model-optimizer/terraform/main.tf
@@ -1,0 +1,92 @@
+# Resolve the GPU Deep Learning AMI from SSM Parameter Store (always latest).
+data "aws_ssm_parameter" "dlami" {
+  name = var.dlami_ssm_parameter
+}
+
+# Use the default VPC + a default subnet for a self-contained, no-frills test box.
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# IAM role + instance profile for SSM Session Manager (no inbound SSH needed).
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "ssm_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ssm" {
+  name               = "${var.name_prefix}-ssm"
+  assume_role_policy = data.aws_iam_policy_document.ssm_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.ssm.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ssm" {
+  name = "${var.name_prefix}-ssm"
+  role = aws_iam_role.ssm.name
+}
+
+# ---------------------------------------------------------------------------
+# Security group: egress only. SSM Session Manager needs no inbound rules.
+# ---------------------------------------------------------------------------
+resource "aws_security_group" "this" {
+  name        = "${var.name_prefix}-sg"
+  description = "ModelOpt runbook - egress only for SSM"
+  vpc_id      = data.aws_vpc.default.id
+
+  egress {
+    description = "Allow all outbound (SSM endpoints, package + model downloads)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# The single GPU instance.
+# ---------------------------------------------------------------------------
+resource "aws_instance" "this" {
+  ami                    = data.aws_ssm_parameter.dlami.value
+  instance_type          = var.instance_type
+  iam_instance_profile   = aws_iam_instance_profile.ssm.name
+  vpc_security_group_ids = [aws_security_group.this.id]
+  subnet_id              = data.aws_subnets.default.ids[0]
+
+  root_block_device {
+    volume_size           = var.root_volume_size_gb
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  # Enforce IMDSv2.
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  tags = {
+    Name = var.name_prefix
+  }
+}

--- a/3.test_cases/pytorch/model-optimizer/terraform/outputs.tf
+++ b/3.test_cases/pytorch/model-optimizer/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_id" {
+  description = "EC2 instance ID of the GPU box."
+  value       = aws_instance.this.id
+}
+
+output "instance_type" {
+  description = "Launched instance type."
+  value       = aws_instance.this.instance_type
+}
+
+output "ami_id" {
+  description = "Resolved Deep Learning AMI ID."
+  value       = nonsensitive(data.aws_ssm_parameter.dlami.value)
+}
+
+output "ssm_start_session_command" {
+  description = "Ready-to-paste command to open an SSM shell on the instance."
+  value       = "aws ssm start-session --target ${aws_instance.this.id} --region ${var.aws_region}"
+}

--- a/3.test_cases/pytorch/model-optimizer/terraform/providers.tf
+++ b/3.test_cases/pytorch/model-optimizer/terraform/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project = var.project_tag
+    }
+  }
+}

--- a/3.test_cases/pytorch/model-optimizer/terraform/variables.tf
+++ b/3.test_cases/pytorch/model-optimizer/terraform/variables.tf
@@ -1,0 +1,43 @@
+variable "aws_region" {
+  description = "AWS region to deploy the GPU instance into."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "instance_type" {
+  description = <<-EOT
+    Single GPU instance type. Defaults to g6e.xlarge (1x L40S, Ada) which supports
+    FP8 and INT8 quantization. Step up to p5.48xlarge (H100) for larger models or
+    tensor-parallel paths, or p6-b200.48xlarge (Blackwell) to exercise NVFP4.
+  EOT
+  type        = string
+  default     = "g6e.xlarge"
+}
+
+variable "root_volume_size_gb" {
+  description = "Root EBS volume size in GiB. Needs room for the model weights (~15 GB) + FP8 export (~8 GB) + caches."
+  type        = number
+  default     = 200
+}
+
+variable "project_tag" {
+  description = "Value applied to the Project tag on all created resources (used for cleanup/identification)."
+  type        = string
+  default     = "modelopt-runbook"
+}
+
+variable "name_prefix" {
+  description = "Name prefix for created resources (IAM role, instance profile, security group, instance)."
+  type        = string
+  default     = "modelopt-runbook"
+}
+
+variable "dlami_ssm_parameter" {
+  description = <<-EOT
+    SSM Parameter Store path that resolves to the GPU Deep Learning AMI ID.
+    Defaults to the base OSS NVIDIA-driver Amazon Linux 2023 DLAMI (driver + Docker,
+    no frameworks - the ModelOpt/vLLM pip wheels bring their own CUDA).
+  EOT
+  type        = string
+  default     = "/aws/service/deeplearning/ami/x86_64/base-oss-nvidia-driver-gpu-amazon-linux-2023/latest/ami-id"
+}

--- a/3.test_cases/pytorch/model-optimizer/terraform/versions.tf
+++ b/3.test_cases/pytorch/model-optimizer/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.14.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.27.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Adds a new test case demonstrating **NVIDIA Model Optimizer (ModelOpt)** FP8 post-training quantization on a **single GPU EC2 instance**, served with vLLM. Unlike the distributed-training test cases, ModelOpt PTQ is a single-process, single-GPU workload, so the recipe provisions one instance with Terraform and connects via SSM Session Manager (no SSH).

## Changes

- New test case: `3.test_cases/pytorch/model-optimizer/`
  - `terraform/` — single `g6e.xlarge` (L40S) instance: SSM IAM role + instance profile, egress-only security group, GPU DLAMI resolved from SSM Parameter Store, gp3 root volume, IMDSv2 enforced. Connects via SSM Session Manager (no inbound SSH, no key pair).
  - `src/` — pinned `setup.sh` (`nvidia-modelopt==0.44.0`), `quantize_fp8.sh` (FP8 PTQ via `examples/llm_ptq/hf_ptq.py`, weights-only, `cnn_dailymail` calibration), `smoke_test_vllm.py`, pinned `requirements.txt`.
  - `README.md` — EC2-vs-EKS rationale, format↔GPU-architecture matrix, full walkthrough, reference results, and known issues.

## Test Plan

**Environment:**
- AWS Service: EC2 (single instance, provisioned via the recipe's Terraform)
- Instance type: `g6e.xlarge` (1× NVIDIA L40S, 48 GB, Ada)
- Number of nodes: 1
- Region: us-west-2

**Test commands:**
```bash
# Infra (verified apply -> SSM -> nvidia-smi -> destroy)
cd 3.test_cases/pytorch/model-optimizer/terraform
terraform init && terraform validate && terraform plan
terraform apply -auto-approve
aws ssm start-session --target <instance-id>     # then: nvidia-smi
terraform destroy -auto-approve

# Workload (verified on the L40S)
cd ../src
bash setup.sh
bash quantize_fp8.sh
python smoke_test_vllm.py --model ~/qwen2.5-7b-fp8
```

## Test Results

- `terraform init/validate/plan/apply/destroy` all succeeded against a real account; AMI resolved to `ami-03ee6edb81d0951b9`; SSM came online ~30 s after launch; `nvidia-smi` reported `NVIDIA L40S, 46068 MiB, 595.71.05`. `terraform destroy` removed all 5 resources with zero left billable.
- ModelOpt `0.44.0` installed in ~90 s; FP8 PTQ of `Qwen/Qwen2.5-7B-Instruct` (weights-only, `cnn_dailymail`) calibrated + exported in ~45 s; peak GPU memory ~16.5 GB.
- Checkpoint size: **15 GB BF16 → 8.2 GB FP8 (~1.8×)**.
- vLLM `0.23.0` loaded the checkpoint (`CutlassFP8ScaledMMLinearKernel`) and produced coherent output:
  - `What is the capital of France?` → `The capital of France is Paris.`

Documented known issue surfaced during testing: **FP8 KV-cache produces garbled output on Ada (L40S)** → recipe defaults to weights-only (`--kv_cache_qformat none`).

## Directory Structure

```
3.test_cases/pytorch/model-optimizer/
├── README.md
├── terraform/
│   ├── versions.tf
│   ├── providers.tf
│   ├── variables.tf
│   ├── main.tf
│   ├── outputs.tf
│   └── README.md
└── src/
    ├── requirements.txt
    ├── setup.sh
    ├── quantize_fp8.sh
    └── smoke_test_vllm.py
```

## Checklist

- [x] I have read the contributing guidelines.
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included with prerequisites, instructions, and known issues.
- [x] New test cases follow the expected directory structure.

---

*Draft:* opening for early review. The EC2 path is live-tested; the EKS/HyperPod graduation path is documented but intentionally out of scope for this PR.
