### PR TITLE
DeepEP - Simplify DeepEP on EFA using a script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,6 @@ micro-benchmarks/nccl-tests/slurm/find_bad_nodes/logs/node_combinations_*.txt
 .testenv
 micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/debug_topology.json
 *.patch
-!micro-benchmarks/expert-parallelism/deepep-benchmark/deepep_aws_efa.patch
 
 # Kiro IDE
 .kiro/

--- a/micro-benchmarks/expert-parallelism/deepep-benchmark/README.md
+++ b/micro-benchmarks/expert-parallelism/deepep-benchmark/README.md
@@ -17,7 +17,7 @@ Run them on **Slurm** ([`slurm/`](./slurm/)) or **Kubernetes / EKS** ([`kubernet
 ## ⚠️ Version constraints
 
 > This particular version works only with NVSHMEM >= [3.7.0-0](https://github.com/NVIDIA/nvshmem/tree/v3.7.0-0)
-> and DeepEP v1 with the **NVSHMEM backend** <= [567632d of Feb 3, 2026](https://github.com/deepseek-ai/DeepEP/tree/567632dd59810d77b3cc05553df953cc0f779799).
+> and DeepEP v1 with the **NVSHMEM backend** = [567632d of Feb 3, 2026](https://github.com/deepseek-ai/DeepEP/tree/567632dd59810d77b3cc05553df953cc0f779799).
 
 This targets DeepEP's legacy NVSHMEM code path (pre-EPv2). EPv2 restructures the kernel sources
 and switches to the NCCL GIN backend; it is out of scope here.
@@ -56,26 +56,22 @@ rebuilding the image.
 - EFA-enabled GPU nodes.
 - **GPU architecture:** the image is built for **both Hopper (`sm_90`) and Blackwell (`sm_100`)**
   by default, so the same image runs on `p5`/`p5en` and `p6-b300` nodes. To build a smaller
-  single-arch image, override `--build-arg GPU_ARCH=90 --build-arg TORCH_CUDA_ARCH_LIST=9.0 --build-arg NVCC_GENCODE=-gencode=arch=compute_90,code=sm_90` (Hopper only)
-  or `--build-arg GPU_ARCH=100 --build-arg TORCH_CUDA_ARCH_LIST=10.0 --build-arg NVCC_GENCODE=-gencode=arch=compute_100,code=sm_100` (Blackwell only)
+  single-arch image, override `--build-arg TORCH_CUDA_ARCH_LIST=9.0 --build-arg NVCC_GENCODE=-gencode=arch=compute_90,code=sm_90` (Hopper only)
+  or `--build-arg TORCH_CUDA_ARCH_LIST=10.0 --build-arg NVCC_GENCODE=-gencode=arch=compute_100,code=sm_100` (Blackwell only)
 
 ## Building the DeepEP image
 
 ```bash
 GDRCOPY_VERSION=v2.5.2
 EFA_INSTALLER_VERSION=1.48.0
-NVSHMEM_VERSION=3.7.0
-DEEPEP_COMMIT=567632d
-GPU_ARCH="90;100" # Hopper + Blackwell by default; use "90" or "100" for a single-arch image
-TORCH_CUDA_ARCH_LIST="9.0;10.0" # Hopper + Blackwell by default; use "9.0" or "10.0" for a single-arch image
-NVCC_GENCODE="-gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100" # Hopper + Blackwell by default; use "90" or "100" for a single-arch image
-TAG="efa${EFA_INSTALLER_VERSION}-nvshmem${NVSHMEM_VERSION}-deepep${DEEPEP_COMMIT}"
+TORCH_CUDA_ARCH_LIST="9.0;10.0;10.3" # Hopper + Blackwell by default; use "9.0" or "10.0" for a single-arch image
+NVCC_GENCODE="-gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_103,code=sm_103" # Hopper + Blackwell by default; use "90" or "100" for a single-arch image
+TAG="efa${EFA_INSTALLER_VERSION}"
 DEEPEP_CONTAINER_IMAGE_NAME_TAG="deepep:${TAG}"
 ```
 
 > [!NOTE]
-> The `deepep.Dockerfile` relies on BuildKit features (`RUN --mount` and the
-> auto-populated `TARGETARCH` arg), so the build must run under BuildKit. The
+> The `deepep.Dockerfile` relies on BuildKit features (`RUN --mount`), so the build must run under BuildKit. The
 > command below sets `DOCKER_BUILDKIT=1` explicitly so it works even on hosts
 > where the legacy builder is still the default. Alternatively, use
 > `docker buildx build ...`.
@@ -84,9 +80,6 @@ DEEPEP_CONTAINER_IMAGE_NAME_TAG="deepep:${TAG}"
 DOCKER_BUILDKIT=1 docker build --progress=plain -f ./deepep.Dockerfile \
       --build-arg="GDRCOPY_VERSION=${GDRCOPY_VERSION}" \
       --build-arg="EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION}" \
-      --build-arg="NVSHMEM_VERSION=${NVSHMEM_VERSION}" \
-      --build-arg="DEEPEP_COMMIT=${DEEPEP_COMMIT}" \
-      --build-arg="GPU_ARCH=${GPU_ARCH}" \
       --build-arg "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}" \
       --build-arg "NVCC_GENCODE=${NVCC_GENCODE}" \
       -t ${DEEPEP_CONTAINER_IMAGE_NAME_TAG} \

--- a/micro-benchmarks/expert-parallelism/deepep-benchmark/README.md
+++ b/micro-benchmarks/expert-parallelism/deepep-benchmark/README.md
@@ -28,10 +28,11 @@ DeepEP's internode kernels were written for [IBGDA](https://docs.nvidia.com/nvsh
 RDMA over InfiniBand), which EFA does not provide. The image works around this:
 
 - **NVSHMEM 3.7.0**
-- [`deepep_aws_efa.patch`](./deepep_aws_efa.patch) **patches DeepEP** to replace its IBGDA device
-  calls with NVSHMEM host-proxy QP APIs (`nvshmemx_qp_*`), maps the dispatch/combine tail updates
-  onto a combined put+signal, and raises `NVSHMEM_MAX_TEAMS` for NVSHMEM 3.7.
-- The build requires PyTorch, PyTorch's bundled `nvidia-nvshmem-cu13` is uninstalled so it does not clash with the OS libraries NVSHMEM 3.7.0.
+- [`setup_deepep_efa.sh`](./setup_deepep_efa.sh) — a self-contained script that downloads NVSHMEM,
+  clones DeepEP, and applies an **embedded EFA patch** that replaces IBGDA device calls with
+  NVSHMEM host-proxy QP APIs (`nvshmemx_qp_*`), maps the dispatch/combine tail updates onto a
+  combined put+signal, and raises `NVSHMEM_MAX_TEAMS` for NVSHMEM 3.7.
+- The build requires PyTorch; PyTorch's bundled `nvidia-nvshmem-cu13` is uninstalled so it does not clash with the OS-installed NVSHMEM 3.7.0 during runtime.
 - The image is built on **CUDA 13** (PyTorch `cu130`). This is required for Blackwell (B200/B300):
   CUDA ≤ 12.9 CUPTI fails on those GPUs (`CUPTI_ERROR_INVALID_DEVICE`), which breaks the
   internode/low-latency tuning phase that profiles kernels.

--- a/micro-benchmarks/expert-parallelism/deepep-benchmark/deepep.Dockerfile
+++ b/micro-benchmarks/expert-parallelism/deepep-benchmark/deepep.Dockerfile
@@ -145,12 +145,13 @@ RUN CUDA_VER=$(nvcc --version | grep -oP 'release \K[0-9]+\.[0-9]+' | tr -d '.')
 ARG DEEPEP_PREFIX="/DeepEP"
 
 RUN --mount=type=bind,source=setup_deepep_efa.sh,target=/tmp/setup_deepep_efa.sh \
-    ./tmp/setup_deepep_efa.sh --deepep-prefix "${DEEPEP_PREFIX}" && \
+    /tmp/setup_deepep_efa.sh --deepep-prefix "${DEEPEP_PREFIX}" && \
     pip3 uninstall -y nvidia-nvshmem-cu13 nvidia-nvshmem-cu12 nvidia-nvshmem
 
 ENV LD_LIBRARY_PATH="/opt/amazon/nvshmem/lib:${LD_LIBRARY_PATH}"
 ENV PATH="/opt/amazon/nvshmem/bin:${PATH}"
 
+ENV FI_PROVIDER=efa
 ENV NVSHMEM_REMOTE_TRANSPORT=libfabric
 ENV NVSHMEM_LIBFABRIC_PROVIDER=efa
 ENV NVSHMEM_NETDEVS_POLICY=EXTERNAL_SHARING_PCIE_SWITCH_NIC_EXCLUSIVE

--- a/micro-benchmarks/expert-parallelism/deepep-benchmark/deepep.Dockerfile
+++ b/micro-benchmarks/expert-parallelism/deepep-benchmark/deepep.Dockerfile
@@ -10,12 +10,7 @@ ARG GDRCOPY_VERSION=v2.5.2
 ARG EFA_INSTALLER_VERSION=1.48.0
 ARG NCCL_VERSION=v2.30.4-1
 ARG NCCL_TESTS_VERSION=v2.18.3
-ARG NVSHMEM_VERSION=3.7.0
 ARG TORCH_VERSION=2.11.0
-# NOTE: deepep_aws_efa.patch is generated against this exact commit. If you bump
-# DEEPEP_COMMIT, regenerate the patch too -- `git apply` is exact and the build
-# will fail on a mismatch.
-ARG DEEPEP_COMMIT=567632d
 
 # CUDA architecture(s), semicolon-separated:
 # 9.0 = Hopper (H100, sm_90), 10.0 and 10.3 = Blackwell (B200/B300, sm_100,sm_103). Defaults to
@@ -126,27 +121,6 @@ RUN git clone -b ${NCCL_TESTS_VERSION} https://github.com/NVIDIA/nccl-tests.git 
     CUDA_HOME="${CUDA_HOME}" \
     NCCL_HOME=/opt/nccl/build
 
-###################################################
-## Install NVSHMEM
-ARG NVSHMEM_PREFIX="/opt/nvshmem"
-ARG LIBFABRIC_HOME="/opt/amazon/efa"
-
-RUN CUDA_VERSION_MAJOR=$(nvcc --version | grep -oP 'release \K[0-9]+') && \
-    if [ "${TARGETARCH}" = "arm64" ]; then NVSHMEM_ARCH="linux-sbsa"; else NVSHMEM_ARCH="linux-x86_64"; fi && \
-    NVSHMEM_ARCHIVE="libnvshmem-${NVSHMEM_ARCH}-${NVSHMEM_VERSION}_cuda${CUDA_VERSION_MAJOR}-archive.tar.xz" && \
-    NVSHMEM_DOWNLOAD_URL="https://developer.download.nvidia.com/compute/nvshmem/redist/libnvshmem/${NVSHMEM_ARCH}/${NVSHMEM_ARCHIVE}" && \
-    curl -fSL "${NVSHMEM_DOWNLOAD_URL}" -o "/tmp/${NVSHMEM_ARCHIVE}" && \
-    mkdir -p "$NVSHMEM_PREFIX" && \
-    tar -xf "/tmp/${NVSHMEM_ARCHIVE}" --strip-components=1 -C "$NVSHMEM_PREFIX" && \
-    rm "/tmp/${NVSHMEM_ARCHIVE}"
-
-ENV LD_LIBRARY_PATH="${NVSHMEM_PREFIX}/lib:${LD_LIBRARY_PATH}"
-ENV PATH="${NVSHMEM_PREFIX}/bin:${PATH}"
-
-ENV NVSHMEM_REMOTE_TRANSPORT=libfabric
-ENV NVSHMEM_LIBFABRIC_PROVIDER=efa
-ENV NVSHMEM_NETDEVS_POLICY=EXTERNAL_SHARING_PCIE_SWITCH_NIC_EXCLUSIVE
-
 RUN rm -rf /var/lib/apt/lists/*
 
 ## Set Open MPI variables to exclude network interface and conduit.
@@ -165,24 +139,20 @@ ENV LD_PRELOAD=/opt/nccl/build/lib/libnccl.so
 ################################ PyTorch ########################################
 RUN CUDA_VER=$(nvcc --version | grep -oP 'release \K[0-9]+\.[0-9]+' | tr -d '.') && \
     CUDA_MAJOR=$(nvcc --version | grep -oP 'release \K[0-9]+') && \
-    pip3 install torch==${TORCH_VERSION} numpy --index-url https://download.pytorch.org/whl/cu${CUDA_VER} && \
-    pip3 uninstall -y nvidia-nvshmem-cu${CUDA_MAJOR}
+    pip3 install torch==${TORCH_VERSION} numpy --index-url https://download.pytorch.org/whl/cu${CUDA_VER}
 
-################################ DeepEP ########################################
+################################ DeepEP & NVSHMEM ########################################
 ARG DEEPEP_PREFIX="/DeepEP"
 
-RUN --mount=type=bind,source=deepep_aws_efa.patch,target=/tmp/deepep_aws/deepep_aws_efa.patch \
-    if [ "${TORCH_CUDA_ARCH_LIST}" = "9.0" ]; then DISABLE_AGGRESSIVE_PTX_INSTRS=0; else DISABLE_AGGRESSIVE_PTX_INSTRS=1; fi && \
-    export DISABLE_AGGRESSIVE_PTX_INSTRS && \
-    git clone https://github.com/deepseek-ai/DeepEP.git ${DEEPEP_PREFIX} && \
-    cd ${DEEPEP_PREFIX} && \
-    git checkout ${DEEPEP_COMMIT} && \
-    git apply --check /tmp/deepep_aws/deepep_aws_efa.patch && \
-    git apply /tmp/deepep_aws/deepep_aws_efa.patch && \
-    CUDA_VERSION_MAJOR=$(nvcc --version | grep -oP 'release \K[0-9]+') && \
-    if [ "${CUDA_VERSION_MAJOR}" -ge 13 ]; then \
-        sed -i "s|f'{nvshmem_dir}/include']|f'{nvshmem_dir}/include', '${CUDA_HOME}/include/cccl']|" "setup.py"; \
-    fi && \
-    NVSHMEM_DIR="${NVSHMEM_PREFIX}" pip3 install -vv --no-build-isolation .
+RUN --mount=type=bind,source=setup_deepep_efa.sh,target=/tmp/setup_deepep_efa.sh \
+    ./tmp/setup_deepep_efa.sh --deepep-prefix "${DEEPEP_PREFIX}" && \
+    pip3 uninstall -y nvidia-nvshmem-cu13 nvidia-nvshmem-cu12 nvidia-nvshmem
+
+ENV LD_LIBRARY_PATH="/opt/amazon/nvshmem/lib:${LD_LIBRARY_PATH}"
+ENV PATH="/opt/amazon/nvshmem/bin:${PATH}"
+
+ENV NVSHMEM_REMOTE_TRANSPORT=libfabric
+ENV NVSHMEM_LIBFABRIC_PROVIDER=efa
+ENV NVSHMEM_NETDEVS_POLICY=EXTERNAL_SHARING_PCIE_SWITCH_NIC_EXCLUSIVE
 
 ENV NVIDIA_GDRCOPY="enabled"

--- a/micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh
+++ b/micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh
@@ -1,3 +1,500 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+set -euo pipefail
+
+log() {
+    printf '%s\n' "$*" >&2
+}
+
+warn() {
+    printf 'WARNING: %s\n' "$*" >&2
+}
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2 || true
+    exit 1
+}
+
+PROG_NAME="${0##*/}"
+if [[ -z "$PROG_NAME" || "$PROG_NAME" == "bash" || "$PROG_NAME" == "-bash" ]]; then
+    PROG_NAME="setup_deepep_efa.sh"
+fi
+
+print_help() {
+    cat <<EOF
+Usage: ${PROG_NAME} [options]
+
+Install NVSHMEM and build DeepEP for AWS EFA (libfabric).
+
+With no arguments, downloads a prebuilt NVSHMEM release, clones DeepEP at the
+only supported commit, applies the embedded AWS EFA patch, and installs DeepEP
+into the active Python environment.
+
+Options:
+  --nvshmem-version <v>     NVSHMEM version to download, MAJOR.MINOR.PATCH form
+                            (default: 3.7.0)
+  --nvshmem-prefix <path>   NVSHMEM install location
+                            (default: /opt/amazon/nvshmem)
+  --nvshmem-src <path>      Build NVSHMEM from this existing source tree instead
+                            of downloading the prebuilt release
+                            (default: unset; download prebuilt)
+  --deepep-commit <sha>     DeepEP commit to checkout, 7-40 hex chars
+                            (default: 567632d)
+  --deepep-prefix <path>    DeepEP clone/build location
+                            (default: /opt/amazon/deepep)
+  --deepep-src <path>       Build DeepEP from this existing source tree instead
+                            of cloning from GitHub
+                            (default: unset; clone from GitHub)
+  --wheel-only              Build a DeepEP wheel but do not install it
+                            (default: off; install into the active environment)
+  --wheel-output-dir <path> Directory to write the DeepEP wheel into
+                            (default: /opt/amazon/wheels)
+  --libfabric-home <path>   Libfabric install dir (NVSHMEM source build only)
+                            (default: /opt/amazon/efa)
+  --gdrcopy-home <path>     GDRCopy install dir (NVSHMEM source build only)
+                            (default: /usr)
+  --cuda-home <path>        CUDA toolkit directory
+                            (default: /usr/local/cuda)
+  --gen-ldconfig            Write /etc/ld.so.conf.d/nvshmem.conf and refresh the
+                            dynamic linker cache (default: off)
+  --python <cmd|path>       Python interpreter command or absolute path
+                            (default: python3)
+  --pip <cmd|path>          pip command or absolute path
+                            (default: pip3)
+  --force                   Skip the DeepEP commit-compatibility check and build
+                            at your own risk (default: off)
+  --skip-checks             Skip Python prerequisite validation (torch, pip,
+                            ninja checks) (default: off)
+  -h, --help                Print this usage information and exit
+
+Environment:
+  TORCH_CUDA_ARCH_LIST      GPU architectures, dotted and ;-separated
+                            (default: 9.0;10.0)
+EOF
+    exit 0
+}
+
+parse_args() {
+    NVSHMEM_VERSION="3.7.0"
+    NVSHMEM_PREFIX="/opt/amazon/nvshmem"
+    NVSHMEM_SRC=""
+    DEEPEP_COMMIT="567632d"
+    DEEPEP_PREFIX="/opt/amazon/deepep"
+    DEEPEP_SRC=""
+    WHEEL_ONLY="false"
+    WHEEL_OUTPUT_DIR="/opt/amazon/wheels"
+    LIBFABRIC_HOME="/opt/amazon/efa"
+    GDRCOPY_HOME="/usr"
+    CUDA_HOME="/usr/local/cuda"
+    GEN_LDCONFIG="false"
+    FORCE="false"
+    SKIP_CHECKS="false"
+    PYTHON_CMD="python3"
+    PIP_CMD="pip3"
+    TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST-9.0;10.0}"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --nvshmem-version)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                NVSHMEM_VERSION="$2"; shift 2 ;;
+            --nvshmem-prefix)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                NVSHMEM_PREFIX="$2"; shift 2 ;;
+            --nvshmem-src)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                NVSHMEM_SRC="$2"; shift 2 ;;
+            --deepep-commit)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                DEEPEP_COMMIT="$2"; shift 2 ;;
+            --deepep-prefix)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                DEEPEP_PREFIX="$2"; shift 2 ;;
+            --deepep-src)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                DEEPEP_SRC="$2"; shift 2 ;;
+            --wheel-only)
+                WHEEL_ONLY="true"; shift ;;
+            --wheel-output-dir)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                WHEEL_OUTPUT_DIR="$2"; shift 2 ;;
+            --libfabric-home)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                LIBFABRIC_HOME="$2"; shift 2 ;;
+            --gdrcopy-home)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                GDRCOPY_HOME="$2"; shift 2 ;;
+            --cuda-home)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                CUDA_HOME="$2"; shift 2 ;;
+            --python)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                PYTHON_CMD="$2"; shift 2 ;;
+            --pip)
+                [[ $# -ge 2 ]] || die "option '$1' requires a value"
+                PIP_CMD="$2"; shift 2 ;;
+            --gen-ldconfig)
+                GEN_LDCONFIG="true"; shift ;;
+            --force)
+                FORCE="true"; shift ;;
+            --skip-checks)
+                SKIP_CHECKS="true"; shift ;;
+            -h|--help)
+                print_help ;;
+            *)
+                die "unrecognized argument: '$1'" ;;
+        esac
+    done
+}
+
+validate_version() {
+    local version="$1"
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        die "invalid NVSHMEM version: '$version' (expected MAJOR.MINOR.PATCH, e.g. 3.7.0)"
+    fi
+}
+
+validate_commit() {
+    local commit="$1"
+    if [[ ! "$commit" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+        die "invalid DeepEP commit: '$commit' (expected 7-40 hexadecimal characters)"
+    fi
+}
+
+validate_arch_list() {
+    local arch_list="$1"
+    if [[ ! "$arch_list" =~ ^[0-9]+\.[0-9]+(;[0-9]+\.[0-9]+)*$ ]]; then
+        die "invalid TORCH_CUDA_ARCH_LIST: '$arch_list' (expected non-empty, dotted, ;-separated architectures, e.g. 9.0;10.0)"
+    fi
+}
+
+compute_disable_ptx() {
+    local arch_list="${1-${TORCH_CUDA_ARCH_LIST:-}}"
+    if [[ "$arch_list" == "9.0" ]]; then
+        printf '0\n'
+    else
+        printf '1\n'
+    fi
+}
+
+arch_list_to_cmake() {
+    local arch_list="${1-${TORCH_CUDA_ARCH_LIST:-}}"
+    local out="" entry first=1
+    local IFS=';'
+    for entry in $arch_list; do
+        if (( first )); then
+            first=0
+        else
+            out+=";"
+        fi
+        out+="${entry/./}"
+    done
+    printf '%s\n' "$out"
+}
+
+detect_arch() {
+    local machine
+    machine="$(uname -m)"
+
+    case "$machine" in
+        aarch64|arm64)
+            ARCH_KEY="linux-sbsa"
+            ;;
+        x86_64)
+            ARCH_KEY="linux-x86_64"
+            ;;
+        *)
+            die "unsupported architecture: '$machine' (expected aarch64, arm64, or x86_64)"
+            ;;
+    esac
+
+    case "$machine" in
+        aarch64|arm64)
+            if [[ "$ARCH_KEY" != "linux-sbsa" ]]; then
+                die "architecture mismatch: host is '$machine' but selected key is '$ARCH_KEY' (expected linux-sbsa)"
+            fi
+            ;;
+        x86_64)
+            if [[ "$ARCH_KEY" != "linux-x86_64" ]]; then
+                die "architecture mismatch: host is '$machine' but selected key is '$ARCH_KEY' (expected linux-x86_64)"
+            fi
+            ;;
+    esac
+
+    log "Detected arch: $ARCH_KEY"
+    printf '%s\n' "$ARCH_KEY"
+}
+
+detect_cuda_major() {
+    local nvcc_path=""
+
+    if command -v nvcc >/dev/null 2>&1; then
+        nvcc_path="$(command -v nvcc)"
+    elif [[ -n "${CUDA_HOME:-}" && -x "${CUDA_HOME}/bin/nvcc" ]]; then
+        nvcc_path="${CUDA_HOME}/bin/nvcc"
+    else
+        die "cannot find nvcc: not on PATH and not at \${CUDA_HOME}/bin/nvcc (is the CUDA toolkit installed?)"
+    fi
+
+    local version_output major
+    version_output="$("$nvcc_path" --version 2>/dev/null)" || \
+        die "failed to run '$nvcc_path --version'"
+
+    major="$(printf '%s\n' "$version_output" | \
+        sed -n 's/.*release \([0-9][0-9]*\)\..*/\1/p')"
+
+    if [[ -z "$major" ]]; then
+        die "unable to parse CUDA major version from nvcc output"
+    fi
+
+    CUDA_MAJOR="$major"
+    log "Detected CUDA major version: $CUDA_MAJOR"
+    printf '%s\n' "$CUDA_MAJOR"
+}
+
+check_python_prereqs() {
+    # Validate that PYTHON_CMD and PIP_CMD are resolvable before checking prereqs.
+    local python_cmd="${PYTHON_CMD:-python3}"
+    local pip_cmd="${PIP_CMD:-pip3}"
+
+    if [[ "$python_cmd" == /* ]]; then
+        [[ -x "$python_cmd" ]] || die "python command not found: '$python_cmd' is not an executable file"
+    else
+        command -v "$python_cmd" >/dev/null 2>&1 || die "python command not found: '$python_cmd' is not on PATH"
+    fi
+
+    if [[ "$pip_cmd" == /* ]]; then
+        [[ -x "$pip_cmd" ]] || die "pip command not found: '$pip_cmd' is not an executable file"
+    else
+        command -v "$pip_cmd" >/dev/null 2>&1 || die "pip command not found: '$pip_cmd' is not on PATH"
+    fi
+
+    local missing=()
+
+    if ! command -v "$python_cmd" >/dev/null 2>&1; then
+        missing+=("$python_cmd")
+    else
+        if ! "$python_cmd" -c "import torch" >/dev/null 2>&1; then
+            missing+=("torch (Python module)")
+        fi
+        if ! "$python_cmd" -m pip --version >/dev/null 2>&1; then
+            missing+=("pip")
+        fi
+    fi
+
+    if ! command -v ninja >/dev/null 2>&1; then
+        missing+=("ninja")
+    fi
+
+    if (( ${#missing[@]} > 0 )); then
+        local IFS=', '
+        die "missing prerequisites: ${missing[*]} (install them before running this script)"
+    fi
+
+    return 0
+}
+
+download_with_retry() {
+    local url="$1"
+    local dest="$2"
+    local max_attempts=3
+    local attempt
+
+    for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
+        if command -v curl >/dev/null 2>&1; then
+            if curl -fsSL -o "$dest" "$url"; then
+                return 0
+            fi
+        elif command -v wget >/dev/null 2>&1; then
+            if wget -q -O "$dest" "$url"; then
+                return 0
+            fi
+        else
+            die "Neither curl nor wget is available; cannot download ${url}"
+        fi
+
+        if (( attempt < max_attempts )); then
+            log "Download attempt ${attempt}/${max_attempts} failed for ${url}; retrying in 2s..."
+            sleep 2
+        fi
+    done
+
+    die "Failed to download ${url} after ${max_attempts} attempts"
+}
+
+verify_sha256() {
+    local file="$1"
+    local expected="$2"
+    local actual
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum "$file" | awk '{print $1}')"
+    elif command -v shasum >/dev/null 2>&1; then
+        actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+    else
+        die "Neither sha256sum nor shasum is available; cannot verify integrity of ${file}"
+    fi
+
+    if [[ "$actual" != "$expected" ]]; then
+        die "SHA256 mismatch for ${file}: expected=${expected}, actual=${actual}"
+    fi
+}
+
+readonly NVSHMEM_REDIST_ROOT="https://developer.download.nvidia.com/compute/nvshmem/redist/"
+
+resolve_nvshmem_archive() {
+    local manifest_url="${NVSHMEM_REDIST_ROOT}redistrib_${NVSHMEM_VERSION}.json"
+    local manifest_tmp
+    manifest_tmp="$(mktemp)"
+
+    download_with_retry "$manifest_url" "$manifest_tmp"
+
+    local parsed
+    if ! parsed="$("$PYTHON_CMD" - "$manifest_tmp" "$ARCH_KEY" "$CUDA_MAJOR" <<'PY'
+import json, sys
+manifest, arch_key, major = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(manifest) as f:
+    data = json.load(f)
+obj = data["libnvshmem"][arch_key]["cuda" + major]
+print(obj["relative_path"], obj["sha256"])
+PY
+    )"; then
+        rm -f "$manifest_tmp"
+        die "NVSHMEM manifest does not contain an entry for arch='${ARCH_KEY}', cuda='${CUDA_MAJOR}' (version ${NVSHMEM_VERSION})"
+    fi
+
+    rm -f "$manifest_tmp"
+    read -r NVSHMEM_REL_PATH NVSHMEM_SHA256 <<< "$parsed"
+}
+
+install_prebuilt_nvshmem() {
+    log "Installing prebuilt NVSHMEM ${NVSHMEM_VERSION} for ${ARCH_KEY}/cuda${CUDA_MAJOR}..."
+
+    resolve_nvshmem_archive
+
+    local archive_url="${NVSHMEM_REDIST_ROOT}${NVSHMEM_REL_PATH}"
+    local archive_tmp
+    archive_tmp="$(mktemp)"
+
+    download_with_retry "$archive_url" "$archive_tmp"
+    verify_sha256 "$archive_tmp" "$NVSHMEM_SHA256"
+
+    mkdir -p "$NVSHMEM_PREFIX"
+    tar -xf "$archive_tmp" --strip-components=1 -C "$NVSHMEM_PREFIX"
+    rm -f "$archive_tmp"
+
+    log "Prebuilt NVSHMEM ${NVSHMEM_VERSION} installed to ${NVSHMEM_PREFIX}"
+}
+
+build_nvshmem_from_source() {
+    if [[ ! -d "$NVSHMEM_SRC" ]]; then
+        die "NVSHMEM source path does not exist or is not a directory: '$NVSHMEM_SRC'"
+    fi
+    if [[ ! -f "$NVSHMEM_SRC/CMakeLists.txt" ]]; then
+        die "NVSHMEM source path does not contain CMakeLists.txt: '$NVSHMEM_SRC' does not look like an NVSHMEM source tree"
+    fi
+    if [[ ! -d "$LIBFABRIC_HOME" ]]; then
+        die "libfabric not found at LIBFABRIC_HOME: '$LIBFABRIC_HOME' does not exist or is not a directory"
+    fi
+
+    log "Building NVSHMEM from source at ${NVSHMEM_SRC}..."
+
+    local cmake_archs
+    cmake_archs="$(arch_list_to_cmake)"
+
+    local build_dir="${NVSHMEM_SRC}/build"
+    rm -rf "$build_dir"
+    mkdir -p "$build_dir"
+
+    cmake -S "$NVSHMEM_SRC" -B "$build_dir" \
+        -DCMAKE_INSTALL_PREFIX="$NVSHMEM_PREFIX" \
+        -DCUDA_HOME="$CUDA_HOME" \
+        -DLIBFABRIC_HOME="$LIBFABRIC_HOME" \
+        -DNVSHMEM_LIBFABRIC_SUPPORT=ON \
+        -DNVSHMEM_MPI_SUPPORT=OFF \
+        -DNVSHMEM_IBRC_SUPPORT=OFF \
+        -DNVSHMEM_IBGDA_SUPPORT=OFF \
+        -DNVSHMEM_IBDEVX_SUPPORT=OFF \
+        -DNVSHMEM_UCX_SUPPORT=OFF \
+        -DNVSHMEM_SHMEM_SUPPORT=OFF \
+        -DNVSHMEM_PMIX_SUPPORT=OFF \
+        -DNVSHMEM_USE_NCCL=OFF \
+        -DNVSHMEM_USE_GDRCOPY=ON \
+        -DGDRCOPY_HOME="$GDRCOPY_HOME" \
+        -DNVSHMEM_USE_MLX5DV=OFF \
+        -DNVSHMEM_BUILD_TESTS=OFF \
+        -DNVSHMEM_BUILD_EXAMPLES=OFF \
+        -DNVSHMEM_BUILD_PYTHON_LIB=OFF \
+        -DNVSHMEM_BUILD_BITCODE_LIBRARY=OFF \
+        -DCMAKE_CUDA_ARCHITECTURES="$cmake_archs" \
+        || die "NVSHMEM CMake configure failed"
+
+    make -C "$build_dir" -j"$(nproc)" \
+        || die "NVSHMEM build (make) failed"
+
+    make -C "$build_dir" install \
+        || die "NVSHMEM install (make install) failed"
+
+    log "NVSHMEM built from source and installed to ${NVSHMEM_PREFIX}"
+}
+
+acquire_deepep() {
+    if [[ -z "${DEEPEP_SRC:-}" ]]; then
+        log "Cloning DeepEP into ${DEEPEP_PREFIX} at commit ${DEEPEP_COMMIT}..."
+
+        rm -rf "$DEEPEP_PREFIX"
+        mkdir -p "$(dirname "$DEEPEP_PREFIX")"
+
+        git clone https://github.com/deepseek-ai/DeepEP "$DEEPEP_PREFIX" \
+            || die "failed to clone DeepEP from https://github.com/deepseek-ai/DeepEP"
+
+        git -C "$DEEPEP_PREFIX" checkout "$DEEPEP_COMMIT" \
+            || die "failed to checkout DeepEP commit '${DEEPEP_COMMIT}'"
+
+        log "DeepEP cloned and checked out at commit ${DEEPEP_COMMIT}"
+    else
+        log "Using existing DeepEP source tree at ${DEEPEP_SRC}..."
+
+        if [[ ! -d "$DEEPEP_SRC" ]]; then
+            die "DeepEP source path does not exist or is not a directory: '${DEEPEP_SRC}'"
+        fi
+
+        if [[ ! -f "$DEEPEP_SRC/csrc/kernels/internode.cu" ]]; then
+            die "DeepEP source path does not contain csrc/kernels/internode.cu: '${DEEPEP_SRC}' does not look like a valid DeepEP source tree"
+        fi
+
+        DEEPEP_PREFIX="$DEEPEP_SRC"
+        log "DeepEP source tree validated at ${DEEPEP_SRC}"
+    fi
+}
+
+readonly DEEPEP_SUPPORTED_COMMIT="567632d"
+
+commit_compat_gate() {
+    if [[ "$DEEPEP_COMMIT" == "$DEEPEP_SUPPORTED_COMMIT" ]]; then
+        log "DeepEP commit ${DEEPEP_COMMIT} matches the supported commit"
+        return 0
+    fi
+
+    if [[ "$FORCE" != "true" ]]; then
+        die "DeepEP commit '${DEEPEP_COMMIT}' is not supported; the only supported commit is ${DEEPEP_SUPPORTED_COMMIT}. Use --force to override at your own risk."
+    fi
+
+    warn "DeepEP commit '${DEEPEP_COMMIT}' differs from the supported commit ${DEEPEP_SUPPORTED_COMMIT}; proceeding at your own risk (--force)"
+    return 0
+}
+
+apply_efa_patch() {
+    cd "$DEEPEP_PREFIX"
+
+    log "Applying EFA patch to DeepEP at ${DEEPEP_PREFIX}..."
+
+    local efa_patch
+    efa_patch="$(mktemp -t deepep-efa.XXXXXX.patch)"
+
+    cat > "$efa_patch" << 'PATCHEOF'
 diff --git a/csrc/kernels/ibgda_device.cuh b/csrc/kernels/ibgda_device.cuh
 index 421ec2a..b3473db 100644
 --- a/csrc/kernels/ibgda_device.cuh
@@ -701,3 +1198,166 @@ index 37512ee..b29ff63 100644
              # Disable NVLink SHArP
              os.environ['NVSHMEM_DISABLE_NVLS'] = '1'
              # NOTES: NVSHMEM initialization requires at least 256 MiB
+
+PATCHEOF
+
+    if ! git apply --check "$efa_patch" 2>/dev/null; then
+        rm -f "$efa_patch"
+        die "EFA patch does not apply cleanly; the patch was validated against commit ${DEEPEP_SUPPORTED_COMMIT}. Is the tree at that commit?"
+    fi
+
+    git apply "$efa_patch"
+    rm -f "$efa_patch"
+
+    log "EFA patch applied successfully (4 files patched atomically)"
+}
+
+apply_cuda13_cccl_fix() {
+    if (( CUDA_MAJOR < 13 )); then
+        log "CUDA major ${CUDA_MAJOR} < 13; skipping cccl include fix"
+        return 0
+    fi
+
+    local setup_py="${DEEPEP_PREFIX}/setup.py"
+
+    if [[ ! -f "$setup_py" ]]; then
+        die "cannot apply CUDA 13 cccl fix: setup.py not found at '${setup_py}'"
+    fi
+
+    if grep -q "include/cccl" "$setup_py"; then
+        log "CUDA 13 cccl include path already present in setup.py; skipping (idempotent)"
+        return 0
+    fi
+
+    local target_pattern="f'{nvshmem_dir}/include']"
+
+    if ! grep -q "$target_pattern" "$setup_py"; then
+        die "cannot apply CUDA 13 cccl fix: target include-list pattern not found in ${setup_py} (expected line containing: ${target_pattern})"
+    fi
+
+    sed -i'' -e "s|f'{nvshmem_dir}/include']|f'{nvshmem_dir}/include', '${CUDA_HOME}/include/cccl']|" "$setup_py"
+
+    log "Applied CUDA 13 cccl include fix to ${setup_py} (added ${CUDA_HOME}/include/cccl)"
+}
+
+warn_nvshmem_pip_conflict() {
+    local pkg="nvidia-nvshmem-cu${CUDA_MAJOR}"
+
+    if "$PIP_CMD" show "$pkg" >/dev/null 2>&1; then
+        warn "pip package '${pkg}' is installed and conflicts with the standalone NVSHMEM library at Python runtime. Please remove it manually: $PIP_CMD uninstall ${pkg}"
+    fi
+}
+
+build_deepep() {
+    warn_nvshmem_pip_conflict
+
+    local disable_ptx
+    disable_ptx="$(compute_disable_ptx)"
+
+    export LD_LIBRARY_PATH="${NVSHMEM_PREFIX}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+    if [[ "$WHEEL_ONLY" == "true" ]]; then
+        log "Building DeepEP wheel (wheel-only mode)..."
+
+        mkdir -p "$WHEEL_OUTPUT_DIR" \
+            || die "failed to create wheel output directory: '${WHEEL_OUTPUT_DIR}'"
+
+        cd "$DEEPEP_PREFIX"
+        DISABLE_AGGRESSIVE_PTX_INSTRS="$disable_ptx" \
+        TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
+        NVSHMEM_DIR="$NVSHMEM_PREFIX" \
+            "$PIP_CMD" wheel -vv --no-build-isolation --wheel-dir "$WHEEL_OUTPUT_DIR" . \
+            || die "DeepEP wheel build failed"
+
+        local wheel_file
+        wheel_file="$(find "$WHEEL_OUTPUT_DIR" -maxdepth 1 -name '*.whl' -type f | sort | tail -n1)"
+        if [[ -z "$wheel_file" ]]; then
+            die "DeepEP wheel build completed but no .whl file found in '${WHEEL_OUTPUT_DIR}'"
+        fi
+
+        printf '%s\n' "$wheel_file"
+        log "DeepEP wheel written to ${wheel_file}"
+    else
+        log "Building and installing DeepEP (install mode)..."
+
+        "$PIP_CMD" uninstall -y deep_ep 2>/dev/null || true
+
+        cd "$DEEPEP_PREFIX"
+        DISABLE_AGGRESSIVE_PTX_INSTRS="$disable_ptx" \
+        TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
+        NVSHMEM_DIR="$NVSHMEM_PREFIX" \
+            "$PIP_CMD" install -vv --no-build-isolation . \
+            || die "DeepEP build/install failed"
+
+        log "DeepEP installed successfully"
+    fi
+}
+
+print_completion_notes() {
+    if [[ "$GEN_LDCONFIG" == "true" ]]; then
+        local ldconfig_file="/etc/ld.so.conf.d/nvshmem.conf"
+        local lib_path="${NVSHMEM_PREFIX}/lib"
+
+        if ! printf '%s\n' "$lib_path" > "$ldconfig_file" 2>/dev/null; then
+            die "insufficient permissions to write ${ldconfig_file}; elevated privileges are required for --gen-ldconfig"
+        fi
+
+        if ldconfig 2>/dev/null; then
+            log "Wrote ${ldconfig_file} and refreshed the linker cache successfully"
+        else
+            die "wrote ${ldconfig_file} but failed to refresh the linker cache (ldconfig); elevated privileges may be required"
+        fi
+    fi
+
+    log ""
+    log "=== DeepEP setup complete ==="
+    log ""
+    log "To use DeepEP at runtime, configure the following environment variables:"
+    log ""
+    log "  export LD_LIBRARY_PATH=${NVSHMEM_PREFIX}/lib:\${LD_LIBRARY_PATH}"
+    log "  export PATH=${NVSHMEM_PREFIX}/bin:\${PATH}"
+    log ""
+    log "  export NVSHMEM_REMOTE_TRANSPORT=libfabric"
+    log "  export NVSHMEM_LIBFABRIC_PROVIDER=efa"
+    log "  export NVSHMEM_NETDEVS_POLICY=EXTERNAL_SHARING_PCIE_SWITCH_NIC_EXCLUSIVE"
+    log ""
+    log "NOTE: If the nvidia-nvshmem-cu${CUDA_MAJOR} Python package is installed in your environment,"
+    log "      you must uninstall it to avoid conflicts with the standalone NVSHMEM library at Python runtime"
+    log "      built by this script:"
+    log ""
+    log "  $PIP_CMD uninstall -y nvidia-nvshmem-cu${CUDA_MAJOR}"
+    log ""
+}
+
+main() {
+    parse_args "$@"
+
+    if [[ -z "${NVSHMEM_SRC}" ]]; then
+        validate_version "$NVSHMEM_VERSION"
+    fi
+    validate_commit "$DEEPEP_COMMIT"
+    validate_arch_list "$TORCH_CUDA_ARCH_LIST"
+
+    detect_arch
+    detect_cuda_major
+    if [[ "$SKIP_CHECKS" != "true" ]]; then
+        check_python_prereqs
+    fi
+
+    if [[ -n "${NVSHMEM_SRC}" ]]; then
+        build_nvshmem_from_source
+    else
+        install_prebuilt_nvshmem
+    fi
+
+    acquire_deepep
+    commit_compat_gate
+    apply_efa_patch
+    apply_cuda13_cccl_fix
+    build_deepep
+    print_completion_notes
+}
+
+if [[ "${SETUP_DEEPEP_EFA_LIB:-}" != "1" ]]; then
+    main "$@"
+fi

--- a/micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh
+++ b/micro-benchmarks/expert-parallelism/deepep-benchmark/setup_deepep_efa.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
+# Build DeepEP with NVSHMEM EFA (libfabric) transport for AWS EFA clusters.
 
 set -euo pipefail
 
@@ -207,19 +208,6 @@ detect_arch() {
             ;;
         *)
             die "unsupported architecture: '$machine' (expected aarch64, arm64, or x86_64)"
-            ;;
-    esac
-
-    case "$machine" in
-        aarch64|arm64)
-            if [[ "$ARCH_KEY" != "linux-sbsa" ]]; then
-                die "architecture mismatch: host is '$machine' but selected key is '$ARCH_KEY' (expected linux-sbsa)"
-            fi
-            ;;
-        x86_64)
-            if [[ "$ARCH_KEY" != "linux-x86_64" ]]; then
-                die "architecture mismatch: host is '$machine' but selected key is '$ARCH_KEY' (expected linux-x86_64)"
-            fi
             ;;
     esac
 


### PR DESCRIPTION
## Purpose

<!-- Link related issues using "Fixes #123" or "Relates to #123" -->

The script simplify installation of DeepEP on EFA by
1. Installing NVSHMEM from NVIDIA upstream
2. Cloning DeepEP at pre-v2 commit
3. Patching DeepEP to work with AWS EFA and NVHSMEM 3.7
4. Installing DeepEP

## Changes

<!-- Summarize the changes made in this PR -->

- Removed patch
- Removed NVSHMEM installation step
- Added the `setup_deepep_efa.sh` script to simplify installation.

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service: EKS
- Instance type: p6-b200.48xlarge
- Number of nodes: 2

**Test commands:**
```bash
export IMAGE_URI=<HIDDEN>
export INSTANCE_TYPE=p6-b200.48xlarge
export GPU_PER_NODE=8
export EFA_PER_NODE=8
export NUM_NODES=2

envsubst '$IMAGE_URI $INSTANCE_TYPE $GPU_PER_NODE $EFA_PER_NODE' < test-intranode.yaml | kubectl apply -f -
envsubst '$IMAGE_URI $INSTANCE_TYPE $GPU_PER_NODE $EFA_PER_NODE' < test-intranode.yaml | kubectl delete -f -

envsubst '$IMAGE_URI $INSTANCE_TYPE $GPU_PER_NODE $EFA_PER_NODE $NUM_NODES' < test-low-latency.yaml | kubectl apply -f -
envsubst '$IMAGE_URI $INSTANCE_TYPE $GPU_PER_NODE $EFA_PER_NODE $NUM_NODES' < test-low-latency.yaml | kubectl delete -f -

envsubst '$IMAGE_URI $INSTANCE_TYPE $GPU_PER_NODE $EFA_PER_NODE $NUM_NODES' < test-internode.yaml | kubectl apply -f -
envsubst '$IMAGE_URI $INSTANCE_TYPE $GPU_PER_NODE $EFA_PER_NODE $NUM_NODES' < test-internode.yaml | kubectl delete -f -
```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
5.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
