### PR TITLE
fix(hyperpod-slurm-tf): allow training plans per instance group

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/hyperpod_cluster/main.tf
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/hyperpod_cluster/main.tf
@@ -40,12 +40,6 @@ locals {
       } : {}
     )
   ]
-
-  # Optional safety check: allow at most one instance group to carry a training plan ARN
-  training_plan_groups = [
-    for ig in var.instance_groups : ig.name
-    if try(ig.training_plan_arn, null) != null
-  ]
 }
 
 resource "awscc_sagemaker_cluster" "hyperpod_cluster" {
@@ -66,11 +60,4 @@ resource "awscc_sagemaker_cluster" "hyperpod_cluster" {
       value = "${var.resource_name_prefix}-hyperpod-cluster"
     }
   ]
-
-  lifecycle {
-    precondition {
-      condition     = length(local.training_plan_groups) <= 1
-      error_message = "At most one instance group may include training_plan_arn. Found training_plan_arn in: ${join(", ", local.training_plan_groups)}"
-    }
-  }
 }


### PR DESCRIPTION
Removes the cluster-wide restriction that limited a HyperPod cluster to at most one `training_plan_arn`, enabling each instance group to carry its own training plan independently.

## Purpose

Removes the cluster-wide restriction that limited a HyperPod cluster to at most one `training_plan_arn`, enabling each instance group to carry its own training plan independently.

## Background

The `hyperpod_cluster` module already models `training_plan_arn` as an optional, per-instance-group attribute  (`optional(string)` in `variables.tf`), and the `instance_groups_list` local merges each group's ARN independently.

However, a `lifecycle.precondition` on `awscc_sagemaker_cluster.hyperpod_cluster` counted every group with a non-null `training_plan_arn` across the whole cluster and failed if that count exceeded 1
``` 
# Optional safety check: allow at most one instance group to carry a training plan ARN
  training_plan_groups = [
    for ig in var.instance_groups : ig.name
    if try(ig.training_plan_arn, null) != null
  ]
``` 
``` 
lifecycle {
    precondition {
      condition     = length(local.training_plan_groups) <= 1
      error_message = "At most one instance group may include training_plan_arn. Found training_plan_arn in: ${join(", ", local.training_plan_groups)}"
    }
```

##  Summarize the changes made in this PR 

``` 
Removed the training_plan_groups local (only used by the precondition).
Removed the lifecycle.precondition block enforcing <= 1 training plan.
``` 
-
## Share relevant metrics, logs, or screenshots 
``` 
The module initialized cleanly (providers awscc, aws, time resolved) and the edited main.tf validates without errors.
``` 
## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [x] New test cases follow the [expected directory structure](#directory-structure).
