### PR TITLE
chore: bump otel_collector image version to v1782332626135

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_otel_collector.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/observability/install_otel_collector.sh
@@ -7,7 +7,7 @@
 CONTAINER_NAME="otel-collector"
 
 ECR_ACCOUNT_ID=602401143452
-VERSION=v1754424030352
+VERSION=v1782332626135
 IMAGE="$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/hyperpod/otel_collector:${VERSION}"
 
 # Maximum number of retries


### PR DESCRIPTION
## Purpose

  Bump the HyperPod OTel collector image to include the `awsattributelimit` processor which enforces a 150-label cap on AMP metrics.

  ## Changes

  - Updated `otel_collector` image version from `v1754424030352` to `v1782332626135` in `install_otel_collector.sh`

  ## Test Plan

  **Environment:**
  - AWS Service: SageMaker HyperPod (EKS)
  - Instance type: EKS cluster (us-west-2)
  - Number of nodes: 4 (verified via node-exporter pod count)

  **Test commands:**
  ```bash
  # Created EKS cluster and deployed addon v1.0.7-eksbuild.1
  # Verified collector pods running with new image
  kubectl get pods -n hyperpod-observability -o wide
  kubectl describe pod hyperpod-observability-node-collector-85cjm -n hyperpod-observability

  # Injected test metrics via OTLP HTTP receiver
  kubectl port-forward hyperpod-observability-node-collector-85cjm 4318:4318 -n hyperpod-observability &
  python3 send_test_metrics.py

  # Queried AMP to verify label enforcement
  awscurl --service aps "https://<amp-endpoint>/api/v1/query?query=test_over_150_labels"

