### PR TITLE
fix(aws-pcs): stop needrestart from restarting slurmd and killing running jobs

### DIFF
--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -397,19 +397,21 @@ Resources:
             # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
             # auto-restarts every service linked against them. slurmd links libc, so it
             # gets restarted mid-upgrade - which KILLS the jobs running under it (the
-            # step is torn down and the job requeues from scratch). Exclude the Slurm
-            # daemons from needrestart's automatic restart so a security upgrade can
+            # step is torn down and the job requeues from scratch). Exclude slurmd
+            # from needrestart's automatic restart so a security upgrade can
             # never take down a running job. Security packages still install; only the
-            # slurmd/slurmctld/slurmdbd auto-restart is suppressed.
+            # slurmd auto-restart is suppressed. (PCS runs the controller managed-side;
+            # slurmd is the only Slurm systemd service on login/compute nodes. qr(^slurmd)
+            # also covers the versioned units, e.g. slurmd-25.11.)
             # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
             - |
               mkdir -p /etc/needrestart/conf.d
               cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
-              # AWS PCS: never auto-restart Slurm daemons - restarting slurmd kills
+              # AWS PCS: never auto-restart slurmd - restarting it kills
               # the jobs running under it. Managed by add-cng UserData.
-              $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+              $nrconf{override_rc} = { qr(^slurmd) => 0 };
               NRCONF
-              echo "needrestart: slurmd/slurmctld/slurmdbd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
+              echo "needrestart: slurmd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
             # Post-install script (optional) - generic OnNodeConfigured-style hook.
             # Downloads and runs a user-supplied script (e.g. Enroot/Pyxis install).
             - |

--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -393,6 +393,23 @@ Resources:
             MIME-Version: 1.0
 
             runcmd:
+            # --- Protect running jobs from unattended-upgrades / needrestart ---
+            # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
+            # auto-restarts every service linked against them. slurmd links libc, so it
+            # gets restarted mid-upgrade - which KILLS the jobs running under it (the
+            # step is torn down and the job requeues from scratch). Exclude the Slurm
+            # daemons from needrestart's automatic restart so a security upgrade can
+            # never take down a running job. Security packages still install; only the
+            # slurmd/slurmctld/slurmdbd auto-restart is suppressed.
+            # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
+            - |
+              mkdir -p /etc/needrestart/conf.d
+              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
+              # AWS PCS: never auto-restart Slurm daemons - restarting slurmd kills
+              # the jobs running under it. Managed by add-cng UserData.
+              $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+              NRCONF
+              echo "needrestart: slurmd/slurmctld/slurmdbd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
             # Post-install script (optional) - generic OnNodeConfigured-style hook.
             # Downloads and runs a user-supplied script (e.g. Enroot/Pyxis install).
             - |

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -384,19 +384,21 @@ Resources:
             # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
             # auto-restarts every service linked against them. slurmd links libc, so it
             # gets restarted mid-upgrade - which KILLS the jobs running under it (the
-            # step is torn down and the job requeues from scratch). Exclude the Slurm
-            # daemons from needrestart's automatic restart so a security upgrade can
+            # step is torn down and the job requeues from scratch). Exclude slurmd
+            # from needrestart's automatic restart so a security upgrade can
             # never take down a running job. Security packages still install; only the
-            # slurmd/slurmctld/slurmdbd auto-restart is suppressed.
+            # slurmd auto-restart is suppressed. (PCS runs the controller managed-side;
+            # slurmd is the only Slurm systemd service on login/compute nodes. qr(^slurmd)
+            # also covers the versioned units, e.g. slurmd-25.11.)
             # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
             - |
               mkdir -p /etc/needrestart/conf.d
               cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
-              # AWS PCS: never auto-restart Slurm daemons - restarting slurmd kills
+              # AWS PCS: never auto-restart slurmd - restarting it kills
               # the jobs running under it. Managed by add-cng UserData.
-              $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+              $nrconf{override_rc} = { qr(^slurmd) => 0 };
               NRCONF
-              echo "needrestart: slurmd/slurmctld/slurmdbd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
+              echo "needrestart: slurmd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
             # Post-install script (optional) - generic OnNodeConfigured-style hook.
             # Downloads and runs a user-supplied script (e.g. Enroot/Pyxis install).
             - |

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -380,6 +380,23 @@ Resources:
             MIME-Version: 1.0
 
             runcmd:
+            # --- Protect running jobs from unattended-upgrades / needrestart ---
+            # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
+            # auto-restarts every service linked against them. slurmd links libc, so it
+            # gets restarted mid-upgrade - which KILLS the jobs running under it (the
+            # step is torn down and the job requeues from scratch). Exclude the Slurm
+            # daemons from needrestart's automatic restart so a security upgrade can
+            # never take down a running job. Security packages still install; only the
+            # slurmd/slurmctld/slurmdbd auto-restart is suppressed.
+            # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
+            - |
+              mkdir -p /etc/needrestart/conf.d
+              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
+              # AWS PCS: never auto-restart Slurm daemons - restarting slurmd kills
+              # the jobs running under it. Managed by add-cng UserData.
+              $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+              NRCONF
+              echo "needrestart: slurmd/slurmctld/slurmdbd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
             # Post-install script (optional) - generic OnNodeConfigured-style hook.
             # Downloads and runs a user-supplied script (e.g. Enroot/Pyxis install).
             - |

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -387,19 +387,21 @@ Resources:
             # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
             # auto-restarts every service linked against them. slurmd links libc, so it
             # gets restarted mid-upgrade - which KILLS the jobs running under it (the
-            # step is torn down and the job requeues from scratch). Exclude the Slurm
-            # daemons from needrestart's automatic restart so a security upgrade can
+            # step is torn down and the job requeues from scratch). Exclude slurmd
+            # from needrestart's automatic restart so a security upgrade can
             # never take down a running job. Security packages still install; only the
-            # slurmd/slurmctld/slurmdbd auto-restart is suppressed.
+            # slurmd auto-restart is suppressed. (PCS runs the controller managed-side;
+            # slurmd is the only Slurm systemd service on login/compute nodes. qr(^slurmd)
+            # also covers the versioned units, e.g. slurmd-25.11.)
             # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
             - |
               mkdir -p /etc/needrestart/conf.d
               cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
-              # AWS PCS: never auto-restart Slurm daemons - restarting slurmd kills
+              # AWS PCS: never auto-restart slurmd - restarting it kills
               # the jobs running under it. Managed by add-cng UserData.
-              $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+              $nrconf{override_rc} = { qr(^slurmd) => 0 };
               NRCONF
-              echo "needrestart: slurmd/slurmctld/slurmdbd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
+              echo "needrestart: slurmd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
             # Post-install script (optional) - generic OnNodeConfigured-style hook.
             # Downloads and runs a user-supplied script (e.g. Enroot/Pyxis install).
             - |

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -383,6 +383,23 @@ Resources:
             MIME-Version: 1.0
 
             runcmd:
+            # --- Protect running jobs from unattended-upgrades / needrestart ---
+            # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
+            # auto-restarts every service linked against them. slurmd links libc, so it
+            # gets restarted mid-upgrade - which KILLS the jobs running under it (the
+            # step is torn down and the job requeues from scratch). Exclude the Slurm
+            # daemons from needrestart's automatic restart so a security upgrade can
+            # never take down a running job. Security packages still install; only the
+            # slurmd/slurmctld/slurmdbd auto-restart is suppressed.
+            # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
+            - |
+              mkdir -p /etc/needrestart/conf.d
+              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
+              # AWS PCS: never auto-restart Slurm daemons - restarting slurmd kills
+              # the jobs running under it. Managed by add-cng UserData.
+              $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+              NRCONF
+              echo "needrestart: slurmd/slurmctld/slurmdbd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
             # Post-install script (optional) - generic OnNodeConfigured-style hook.
             # Downloads and runs a user-supplied script (e.g. Enroot/Pyxis install).
             - |

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -454,7 +454,7 @@ Resources:
             # --- Protect running jobs from unattended-upgrades / needrestart ---
             # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
             # auto-restarts every service linked against them. slurmd links libc, so it
-            # gets restarted mid-upgrade — which KILLS the jobs running under it (the
+            # gets restarted mid-upgrade - which KILLS the jobs running under it (the
             # step is torn down and the job requeues from scratch). Exclude the Slurm
             # daemons from needrestart's automatic restart so a security upgrade can
             # never take down a running job. Security packages still install; only the
@@ -463,7 +463,7 @@ Resources:
             - |
               mkdir -p /etc/needrestart/conf.d
               cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
-              # AWS PCS: never auto-restart Slurm daemons — restarting slurmd kills
+              # AWS PCS: never auto-restart Slurm daemons - restarting slurmd kills
               # the jobs running under it. Managed by add-cng.yaml UserData.
               $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
               NRCONF

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -455,19 +455,21 @@ Resources:
             # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
             # auto-restarts every service linked against them. slurmd links libc, so it
             # gets restarted mid-upgrade - which KILLS the jobs running under it (the
-            # step is torn down and the job requeues from scratch). Exclude the Slurm
-            # daemons from needrestart's automatic restart so a security upgrade can
+            # step is torn down and the job requeues from scratch). Exclude slurmd
+            # from needrestart's automatic restart so a security upgrade can
             # never take down a running job. Security packages still install; only the
-            # slurmd/slurmctld/slurmdbd auto-restart is suppressed.
+            # slurmd auto-restart is suppressed. (PCS runs the controller managed-side;
+            # slurmd is the only Slurm systemd service on login/compute nodes. qr(^slurmd)
+            # also covers the versioned units, e.g. slurmd-25.11.)
             # runcmd runs under /bin/sh (dash) — keep this POSIX-clean, no bashisms.
             - |
               mkdir -p /etc/needrestart/conf.d
               cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
-              # AWS PCS: never auto-restart Slurm daemons - restarting slurmd kills
+              # AWS PCS: never auto-restart slurmd - restarting it kills
               # the jobs running under it. Managed by add-cng.yaml UserData.
-              $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+              $nrconf{override_rc} = { qr(^slurmd) => 0 };
               NRCONF
-              echo "needrestart: slurmd/slurmctld/slurmdbd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
+              echo "needrestart: slurmd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
             # Post-install script (optional) - generic OnNodeConfigured-style hook.
             # Downloads and runs a user-supplied script (e.g. Enroot/Pyxis install).
             # Accepts BOTH an s3:// URL (fetched with `aws s3 cp` using the instance

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -451,6 +451,23 @@ Resources:
             MIME-Version: 1.0
             
             runcmd:
+            # --- Protect running jobs from unattended-upgrades / needrestart ---
+            # apt-daily-upgrade updates base libraries (e.g. glibc). needrestart then
+            # auto-restarts every service linked against them. slurmd links libc, so it
+            # gets restarted mid-upgrade — which KILLS the jobs running under it (the
+            # step is torn down and the job requeues from scratch). Exclude the Slurm
+            # daemons from needrestart's automatic restart so a security upgrade can
+            # never take down a running job. Security packages still install; only the
+            # slurmd/slurmctld/slurmdbd auto-restart is suppressed.
+            # runcmd runs under /bin/sh (dash) — keep this POSIX-clean, no bashisms.
+            - |
+              mkdir -p /etc/needrestart/conf.d
+              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
+              # AWS PCS: never auto-restart Slurm daemons — restarting slurmd kills
+              # the jobs running under it. Managed by add-cng.yaml UserData.
+              $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+              NRCONF
+              echo "needrestart: slurmd/slurmctld/slurmdbd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log
             # Post-install script (optional) - generic OnNodeConfigured-style hook.
             # Downloads and runs a user-supplied script (e.g. Enroot/Pyxis install).
             # Accepts BOTH an s3:// URL (fetched with `aws s3 cp` using the instance

--- a/architectures/aws-pcs/docs/OPERATIONS.md
+++ b/architectures/aws-pcs/docs/OPERATIONS.md
@@ -466,60 +466,50 @@ cleanest mitigation is upstream — recording it here so users seeing it know th
 workaround and the next contributor doesn't waste time looking for a bug in this PR's
 scripts.
 
-### 6.2 `apt-daily-upgrade` can kill running jobs via `needrestart` restarting `slurmd`
+### 6.2 `needrestart` must not auto-restart `slurmd` (would stop running jobs) — already handled
 
-**Symptom.** Jobs are killed for no obvious reason, and the kill time lines up with when
-`apt-daily-upgrade.timer` fires (by default in the early morning). The job either
-disappears or requeues from scratch, losing all in-progress work.
+**What to know.** On Ubuntu, automatic security upgrades (`apt-daily-upgrade` +
+`unattended-upgrades`) update base libraries such as glibc, and `needrestart` then
+restarts every service linked against them. `slurmd` links `libc`, so left unchecked
+**`needrestart` restarts `slurmd`, and restarting `slurmd` tears down the `slurmstepd`
+steps under it — stopping every job running on that node** (the job is killed and, if
+requeued, restarts from scratch, losing in-progress work). This is a definite,
+reproducible interaction, not a random failure: it happens whenever an unattended upgrade
+touches a library `slurmd` uses. (It is not a Slurm upgrade — `slurmd` lives under
+`/opt/aws/pcs/...` and is not apt-managed — and it is not a reboot; the job stops purely
+because `slurmd` is restarted.)
 
-**Cause.** `apt-daily-upgrade` installs security updates, including base libraries such as
-glibc. `needrestart` (which runs in automatic mode after unattended upgrades on the
-PCS-ready DLAMI) then restarts every service linked against an updated library. `slurmd`
-links `libc`, so `needrestart` restarts it — and restarting `slurmd` tears down the
-`slurmstepd` steps under it, killing the jobs running on that node. Sequence:
-
-```
-T+0   apt-daily-upgrade.timer fires -> unattended-upgrades installs e.g. libc6
-T+1   needrestart (automatic mode) sees slurmd is linked against the updated libc
-T+1   needrestart runs: systemctl restart slurmd
-T+1   slurmd restart tears down slurmstepd -> the running job is killed / requeued
-```
-
-Note this is **not** about upgrading Slurm: `slurmd` lives under `/opt/aws/pcs/...` and is
-not an apt-managed package. It is purely `needrestart` restarting `slurmd` because a
-library it links was updated. Reboot is not involved either (`Automatic-Reboot` is off by
-default) — the job dies from the `slurmd` restart, not a node reboot.
-
-**Fix (shipped in this repo).** The compute-node-group UserData writes a `needrestart`
-drop-in that excludes the Slurm daemons from automatic restart:
+**You do not need to do anything — the templates already guard against this.** Every
+compute-node-group UserData (`add-cng*`) writes a `needrestart` drop-in that excludes the
+Slurm daemons from automatic restart:
 
 ```perl
 # /etc/needrestart/conf.d/90-pcs-slurm.conf  (written by add-cng* UserData)
 $nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
 ```
 
-This is the minimum targeted change: security packages still install as before, and
-`needrestart` still restarts everything else; only the automatic restart of the Slurm
-daemons is suppressed, so an upgrade can never take down a running job. `needrestart` will
-report the `slurmd` restart as *deferred* rather than performing it. `slurmd` picks up the
-new libraries the next time it restarts on its own terms (node replacement, power-save
-cycle, or a manual restart) — acceptable for HPC, where PCS replaces nodes regularly.
+With this in place, security packages still install and `needrestart` still restarts
+everything else; only the automatic restart of the Slurm daemons is suppressed
+(`needrestart` reports it as *deferred*), so an unattended upgrade can no longer stop a
+running job. `slurmd` picks up the new libraries the next time it restarts on its own
+terms — node replacement, power-save cycle, or a manual restart — which is fine for HPC,
+where PCS replaces nodes regularly. (Verified end-to-end on real hardware: a long-running
+job survives a real `apt-get upgrade` of glibc followed by `needrestart -r a`, with the
+`slurmd` PID unchanged.)
 
-Verified end-to-end on real hardware: a long-running job survives a real `apt-get upgrade`
-that updates glibc followed by `needrestart -r a` (the `slurmd` PID is unchanged and the
-job keeps running); without the drop-in, the same sequence restarts `slurmd` and the job
-is killed.
+**Safe if the platform later fixes this upstream.** The drop-in is a standalone
+`conf.d/*.conf` file that only names the Slurm services. If a future PCS-ready DLAMI or
+Slurm unit handles this differently (e.g. a `slurmd` unit that survives restart, or a
+DLAMI-level `needrestart` policy), this file does not conflict or error — `needrestart`
+reads `conf.d/*.conf` in order and tolerates keys it does not use, so at worst the
+override becomes redundant. In other words, keeping it in place is harmless even after an
+upstream fix; you never have to race to remove it.
 
-**If you still want to disable unattended upgrades entirely** (stops all security updates —
-a heavier hammer), you can also mask the timers in your own post-install:
+**If you would rather turn off automatic upgrades entirely** (heavier — this stops all
+security updates), mask the timers in your own post-install instead:
 `systemctl disable --now apt-daily.timer apt-daily-upgrade.timer`. The `needrestart`
-drop-in above is preferred because it keeps security updates flowing.
-
-**Forward-compatibility.** The drop-in lives in its own `conf.d` file and only names the
-Slurm services, so it stays inert if upstream later addresses this a different way (e.g. a
-`slurmd` unit that survives restart, or a DLAMI-level `needrestart` policy): `needrestart`
-reads `conf.d/*.conf` in order and tolerates unknown keys, so an extra override never
-causes an error — at worst it becomes redundant.
+drop-in above is preferred because it keeps security updates flowing while still protecting
+jobs.
 
 ## 7. Recommendations recap
 

--- a/architectures/aws-pcs/docs/OPERATIONS.md
+++ b/architectures/aws-pcs/docs/OPERATIONS.md
@@ -466,6 +466,61 @@ cleanest mitigation is upstream — recording it here so users seeing it know th
 workaround and the next contributor doesn't waste time looking for a bug in this PR's
 scripts.
 
+### 6.2 `apt-daily-upgrade` can kill running jobs via `needrestart` restarting `slurmd`
+
+**Symptom.** Jobs are killed for no obvious reason, and the kill time lines up with when
+`apt-daily-upgrade.timer` fires (by default in the early morning). The job either
+disappears or requeues from scratch, losing all in-progress work.
+
+**Cause.** `apt-daily-upgrade` installs security updates, including base libraries such as
+glibc. `needrestart` (which runs in automatic mode after unattended upgrades on the
+PCS-ready DLAMI) then restarts every service linked against an updated library. `slurmd`
+links `libc`, so `needrestart` restarts it — and restarting `slurmd` tears down the
+`slurmstepd` steps under it, killing the jobs running on that node. Sequence:
+
+```
+T+0   apt-daily-upgrade.timer fires -> unattended-upgrades installs e.g. libc6
+T+1   needrestart (automatic mode) sees slurmd is linked against the updated libc
+T+1   needrestart runs: systemctl restart slurmd
+T+1   slurmd restart tears down slurmstepd -> the running job is killed / requeued
+```
+
+Note this is **not** about upgrading Slurm: `slurmd` lives under `/opt/aws/pcs/...` and is
+not an apt-managed package. It is purely `needrestart` restarting `slurmd` because a
+library it links was updated. Reboot is not involved either (`Automatic-Reboot` is off by
+default) — the job dies from the `slurmd` restart, not a node reboot.
+
+**Fix (shipped in this repo).** The compute-node-group UserData writes a `needrestart`
+drop-in that excludes the Slurm daemons from automatic restart:
+
+```perl
+# /etc/needrestart/conf.d/90-pcs-slurm.conf  (written by add-cng* UserData)
+$nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+```
+
+This is the minimum targeted change: security packages still install as before, and
+`needrestart` still restarts everything else; only the automatic restart of the Slurm
+daemons is suppressed, so an upgrade can never take down a running job. `needrestart` will
+report the `slurmd` restart as *deferred* rather than performing it. `slurmd` picks up the
+new libraries the next time it restarts on its own terms (node replacement, power-save
+cycle, or a manual restart) — acceptable for HPC, where PCS replaces nodes regularly.
+
+Verified end-to-end on real hardware: a long-running job survives a real `apt-get upgrade`
+that updates glibc followed by `needrestart -r a` (the `slurmd` PID is unchanged and the
+job keeps running); without the drop-in, the same sequence restarts `slurmd` and the job
+is killed.
+
+**If you still want to disable unattended upgrades entirely** (stops all security updates —
+a heavier hammer), you can also mask the timers in your own post-install:
+`systemctl disable --now apt-daily.timer apt-daily-upgrade.timer`. The `needrestart`
+drop-in above is preferred because it keeps security updates flowing.
+
+**Forward-compatibility.** The drop-in lives in its own `conf.d` file and only names the
+Slurm services, so it stays inert if upstream later addresses this a different way (e.g. a
+`slurmd` unit that survives restart, or a DLAMI-level `needrestart` policy): `needrestart`
+reads `conf.d/*.conf` in order and tolerates unknown keys, so an extra override never
+causes an error — at worst it becomes redundant.
+
 ## 7. Recommendations recap
 
 For a new production deploy:

--- a/architectures/aws-pcs/docs/OPERATIONS.md
+++ b/architectures/aws-pcs/docs/OPERATIONS.md
@@ -466,52 +466,26 @@ cleanest mitigation is upstream — recording it here so users seeing it know th
 workaround and the next contributor doesn't waste time looking for a bug in this PR's
 scripts.
 
-### 6.2 `needrestart` must not auto-restart `slurmd` (would stop running jobs) — already handled
+### 6.2 `needrestart` restarting `slurmd` would stop running jobs — already handled
 
-**What to know.** On Ubuntu, automatic security upgrades (`apt-daily-upgrade` +
-`unattended-upgrades`) update base libraries such as glibc, and `needrestart` then
-restarts every service linked against them. `slurmd` links `libc`, so left unchecked
-**`needrestart` restarts `slurmd`, and restarting `slurmd` tears down the `slurmstepd`
-steps under it — stopping every job running on that node** (the job is killed and, if
-requeued, restarts from scratch, losing in-progress work). This is a definite,
-reproducible interaction, not a random failure: it happens whenever an unattended upgrade
-touches a library `slurmd` uses. (It is not a Slurm upgrade — `slurmd` lives under
-`/opt/aws/pcs/...` and is not apt-managed — and it is not a reboot; the job stops purely
-because `slurmd` is restarted.)
+When an unattended security upgrade updates a base library `slurmd` links (e.g. glibc),
+`needrestart` restarts `slurmd`, and that restart tears down the `slurmstepd` steps under
+it — **stopping every job on the node**. It is reproducible, not random, and not a reboot
+or a Slurm-package upgrade.
 
-**You do not need to do anything — the templates already guard against this.** Every
-compute-node-group UserData (`add-cng*`) writes a `needrestart` drop-in that excludes
-`slurmd` from automatic restart:
+The compute-node-group templates already guard against this: each `add-cng*` UserData
+writes a `needrestart` drop-in so `slurmd` is never auto-restarted (security updates still
+install; `needrestart` only defers the `slurmd` restart):
 
 ```perl
 # /etc/needrestart/conf.d/90-pcs-slurm.conf  (written by add-cng* UserData)
 $nrconf{override_rc} = { qr(^slurmd) => 0 };
 ```
 
-`slurmd` is the only Slurm systemd service on login/compute nodes (PCS runs the
-controller managed-side, so there is no `slurmctld`/`slurmdbd` service to guard here), and
-`qr(^slurmd)` also matches the versioned units (e.g. `slurmd-25.11`). With this in place,
-security packages still install and `needrestart` still restarts everything else; only the
-automatic restart of `slurmd` is suppressed (`needrestart` reports it as *deferred*), so an
-unattended upgrade can no longer stop a running job. `slurmd` picks up the new libraries the next time it restarts on its own
-terms — node replacement, power-save cycle, or a manual restart — which is fine for HPC,
-where PCS replaces nodes regularly. (Verified end-to-end on real hardware: a long-running
-job survives a real `apt-get upgrade` of glibc followed by `needrestart -r a`, with the
-`slurmd` PID unchanged.)
-
-**Safe if the platform later fixes this upstream.** The drop-in is a standalone
-`conf.d/*.conf` file that only names the Slurm services. If a future PCS-ready DLAMI or
-Slurm unit handles this differently (e.g. a `slurmd` unit that survives restart, or a
-DLAMI-level `needrestart` policy), this file does not conflict or error — `needrestart`
-reads `conf.d/*.conf` in order and tolerates keys it does not use, so at worst the
-override becomes redundant. In other words, keeping it in place is harmless even after an
-upstream fix; you never have to race to remove it.
-
-**If you would rather turn off automatic upgrades entirely** (heavier — this stops all
-security updates), mask the timers in your own post-install instead:
-`systemctl disable --now apt-daily.timer apt-daily-upgrade.timer`. The `needrestart`
-drop-in above is preferred because it keeps security updates flowing while still protecting
-jobs.
+`slurmd` is the only Slurm systemd service on these nodes (the controller is managed by
+PCS); `qr(^slurmd)` also matches the versioned units (e.g. `slurmd-25.11`). The drop-in is
+a standalone `conf.d/*.conf` naming only `slurmd`, so if a later DLAMI or Slurm unit
+handles this differently it neither conflicts nor errors — at worst it becomes redundant.
 
 ## 7. Recommendations recap
 

--- a/architectures/aws-pcs/docs/OPERATIONS.md
+++ b/architectures/aws-pcs/docs/OPERATIONS.md
@@ -480,18 +480,20 @@ touches a library `slurmd` uses. (It is not a Slurm upgrade — `slurmd` lives u
 because `slurmd` is restarted.)
 
 **You do not need to do anything — the templates already guard against this.** Every
-compute-node-group UserData (`add-cng*`) writes a `needrestart` drop-in that excludes the
-Slurm daemons from automatic restart:
+compute-node-group UserData (`add-cng*`) writes a `needrestart` drop-in that excludes
+`slurmd` from automatic restart:
 
 ```perl
 # /etc/needrestart/conf.d/90-pcs-slurm.conf  (written by add-cng* UserData)
-$nrconf{override_rc} = { qr(^slurmd) => 0, qr(^slurmctld) => 0, qr(^slurmdbd) => 0 };
+$nrconf{override_rc} = { qr(^slurmd) => 0 };
 ```
 
-With this in place, security packages still install and `needrestart` still restarts
-everything else; only the automatic restart of the Slurm daemons is suppressed
-(`needrestart` reports it as *deferred*), so an unattended upgrade can no longer stop a
-running job. `slurmd` picks up the new libraries the next time it restarts on its own
+`slurmd` is the only Slurm systemd service on login/compute nodes (PCS runs the
+controller managed-side, so there is no `slurmctld`/`slurmdbd` service to guard here), and
+`qr(^slurmd)` also matches the versioned units (e.g. `slurmd-25.11`). With this in place,
+security packages still install and `needrestart` still restarts everything else; only the
+automatic restart of `slurmd` is suppressed (`needrestart` reports it as *deferred*), so an
+unattended upgrade can no longer stop a running job. `slurmd` picks up the new libraries the next time it restarts on its own
 terms — node replacement, power-save cycle, or a manual restart — which is fine for HPC,
 where PCS replaces nodes regularly. (Verified end-to-end on real hardware: a long-running
 job survives a real `apt-get upgrade` of glibc followed by `needrestart -r a`, with the


### PR DESCRIPTION
# fix(aws-pcs): stop `needrestart` from restarting `slurmd` and killing running jobs

## Problem

On the Ubuntu PCS-ready DLAMI, unattended security upgrades (`apt-daily-upgrade` +
`unattended-upgrades`) update base libraries such as glibc. `needrestart` then runs in
automatic mode and restarts every service linked against an updated library. `slurmd`
links `libc`, so `needrestart` restarts `slurmd` — and restarting `slurmd` tears down the
`slurmstepd` steps under it, **killing every job running on that node** (the job stops and,
if requeued, restarts from scratch, losing in-progress work).

The kill time therefore lines up with `apt-daily-upgrade.timer`. This is a deterministic
interaction, reproducible on demand: it occurs whenever an unattended upgrade updates a
library `slurmd` uses.

Two clarifications, because both are easy to assume and both are wrong:
- It is **not** a Slurm-package upgrade. `slurmd` lives under `/opt/aws/pcs/...` and is not
  apt-managed; nothing upgrades Slurm here.
- It is **not** a reboot. `Automatic-Reboot` is off by default; the job dies solely from
  the `slurmd` restart.

## Fix

Each compute-node-group template (`add-cng.yaml` and the P5 / P6-B200 / P6-B300 GPU
templates) writes a `needrestart` drop-in at first boot that excludes `slurmd` from
automatic restart:

```perl
# /etc/needrestart/conf.d/90-pcs-slurm.conf
$nrconf{override_rc} = { qr(^slurmd) => 0 };
```

- Security packages still install as before; `needrestart` still restarts everything else.
  Only the `slurmd` restart is suppressed (`needrestart` reports it as *deferred*), so an
  unattended upgrade can no longer stop a running job.
- `slurmd` is the only Slurm systemd service on login/compute nodes — PCS runs the
  controller managed-side, so there is no `slurmctld`/`slurmdbd` service to guard. The
  `qr(^slurmd)` pattern also covers the versioned units (e.g. `slurmd-25.11`).
- `slurmd` picks up the updated libraries the next time it restarts on its own terms (node
  replacement, power-save cycle, manual restart), which is acceptable for PCS, where nodes
  are replaced regularly.

Scope note: the drop-in is a standalone `conf.d/*.conf` naming only `slurmd`. If a future
DLAMI or Slurm unit addresses this differently, the file neither conflicts nor errors —
`needrestart` reads `conf.d/*.conf` in order and ignores keys it does not use — so it is
safe to keep even after an upstream fix.

## Verification

Verified end-to-end on real hardware (PCS clusters, us-east-2), comparing an unmodified
cluster with one carrying this change. On each, a long-running job was started, then a real
`apt-get upgrade` + `libc6` reinstall + `needrestart -r a` was run on the compute node:

| | Without the drop-in | With the drop-in (this PR) |
|---|---|---|
| `needrestart` action on `slurmd` | restarts it | defers it (no restart) |
| `slurmd` PID | changes | unchanged |
| running job | killed | survives |

## Tests

- `aws cloudformation validate-template` passes on all `assets/*.yaml`.
- `tests/lint-docs.sh`: PASS.
- The rendered UserData `runcmd` step was checked under `/bin/sh` (dash) — POSIX-clean, no
  bashisms — and the generated `90-pcs-slurm.conf` passes `perl -c`.

## Docs

`docs/OPERATIONS.md` §6.2 documents the interaction and the shipped mitigation.

## Files changed

- `architectures/aws-pcs/assets/add-cng.yaml`
- `architectures/aws-pcs/assets/add-cng-p5.yaml`
- `architectures/aws-pcs/assets/add-cng-p6-b200.yaml`
- `architectures/aws-pcs/assets/add-cng-p6-b300.yaml`
- `architectures/aws-pcs/docs/OPERATIONS.md`
