### PR TITLE
Add DeepSeek-V4-Flash intra-node 3P1D and GLM-5.2 4x tp=2 SGLang examples

### DIFF
--- a/examples/inference/README.md
+++ b/examples/inference/README.md
@@ -8,6 +8,8 @@ Framework-centric inference engine examples, organized by serving engine.
 | [`sglang`](./sglang) | [`qwen3.5-27b-b300-intra-pd`](./sglang/qwen3.5-27b-b300-intra-pd) | Qwen3.5-27B with intra-node prefill/decode disaggregation on a single B300 node |
 | [`sglang`](./sglang) | [`kimi2.6-h200-1p1d`](./sglang/kimi2.6-h200-1p1d) | Kimi2.6 with node-level 1-prefill / 1-decode disaggregation across two H200 nodes |
 | [`sglang`](./sglang) | [`dsv4pro-b300-single-node`](./sglang/dsv4pro-b300-single-node) | DeepSeek V4 Pro unified (non-PD) serving on a single B300 node |
+| [`sglang`](./sglang) | [`dsv4flash-b300-intra-3p1d`](./sglang/dsv4flash-b300-intra-3p1d) | DeepSeek-V4-Flash with intra-node 3-prefill / 1-decode disaggregation (tp=2 each) on a single B300 node |
+| [`sglang`](./sglang) | [`glm5.2-b300-tp2-dp4`](./sglang/glm5.2-b300-tp2-dp4) | GLM-5.2 (NVFP4) as 4× independent tp=2 engines behind an SGLang router on a single B300 node |
 
 More engines (TRT-LLM, NIM, Dynamo, Ray Serve, …) are planned, including
 content to be merged from [`aws-samples/awsome-inference`](https://github.com/aws-samples/awsome-inference)

--- a/examples/inference/sglang/README.md
+++ b/examples/inference/sglang/README.md
@@ -14,9 +14,13 @@ manifest with `kubectl`.
 | [`qwen3.5-27b-b300-intra-pd`](./qwen3.5-27b-b300-intra-pd) | 1× B300 (8 GPU) | Intra-node PD — 6 prefill + 2 decode in one pod, NIXL, SGLang router sidecar | `lmsysorg/sglang:v0.5.12.post1-cu130`, no inter-node RDMA support |
 | [`kimi2.6-h200-1p1d`](./kimi2.6-h200-1p1d) | 2× H200 nodes | Node-level 1P1D — prefill + decode StatefulSets, NIXL over EFA | Custom ECR build from [`Dockerfile.efa`](./Dockerfile.efa) (lmsysorg/sglang:v0.5.12.post1-cu130 + EFA layer), inter-node RDMA enabled |
 | [`dsv4pro-b300-single-node`](./dsv4pro-b300-single-node) | 1× B300 (8 GPU) | Unified (non-PD) baseline | `lmsysorg/sglang:v0.5.12.post1-cu130`, no inter-node RDMA support |
+| [`dsv4flash-b300-intra-3p1d`](./dsv4flash-b300-intra-3p1d) | 1× B300 (8 GPU) | Intra-node PD — 3 prefill + 1 decode (tp=2 each) in one pod, NIXL, SGLang router sidecar | `lmsysorg/sglang:v0.5.12.post1-cu130`, no inter-node RDMA support |
+| [`glm5.2-b300-tp2-dp4`](./glm5.2-b300-tp2-dp4) | 1× B300 (8 GPU) | 4× independent tp=2 engines behind an SGLang router (cache-aware LB, cluster-level dp=4) | `lmsysorg/sglang:dev-glm52-nvfp4` (GLM-5.2 NVFP4 support not yet in a tagged release) |
 
-All three serve on the same upstream `lmsysorg/sglang:v0.5.12.post1-cu130` image
-(Kimi adds only an EFA layer on top for inter-node RDMA) — no per-model image.
+All samples except GLM-5.2 serve on the same upstream
+`lmsysorg/sglang:v0.5.12.post1-cu130` image (Kimi adds only an EFA layer on top
+for inter-node RDMA); the GLM-5.2 sample uses the `dev-glm52-nvfp4` image until
+NVFP4 support for that model lands in a tagged release.
 
 ## Shared helpers
 

--- a/examples/inference/sglang/README.md
+++ b/examples/inference/sglang/README.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT-0
 | [`dsv4flash-b300-intra-3p1d`](./dsv4flash-b300-intra-3p1d) | 1× B300 (8 GPU) | Intra-node PD — 3 prefill + 1 decode (tp=2 each) in one pod, NIXL, SGLang router sidecar | `lmsysorg/sglang:v0.5.12.post1-cu130`, no inter-node RDMA support |
 | [`glm5.2-b300-tp2-dp4`](./glm5.2-b300-tp2-dp4) | 1× B300 (8 GPU) | 4× independent tp=2 engines behind an SGLang router (cache-aware LB, cluster-level dp=4) | `lmsysorg/sglang@sha256:bafcd0…` (the `dev-glm52-nvfp4` tag pinned by digest — GLM-5.2 NVFP4 support not yet in a tagged release) |
 
-> The intra-node PD samples deliberately run several engine processes in one pod — not the usual one-process-per-pod shape. Intra-node KV transfer rides NVLink via CUDA IPC, which requires all engines to share an IPC namespace and see each other's GPUs; 
+> The intra-node PD samples deliberately run several engine processes in one pod — not the usual one-process-per-pod shape. Intra-node KV transfer rides NVLink via CUDA IPC, which requires all engines to share an IPC namespace and see each other's GPUs — impossible across separate pods or containers, so the engines share one container (each sample's README explains the full rationale).
 
 > All samples except GLM-5.2 serve on the same upstream `lmsysorg/sglang:v0.5.12.post1-cu130` image (Kimi adds only an EFA layer on top
 for inter-node RDMA); the GLM-5.2 sample uses the `dev-glm52-nvfp4` image (pinned by digest in its manifest, since `dev-*` tags are mutable) until NVFP4 support for that model lands in a tagged release.

--- a/examples/inference/sglang/README.md
+++ b/examples/inference/sglang/README.md
@@ -5,9 +5,7 @@ SPDX-License-Identifier: MIT-0
 
 # SGLang test cases
 
-[SGLang](https://github.com/sgl-project/sglang) deployments on AWS EKS /
-SageMaker HyperPod. Each sub-directory is a self-contained sample — apply its
-manifest with `kubectl`.
+[SGLang](https://github.com/sgl-project/sglang) deployments on AWS EKS / SageMaker HyperPod. Each sub-directory is a self-contained sample — apply its manifest with `kubectl`.
 
 | Test case | Hardware | Topology | Engine image |
 | --- | --- | --- | --- |
@@ -17,10 +15,10 @@ manifest with `kubectl`.
 | [`dsv4flash-b300-intra-3p1d`](./dsv4flash-b300-intra-3p1d) | 1× B300 (8 GPU) | Intra-node PD — 3 prefill + 1 decode (tp=2 each) in one pod, NIXL, SGLang router sidecar | `lmsysorg/sglang:v0.5.12.post1-cu130`, no inter-node RDMA support |
 | [`glm5.2-b300-tp2-dp4`](./glm5.2-b300-tp2-dp4) | 1× B300 (8 GPU) | 4× independent tp=2 engines behind an SGLang router (cache-aware LB, cluster-level dp=4) | `lmsysorg/sglang:dev-glm52-nvfp4` (GLM-5.2 NVFP4 support not yet in a tagged release) |
 
-All samples except GLM-5.2 serve on the same upstream
-`lmsysorg/sglang:v0.5.12.post1-cu130` image (Kimi adds only an EFA layer on top
-for inter-node RDMA); the GLM-5.2 sample uses the `dev-glm52-nvfp4` image until
-NVFP4 support for that model lands in a tagged release.
+> The intra-node PD samples deliberately run several engine processes in one pod — not the usual one-process-per-pod shape. Intra-node KV transfer rides NVLink via CUDA IPC, which requires all engines to share an IPC namespace and see each other's GPUs; 
+
+> All samples except GLM-5.2 serve on the same upstream `lmsysorg/sglang:v0.5.12.post1-cu130` image (Kimi adds only an EFA layer on top
+for inter-node RDMA); the GLM-5.2 sample uses the `dev-glm52-nvfp4` image until NVFP4 support for that model lands in a tagged release.
 
 ## Shared helpers
 
@@ -38,19 +36,15 @@ ECR, printing the image URI on the last line:
 ./build-image.sh   # -> <account>.dkr.ecr.<region>.amazonaws.com/sgl-dev-cu13:<tag>
 ```
 
-Set that URI as `<YOUR_ECR_IMAGE>` in the sample's manifest. Single-node samples
-run the upstream image directly and don't need this build.
+Set that URI as `<YOUR_ECR_IMAGE>` in the sample's manifest. Single-node samples run the upstream image directly and don't need this build.
 
 ### Pre-stage model weights
 
-Download a Hugging Face repo to every matching node's local NVMe
-(`/opt/dlami/nvme`) so the serving pods read weights from fast local disk
-instead of pulling them at startup. [`download-model.sh`](./download-model.sh)
-renders [`download-model-daemonset.yaml`](./download-model-daemonset.yaml) and
-applies it — `LOCAL_DIR_NAME` defaults to the repo id with `/` → `-`:
+Download a Hugging Face repo to every matching node's local NVMe (`/opt/dlami/nvme`) so the serving pods read weights from fast local disk
+instead of pulling them at startup. [`download-model.sh`](./download-model.sh) renders [`download-model-daemonset.yaml`](./download-model-daemonset.yaml) and applies it — `LOCAL_DIR_NAME` defaults to the repo id with `/` → `-`:
 
 ```bash
-./download-model.sh moonshotai/Kimi-K2.5       ml.p5en.48xlarge
+./download-model.sh moonshotai/Kimi-K2.5        ml.p5en.48xlarge
 ./download-model.sh deepseek-ai/DeepSeek-V4-Pro ml.p6-b300.48xlarge
 # watch: kubectl logs -f -l app=model-downloader   (each node prints "Download complete!")
 # then:  kubectl delete daemonset model-downloader
@@ -58,11 +52,4 @@ applies it — `LOCAL_DIR_NAME` defaults to the repo id with `/` → `-`:
 
 ### Metrics
 
-Every serving pod already exposes SGLang metrics on `:30000/metrics` (the engines
-start with `--enable-metrics`) and carries the `sglang-metrics=true` label plus
-the `prometheus.io/{scrape,port,path}` scrape annotations. Point any
-Prometheus-compatible scraper at those pods — e.g. an in-cluster Prometheus
-**agent** remote-writing to **Amazon Managed Prometheus (AMP)** with **Amazon
-Managed Grafana** reading from AMP, or a self-managed Prometheus + Grafana stack.
-Wiring up the scrape backend is left to your cluster's existing observability
-setup; the manifests here only produce the metrics.
+Every serving pod already exposes SGLang metrics on `:30000/metrics` (the engines start with `--enable-metrics`) and carries the `sglang-metrics=true` label plus the `prometheus.io/{scrape,port,path}` scrape annotations. Point any Prometheus-compatible scraper at those pods — e.g. an in-cluster Prometheus **agent** remote-writing to **Amazon Managed Prometheus (AMP)** with **Amazon Managed Grafana** reading from AMP, or a self-managed Prometheus + Grafana stack. Wiring up the scrape backend is left to your cluster's existing observability setup; the manifests here only produce the metrics.

--- a/examples/inference/sglang/README.md
+++ b/examples/inference/sglang/README.md
@@ -13,12 +13,12 @@ SPDX-License-Identifier: MIT-0
 | [`kimi2.6-h200-1p1d`](./kimi2.6-h200-1p1d) | 2× H200 nodes | Node-level 1P1D — prefill + decode StatefulSets, NIXL over EFA | Custom ECR build from [`Dockerfile.efa`](./Dockerfile.efa) (lmsysorg/sglang:v0.5.12.post1-cu130 + EFA layer), inter-node RDMA enabled |
 | [`dsv4pro-b300-single-node`](./dsv4pro-b300-single-node) | 1× B300 (8 GPU) | Unified (non-PD) baseline | `lmsysorg/sglang:v0.5.12.post1-cu130`, no inter-node RDMA support |
 | [`dsv4flash-b300-intra-3p1d`](./dsv4flash-b300-intra-3p1d) | 1× B300 (8 GPU) | Intra-node PD — 3 prefill + 1 decode (tp=2 each) in one pod, NIXL, SGLang router sidecar | `lmsysorg/sglang:v0.5.12.post1-cu130`, no inter-node RDMA support |
-| [`glm5.2-b300-tp2-dp4`](./glm5.2-b300-tp2-dp4) | 1× B300 (8 GPU) | 4× independent tp=2 engines behind an SGLang router (cache-aware LB, cluster-level dp=4) | `lmsysorg/sglang:dev-glm52-nvfp4` (GLM-5.2 NVFP4 support not yet in a tagged release) |
+| [`glm5.2-b300-tp2-dp4`](./glm5.2-b300-tp2-dp4) | 1× B300 (8 GPU) | 4× independent tp=2 engines behind an SGLang router (cache-aware LB, cluster-level dp=4) | `lmsysorg/sglang@sha256:bafcd0…` (the `dev-glm52-nvfp4` tag pinned by digest — GLM-5.2 NVFP4 support not yet in a tagged release) |
 
 > The intra-node PD samples deliberately run several engine processes in one pod — not the usual one-process-per-pod shape. Intra-node KV transfer rides NVLink via CUDA IPC, which requires all engines to share an IPC namespace and see each other's GPUs; 
 
 > All samples except GLM-5.2 serve on the same upstream `lmsysorg/sglang:v0.5.12.post1-cu130` image (Kimi adds only an EFA layer on top
-for inter-node RDMA); the GLM-5.2 sample uses the `dev-glm52-nvfp4` image until NVFP4 support for that model lands in a tagged release.
+for inter-node RDMA); the GLM-5.2 sample uses the `dev-glm52-nvfp4` image (pinned by digest in its manifest, since `dev-*` tags are mutable) until NVFP4 support for that model lands in a tagged release.
 
 ## Shared helpers
 
@@ -40,8 +40,10 @@ Set that URI as `<YOUR_ECR_IMAGE>` in the sample's manifest. Single-node samples
 
 ### Pre-stage model weights
 
-Download a Hugging Face repo to every matching node's local NVMe (`/opt/dlami/nvme`) so the serving pods read weights from fast local disk
-instead of pulling them at startup. [`download-model.sh`](./download-model.sh) renders [`download-model-daemonset.yaml`](./download-model-daemonset.yaml) and applies it — `LOCAL_DIR_NAME` defaults to the repo id with `/` → `-`:
+Download a Hugging Face repo to every matching node's local NVMe so the serving pods read weights from fast local disk instead of pulling them at
+startup. [`download-model.sh`](./download-model.sh) renders [`download-model-daemonset.yaml`](./download-model-daemonset.yaml) and applies it. The
+weights are staged in **HF cache layout** under `<nvme>/huggingface` — the dir every serving manifest mounts at `/root/.cache/huggingface`, with the
+engines loading by repo id, so the staged snapshot is found as a cache hit:
 
 ```bash
 ./download-model.sh moonshotai/Kimi-K2.5        ml.p5en.48xlarge
@@ -49,6 +51,8 @@ instead of pulling them at startup. [`download-model.sh`](./download-model.sh) r
 # watch: kubectl logs -f -l app=model-downloader   (each node prints "Download complete!")
 # then:  kubectl delete daemonset model-downloader
 ```
+
+Like the serving manifests, the daemonset's NVMe `hostPath` defaults to HyperPod's `/opt/dlami/nvme` — on self-managed EKS change it to `/mnt/k8s-disks/0` so it stages to the disk the serving pods actually mount.
 
 ### Metrics
 

--- a/examples/inference/sglang/download-model-daemonset.yaml
+++ b/examples/inference/sglang/download-model-daemonset.yaml
@@ -2,17 +2,22 @@
 # SPDX-License-Identifier: MIT-0
 #
 # Generic model pre-stager: downloads a Hugging Face repo to every matching
-# node's local NVMe (/opt/dlami/nvme) so the serving pods read weights from
-# fast local disk instead of pulling them at startup.
+# node's local NVMe so the serving pods read weights from fast local disk
+# instead of pulling them at startup.
+#
+# The weights are staged in HF cache layout under <nvme>/huggingface — the
+# exact dir every serving manifest here mounts at /root/.cache/huggingface,
+# with engines loading by repo id (--model-path <org>/<model>). The engines
+# then find the staged snapshot as a cache hit; no per-sample path wiring.
 #
 # Rendered and applied by download-model.sh, which fills INSTANCE_TYPE,
-# INSTANCE_TYPE_ALT, HF_REPO_ID, and LOCAL_DIR_NAME. INSTANCE_TYPE_ALT is the
-# other instance-type spelling (bare EC2 type vs the SageMaker `ml.` prefix) so
-# the DaemonSet lands on the GPU nodes of BOTH a plain EKS managed nodegroup and
-# a HyperPod instance group. To apply by hand instead:
+# INSTANCE_TYPE_ALT, and HF_REPO_ID. INSTANCE_TYPE_ALT is the other
+# instance-type spelling (bare EC2 type vs the SageMaker `ml.` prefix) so the
+# DaemonSet lands on the GPU nodes of BOTH a plain EKS managed nodegroup and a
+# HyperPod instance group. To apply by hand instead:
 #   export INSTANCE_TYPE=ml.p5en.48xlarge INSTANCE_TYPE_ALT=p5en.48xlarge \
-#          HF_REPO_ID=moonshotai/Kimi-K2.5 LOCAL_DIR_NAME=moonshotai-Kimi-K2.5
-#   envsubst '${INSTANCE_TYPE} ${INSTANCE_TYPE_ALT} ${HF_REPO_ID} ${LOCAL_DIR_NAME}' \
+#          HF_REPO_ID=moonshotai/Kimi-K2.5
+#   envsubst '${INSTANCE_TYPE} ${INSTANCE_TYPE_ALT} ${HF_REPO_ID}' \
 #     < download-model-daemonset.yaml | kubectl apply -f -
 #   # wait until each pod logs "Download complete!", then deploy the engine
 apiVersion: apps/v1
@@ -59,12 +64,11 @@ spec:
               from huggingface_hub import snapshot_download
               snapshot_download(
                   repo_id='${HF_REPO_ID}',
-                  local_dir='/nvme/${LOCAL_DIR_NAME}',
-                  local_dir_use_symlinks=False,
+                  cache_dir='/nvme/huggingface/hub',
               )
               print('Download complete!')
               " &&
-              echo "Model downloaded to /opt/dlami/nvme/${LOCAL_DIR_NAME} on node $(hostname)" &&
+              echo "Staged ${HF_REPO_ID} on node $(hostname)" &&
               sleep infinity
           volumeMounts:
             - name: nvme
@@ -77,8 +81,16 @@ spec:
               cpu: "4"
               memory: "8Gi"
       volumes:
+      # ⚠️  SET THIS PER CLUSTER — same warning as the serving manifests. The
+      # node's local NVMe is mounted at different paths on the two AMIs:
+      #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme
+      #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0   (setup-local-disks raid0)
+      # Picking the WRONG path is not a hard error: type=DirectoryOrCreate will
+      # silently create an empty dir on the small root disk and the weights
+      # download there and can fill it up. Must match the serving manifest's
+      # hostPath so the engines read what this daemonset stages.
         - name: nvme
           hostPath:
-            path: /opt/dlami/nvme
+            path: /opt/dlami/nvme  # For EKS: /mnt/k8s-disks/0
             type: DirectoryOrCreate
       restartPolicy: Always

--- a/examples/inference/sglang/download-model.sh
+++ b/examples/inference/sglang/download-model.sh
@@ -6,28 +6,28 @@
 # it, pre-staging the weights to every matching node's NVMe (/opt/dlami/nvme).
 #
 # Usage:
-#   ./download-model.sh <HF_REPO_ID> <INSTANCE_TYPE> [LOCAL_DIR_NAME]
+#   ./download-model.sh <HF_REPO_ID> <INSTANCE_TYPE>
 #
 # Examples:
-#   ./download-model.sh moonshotai/Kimi-K2.5  ml.p5en.48xlarge
 #   ./download-model.sh deepseek-ai/DeepSeek-V4-Pro ml.p6-b300.48xlarge
+#   ./download-model.sh moonshotai/Kimi-K2.5 ml.p5en.48xlarge
 #
-# LOCAL_DIR_NAME defaults to the repo id with '/' replaced by '-'
-# (e.g. moonshotai/Kimi-K2.5 -> moonshotai-Kimi-K2.5). The weights land at
-# /opt/dlami/nvme/<LOCAL_DIR_NAME> on each node.
+# The weights are staged in HF cache layout under
+# /opt/dlami/nvme/huggingface — the dir every serving manifest mounts at
+# /root/.cache/huggingface, with engines loading by repo id, so the staged
+# snapshot is found as a cache hit.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ $# -lt 2 ]]; then
-    echo "Usage: $0 <HF_REPO_ID> <INSTANCE_TYPE> [LOCAL_DIR_NAME]" >&2
+    echo "Usage: $0 <HF_REPO_ID> <INSTANCE_TYPE>" >&2
     exit 1
 fi
 
 export HF_REPO_ID="$1"
 export INSTANCE_TYPE="$2"
-export LOCAL_DIR_NAME="${3:-${HF_REPO_ID//\//-}}"
 
 # The two cluster types label instance-type differently: a plain EKS managed
 # nodegroup uses the bare EC2 type (p5en.48xlarge), a SageMaker HyperPod instance
@@ -42,9 +42,9 @@ fi
 
 echo "==> Pre-staging ${HF_REPO_ID}"
 echo "    nodes:  ${INSTANCE_TYPE} / ${INSTANCE_TYPE_ALT}"
-echo "    target: /opt/dlami/nvme/${LOCAL_DIR_NAME}"
+echo "    target: <nvme>/huggingface (HF cache layout)"
 
-envsubst '${INSTANCE_TYPE} ${INSTANCE_TYPE_ALT} ${HF_REPO_ID} ${LOCAL_DIR_NAME}' \
+envsubst '${INSTANCE_TYPE} ${INSTANCE_TYPE_ALT} ${HF_REPO_ID}' \
     < "${SCRIPT_DIR}/download-model-daemonset.yaml" \
     | kubectl apply -f -
 

--- a/examples/inference/sglang/dsv4flash-b300-intra-3p1d/README.md
+++ b/examples/inference/sglang/dsv4flash-b300-intra-3p1d/README.md
@@ -5,9 +5,7 @@ SPDX-License-Identifier: MIT-0
 
 # DeepSeek-V4-Flash — Intra-node PD on B300 (EKS / HyperPod)
 
-Prefill/decode disaggregation **within a single 8-GPU B300 node** using SGLang.
-All engines run in one pod on one node: three prefill instances and one decode
-instance, each `tp=2` spanning **two GPUs**, split via `--base-gpu-id`:
+Prefill/decode disaggregation **within a single 8-GPU B300 node** using SGLang. All engines run in one pod on one node: three prefill instances and one decode instance, each `tp=2` spanning **two GPUs**, split via `--base-gpu-id`:
 
 | Role | GPUs | HTTP port | Bootstrap port |
 |---|---|---|---|
@@ -16,14 +14,23 @@ instance, each `tp=2` spanning **two GPUs**, split via `--base-gpu-id`:
 | prefill 2 | 4, 5 | 30200 | 9200 |
 | decode    | 6, 7 | 30300 | 9300 |
 
-HTTP ports are spaced 100 apart on purpose: with `--enable-dp-attention`,
-SGLang derives a **block** of internal TCP ports at `--port + 233` (dist-init,
-detokenizer, rpc, metrics, scheduler-input, one per dp rank). Adjacent base
-ports would overlap those blocks and fail with *"Address already in use"*.
+HTTP ports are spaced 100 apart on purpose: with `--enable-dp-attention`, SGLang derives a **block** of internal TCP ports at `--port + 233` (dist-init,
+detokenizer, rpc, metrics, scheduler-input, one per dp rank). Adjacent base ports would overlap those blocks and fail with *"Address already in use"*.
 
-KV cache moves prefill → decode over **NIXL**, staying intra-node. A router
-sidecar shares the pod network namespace and reaches every engine on
+KV cache moves prefill → decode over **NIXL**, staying intra-node. A router sidecar shares the pod network namespace and reaches every engine on
 `127.0.0.1`.
+
+## Why one pod with four engine processes?
+
+Running each engine as its own pod (or its own container) would be the more Kubernetes-native shape, but it breaks the one thing this topology exists for: **NVLink KV transfer**. Intra-node NIXL moves KV pages via CUDA IPC, which requires the prefill and decode processes to share an IPC namespace *and* see each other's GPUs. The device plugin hands each container a **disjoint** GPU set and pods get isolated IPC namespaces, so CUDA IPC handles cannot be opened across them (this fails even between two containers in the *same* pod, because neither can see the peer's GPUs). NIXL then falls back to TCP over the pod network — NVIDIA's [disaggregated-inference guide](https://docs.dynamo.nvidia.com/dynamo/kubernetes-deployment/operate/disagg-communication) measures that fallback at 200–500× worse TTFT.
+
+So the rule of thumb encoded by this repo's samples:
+
+- **PD split across pods/nodes** — correct when the pods are connected by RDMA(EFA); see [`kimi2.6-h200-1p1d`](../kimi2.6-h200-1p1d), where prefill and decode are separate StatefulSets.
+- **PD within one node, no RDMA between engines** — the engines must live in one container that owns all 8 GPUs, as here. The pod is still a single
+  schedulable, restartable unit: probes watch the foreground engine and the whole group restarts together (`strategy: Recreate`), which is also the
+  correct failure semantics — a half-alive PD group can't serve anyway.
+- **No PD at all** — if you just want N independent engines on a node, one-engine-per-pod is the native shape; see [`glm5.2-b300-tp2-dp4`](../glm5.2-b300-tp2-dp4).
 
 ## Deploy
 
@@ -32,17 +39,11 @@ kubectl apply -f dsv4flash-pd-deploy.yaml
 kubectl rollout status deploy/dsv4flash-intra-pd
 ```
 
-Targets a `p6-b300.48xlarge` node (`nodeAffinity` in the manifest matches both
-the bare EKS `p6-b300.48xlarge` and the HyperPod `ml.p6-b300.48xlarge`
-instance-type label).
+Targets a `p6-b300.48xlarge` node (`nodeAffinity` in the manifest matches both the bare EKS `p6-b300.48xlarge` and the HyperPod `ml.p6-b300.48xlarge` instance-type label).
 
-The **one** thing you must set per environment is the NVMe `hostPath` near the
-bottom of the manifest — the local disk is mounted at a different path on each
-AMI (`/opt/dlami/nvme/...` on HyperPod, `/mnt/k8s-disks/0/...` on self-managed
-EKS). The default is HyperPod's.
+The **one** thing you must set per environment is the NVMe `hostPath` near the bottom of the manifest — the local disk is mounted at a different path on each AMI (`/opt/dlami/nvme/...` on HyperPod, `/mnt/k8s-disks/0/...` on self-managed EKS). The default is HyperPod's.
 
-The router exposes an OpenAI-compatible endpoint on `dsv4flash-router:30080`
-(`ClusterIP`) — port-forward to call it:
+The router exposes an OpenAI-compatible endpoint on `dsv4flash-router:30080` (`ClusterIP`) — port-forward to call it:
 
 ```bash
 kubectl port-forward svc/dsv4flash-router 30080:30080

--- a/examples/inference/sglang/dsv4flash-b300-intra-3p1d/README.md
+++ b/examples/inference/sglang/dsv4flash-b300-intra-3p1d/README.md
@@ -1,0 +1,54 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->
+
+# DeepSeek-V4-Flash — Intra-node PD on B300 (EKS / HyperPod)
+
+Prefill/decode disaggregation **within a single 8-GPU B300 node** using SGLang.
+All engines run in one pod on one node: three prefill instances and one decode
+instance, each `tp=2` spanning **two GPUs**, split via `--base-gpu-id`:
+
+| Role | GPUs | HTTP port | Bootstrap port |
+|---|---|---|---|
+| prefill 0 | 0, 1 | 30000 | 9000 |
+| prefill 1 | 2, 3 | 30100 | 9100 |
+| prefill 2 | 4, 5 | 30200 | 9200 |
+| decode    | 6, 7 | 30300 | 9300 |
+
+HTTP ports are spaced 100 apart on purpose: with `--enable-dp-attention`,
+SGLang derives a **block** of internal TCP ports at `--port + 233` (dist-init,
+detokenizer, rpc, metrics, scheduler-input, one per dp rank). Adjacent base
+ports would overlap those blocks and fail with *"Address already in use"*.
+
+KV cache moves prefill → decode over **NIXL**, staying intra-node. A router
+sidecar shares the pod network namespace and reaches every engine on
+`127.0.0.1`.
+
+## Deploy
+
+```bash
+kubectl apply -f dsv4flash-pd-deploy.yaml
+kubectl rollout status deploy/dsv4flash-intra-pd
+```
+
+Targets a `p6-b300.48xlarge` node (`nodeAffinity` in the manifest matches both
+the bare EKS `p6-b300.48xlarge` and the HyperPod `ml.p6-b300.48xlarge`
+instance-type label).
+
+The **one** thing you must set per environment is the NVMe `hostPath` near the
+bottom of the manifest — the local disk is mounted at a different path on each
+AMI (`/opt/dlami/nvme/...` on HyperPod, `/mnt/k8s-disks/0/...` on self-managed
+EKS). The default is HyperPod's.
+
+The router exposes an OpenAI-compatible endpoint on `dsv4flash-router:30080`
+(`ClusterIP`) — port-forward to call it:
+
+```bash
+kubectl port-forward svc/dsv4flash-router 30080:30080
+curl http://localhost:30080/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "deepseek-ai/DeepSeek-V4-Flash", "prompt": "The capital of France is", "max_tokens": 32}'
+```
+
+Tear down with `kubectl delete -f dsv4flash-pd-deploy.yaml`.

--- a/examples/inference/sglang/dsv4flash-b300-intra-3p1d/README.md
+++ b/examples/inference/sglang/dsv4flash-b300-intra-3p1d/README.md
@@ -36,7 +36,7 @@ So the rule of thumb encoded by this repo's samples:
 
 ## Deploy
 
-**Pre-stage the weights first (recommended)** — this pod runs **four** engine processes that all load the same model from the node's HF cache; without pre-staging, the cold start begins with the decode engine downloading the full weights before anything else can proceed:
+**Pre-stage the weights first (required for this sample)** — this pod runs **four** engine processes that all load the same model from the node's HF cache; the decode engine's startup wait-loop gives up after 20 min, so on a cold cache the full weights must download first or the pod restarts until the node cache fills:
 
 ```bash
 ../download-model.sh deepseek-ai/DeepSeek-V4-Flash ml.p6-b300.48xlarge

--- a/examples/inference/sglang/dsv4flash-b300-intra-3p1d/README.md
+++ b/examples/inference/sglang/dsv4flash-b300-intra-3p1d/README.md
@@ -28,11 +28,21 @@ So the rule of thumb encoded by this repo's samples:
 
 - **PD split across pods/nodes** — correct when the pods are connected by RDMA(EFA); see [`kimi2.6-h200-1p1d`](../kimi2.6-h200-1p1d), where prefill and decode are separate StatefulSets.
 - **PD within one node, no RDMA between engines** — the engines must live in one container that owns all 8 GPUs, as here. The pod is still a single
-  schedulable, restartable unit: probes watch the foreground engine and the whole group restarts together (`strategy: Recreate`), which is also the
-  correct failure semantics — a half-alive PD group can't serve anyway.
+  schedulable, restartable unit: the liveness probe ANDs the `/health` of **all four engines**, so if any engine dies the whole group restarts together
+  (`strategy: Recreate`). The router does health-check around a dead prefill, but that leaves the pod serving at reduced capacity with no path back to
+  full — and a dead decode leaves nothing to route to at all — so any dead engine triggers a group restart (at the cost of the ~30 min cold start).
+  Readiness stays on the foreground engine only, so a dying background engine doesn't cut traffic before the restart lands.
 - **No PD at all** — if you just want N independent engines on a node, one-engine-per-pod is the native shape; see [`glm5.2-b300-tp2-dp4`](../glm5.2-b300-tp2-dp4).
 
 ## Deploy
+
+**Pre-stage the weights first (recommended)** — this pod runs **four** engine processes that all load the same model from the node's HF cache; without pre-staging, the cold start begins with the decode engine downloading the full weights before anything else can proceed:
+
+```bash
+../download-model.sh deepseek-ai/DeepSeek-V4-Flash ml.p6-b300.48xlarge
+# wait for "Download complete!" in the downloader pod's logs, then:
+kubectl delete daemonset model-downloader
+```
 
 ```bash
 kubectl apply -f dsv4flash-pd-deploy.yaml

--- a/examples/inference/sglang/dsv4flash-b300-intra-3p1d/dsv4flash-pd-deploy.yaml
+++ b/examples/inference/sglang/dsv4flash-b300-intra-3p1d/dsv4flash-pd-deploy.yaml
@@ -1,0 +1,266 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# DeepSeek-V4-Flash intra-node PD on a single 8-GPU B300 node (EKS / HyperPod).
+#
+# All engines run in ONE pod on ONE node: the sglang-pd container claims all
+# 8 GPUs and starts 3 prefill instances + 1 decode instance, each spanning
+# TWO GPUs (tp=2), split via --base-gpu-id:
+#   prefill 0 -> GPU 0,1   prefill 1 -> GPU 2,3   prefill 2 -> GPU 4,5
+#   decode   -> GPU 6,7
+# KV cache moves prefill -> decode over NIXL, staying intra-node. A router
+# sidecar shares the pod network namespace, so it reaches every engine on
+# 127.0.0.1 (same as the compose host network).
+#
+#   kubectl apply -f dsv4flash-pd-deploy.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dsv4flash-router
+spec:
+  selector:
+    app: dsv4flash-intra-pd
+  ports:
+  - name: http
+    port: 30080
+    targetPort: 30080
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dsv4flash-intra-pd
+  labels:
+    app: dsv4flash-intra-pd
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dsv4flash-intra-pd
+  template:
+    metadata:
+      labels:
+        app: dsv4flash-intra-pd
+        sglang-metrics: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "30000"
+        prometheus.io/path: "/metrics"
+    spec:
+      # Target a p6-b300.48xlarge on either cluster type. A plain EKS managed
+      # nodegroup labels instance-type with the bare EC2 type; a SageMaker
+      # HyperPod instance group uses the `ml.` prefix. A nodeSelector can't
+      # express OR, so match both with nodeAffinity In.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                - p6-b300.48xlarge      # plain EKS managed nodegroup
+                - ml.p6-b300.48xlarge   # SageMaker HyperPod instance group
+      # An eksctl B300 nodegroup taints nodes nvidia.com/gpu=true:NoSchedule to
+      # keep non-GPU pods off; HyperPod nodes have no such taint. A toleration is
+      # a no-op when the taint is absent, so it's safe to always carry it.
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      containers:
+      # ---- 3 prefill + 1 decode engines, all on one node -------------------
+      - name: sglang-pd
+        # Same upstream SGLang image as the other examples — DeepSeek-V4-Flash
+        # serves correctly on it; the model/kernel knobs are all driven by the
+        # SGLANG_OPT_* env vars and serve flags below, not by a dedicated image.
+        image: lmsysorg/sglang:v0.5.12.post1-cu130
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add: ["SYS_NICE", "IPC_LOCK"]
+        env:
+        - name: NIXL_LOG_LEVEL
+          value: INFO
+        # The ONLY model env var the SGLang cookbook lists for the verified
+        # b300 / DeepSeek-V4-Flash / fp4 / high-throughput cell. (The Pro
+        # single-node example needs a longer SGLANG_OPT_* set; Flash does not.)
+        - name: SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK
+          value: "8320"
+        ports:
+        - containerPort: 30000
+          name: http
+        - containerPort: 30080
+          name: router
+        volumeMounts:
+        - name: shm
+          mountPath: /dev/shm
+        - name: nvme-hf
+          mountPath: /root/.cache/huggingface
+        - name: nvme-tmp
+          mountPath: /tmp
+        resources:
+          limits:
+            nvidia.com/gpu: 8
+        # Probe the foreground prefill (30200) — it keeps the container alive, so
+        # if it wedges the pod should restart. The 1800s initial delay clears the
+        # long cold start (4 engines load + DeepGEMM JIT + CUDA-graph capture,
+        # gated behind the decode-ready wait loop) so liveness never fires during
+        # warmup.
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 30200
+          initialDelaySeconds: 1800
+          periodSeconds: 60
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 30200
+          initialDelaySeconds: 180
+          periodSeconds: 10
+          timeoutSeconds: 5
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+
+          # Flags shared by every engine (prefill + decode). These mirror the
+          # SGLang cookbook's verified b300 / DeepSeek-V4-Flash / fp4 /
+          # high-throughput single-node cell — tp=4,dp=4 there — scaled down to
+          # tp=2,dp=2 so each engine fits on two GPUs. Per-role flags
+          # (--disaggregation-mode, --base-gpu-id, ports) are appended below.
+          COMMON="--trust-remote-code \
+            --model-path deepseek-ai/DeepSeek-V4-Flash \
+            --tp 2 \
+            --dp 2 \
+            --enable-dp-attention \
+            --moe-a2a-backend megamoe \
+            --mem-fraction-static 0.85 \
+            --cuda-graph-max-bs 64 \
+            --disaggregation-transfer-backend nixl \
+            --skip-server-warmup \
+            --enable-metrics \
+            --host 0.0.0.0"
+
+          # Engine HTTP ports are spaced 100 apart on purpose. With
+          # --enable-dp-attention on a single node, SGLang derives a BLOCK of
+          # internal TCP ports at (--port + 233): dist_init, detokenizer, rpc,
+          # metrics, scheduler_input, plus one per dp rank. Ports spaced only 1
+          # apart would overlap those blocks ("Address already in use"), so we
+          # use 30000 / 30100 / 30200 (prefill) and 30300 (decode).
+
+          # ---- 1 decode instance (GPU 6,7) ----
+          python3 -m sglang.launch_server $COMMON \
+            --port 30300 --base-gpu-id 6 \
+            --disaggregation-mode decode \
+            --disaggregation-bootstrap-port 9300 > /tmp/decode-30300.log 2>&1 &
+
+          echo "Waiting for decode instance (timeout 20 min)..."
+          for i in $(seq 1 240); do
+            if curl -sf http://localhost:30300/health > /dev/null 2>&1; then
+              echo "Decode instance ready after ${i}*5s"
+              break
+            fi
+            sleep 5
+          done
+          if ! curl -sf http://localhost:30300/health > /dev/null 2>&1; then
+            echo "ERROR: decode 30300 failed to start"; tail -100 /tmp/decode-30300.log; exit 1
+          fi
+          echo "Decode ready, starting prefill instances..."
+
+          # ---- 3 prefill instances, tp=2 each (GPU 0-1, 2-3, 4-5) ----
+          for gpu in 0 2; do
+            port=$((30000 + gpu * 50))   # gpu 0 -> 30000, gpu 2 -> 30100
+            bport=$((9000 + gpu * 50))    # gpu 0 -> 9000,  gpu 2 -> 9100
+            python3 -m sglang.launch_server $COMMON \
+              --port ${port} --base-gpu-id ${gpu} \
+              --disaggregation-mode prefill \
+              --disaggregation-bootstrap-port ${bport} > /tmp/prefill-${port}.log 2>&1 &
+          done
+
+          # Last prefill (GPU 4,5) runs in foreground (keeps container alive)
+          exec python3 -m sglang.launch_server $COMMON \
+            --port 30200 --base-gpu-id 4 \
+            --disaggregation-mode prefill \
+            --disaggregation-bootstrap-port 9200
+      # ---- PD router (shares pod network → reaches engines on 127.0.0.1) ---
+      - name: router
+        image: lmsysorg/sgl-model-gateway:v0.3.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 30080
+          name: http
+        resources:
+          requests:
+            cpu: "2"
+            memory: 4Gi
+          limits:
+            cpu: "4"
+            memory: 8Gi
+        # Liveness is a bare TCP check, not /readiness: the router reports
+        # not-ready whenever its backends are down, and we must not restart the
+        # router for that — only when its own process has wedged.
+        livenessProbe:
+          tcpSocket:
+            port: 30080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 30080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        command:
+        - python3
+        - -m
+        - sglang_router.launch_router
+        args:
+        - --host
+        - "0.0.0.0"
+        - --port
+        - "30080"
+        - --pd-disaggregation
+        - --prefill-policy
+        - round_robin
+        - --decode-policy
+        - round_robin
+        - --prefill
+        - http://127.0.0.1:30000
+        - "9000"
+        - --prefill
+        - http://127.0.0.1:30100
+        - "9100"
+        - --prefill
+        - http://127.0.0.1:30200
+        - "9200"
+        - --decode
+        - http://127.0.0.1:30300
+      volumes:
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 64Gi
+      # ⚠️  SET THIS PER CLUSTER — the one thing scheduling can't auto-detect.
+      # The node's local NVMe is mounted at different paths on the two AMIs:
+      #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
+      #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
+      # Picking the WRONG path is not a hard error: type=DirectoryOrCreate will
+      # silently create an empty dir on the small root disk, and the 500GB+
+      # weights then download there and can fill it up.
+      - name: nvme-hf
+        hostPath:
+          path: /opt/dlami/nvme/huggingface  # For EKS: /mnt/k8s-disks/0/huggingface
+          type: DirectoryOrCreate
+      - name: nvme-tmp
+        hostPath:
+          path: /opt/dlami/nvme/tmp          # For EKS: /mnt/k8s-disks/0/tmp
+          type: DirectoryOrCreate

--- a/examples/inference/sglang/dsv4flash-b300-intra-3p1d/dsv4flash-pd-deploy.yaml
+++ b/examples/inference/sglang/dsv4flash-b300-intra-3p1d/dsv4flash-pd-deploy.yaml
@@ -12,6 +12,15 @@
 # sidecar shares the pod network namespace, so it reaches every engine on
 # 127.0.0.1 (same as the compose host network).
 #
+# Why one pod with 4 engine processes, not one pod per engine? Intra-node KV
+# transfer rides NVLink via CUDA IPC, which requires the prefill and decode
+# processes to see each other's GPUs and share an IPC namespace. Pods (and
+# containers) each get a DISJOINT 2-GPU set from the device plugin and isolated
+# IPC namespaces, so CUDA IPC handles can't be opened across them and NIXL
+# falls back to TCP over the pod network — NVIDIA measures that fallback at
+# 200-500x worse TTFT. Splitting PD across pods is the right shape only with
+# RDMA between them (see ../kimi2.6-h200-1p1d for the EFA-based version).
+#
 #   kubectl apply -f dsv4flash-pd-deploy.yaml
 ---
 apiVersion: v1
@@ -46,6 +55,11 @@ spec:
         app: dsv4flash-intra-pd
         sglang-metrics: "true"
       annotations:
+        # The prometheus.io annotation convention carries ONE port, but this pod
+        # runs four engines (30000/30100/30200/30300), each with its own
+        # /metrics. Annotation-driven scrapers therefore only see prefill-0; to
+        # scrape all four, target the named container ports (prefill-*/decode)
+        # via the sglang-metrics label instead.
         prometheus.io/scrape: "true"
         prometheus.io/port: "30000"
         prometheus.io/path: "/metrics"
@@ -91,11 +105,17 @@ spec:
         # single-node example needs a longer SGLANG_OPT_* set; Flash does not.)
         - name: SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK
           value: "8320"
+        # One named port per engine — exactly what this container listens on.
+        # 30080 belongs to the router sidecar and is declared there, not here.
         ports:
         - containerPort: 30000
-          name: http
-        - containerPort: 30080
-          name: router
+          name: prefill-0
+        - containerPort: 30100
+          name: prefill-1
+        - containerPort: 30200
+          name: prefill-2
+        - containerPort: 30300
+          name: decode
         volumeMounts:
         - name: shm
           mountPath: /dev/shm

--- a/examples/inference/sglang/dsv4flash-b300-intra-3p1d/dsv4flash-pd-deploy.yaml
+++ b/examples/inference/sglang/dsv4flash-b300-intra-3p1d/dsv4flash-pd-deploy.yaml
@@ -126,18 +126,33 @@ spec:
         resources:
           limits:
             nvidia.com/gpu: 8
-        # Probe the foreground prefill (30200) — it keeps the container alive, so
-        # if it wedges the pod should restart. The 1800s initial delay clears the
-        # long cold start (4 engines load + DeepGEMM JIT + CUDA-graph capture,
-        # gated behind the decode-ready wait loop) so liveness never fires during
-        # warmup.
+        # Liveness ANDs all four engines: httpGet can only hit one port, and a
+        # dead engine is otherwise never recovered — the router health-checks
+        # around a dead prefill (pod stays Ready at 2/3 capacity), and a dead
+        # decode leaves nothing to route to at all. Any engine down for
+        # 5x60s restarts the whole container, i.e. the whole PD group
+        # (~30 min cold start — the price of self-healing back to full
+        # capacity). The 1800s initial delay clears that cold start (4 engines
+        # load + DeepGEMM JIT + CUDA-graph capture, gated behind the
+        # decode-ready wait loop) so liveness never fires during warmup.
         livenessProbe:
-          httpGet:
-            path: /health
-            port: 30200
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              for p in 30000 30100 30200 30300; do
+                curl -sf -m 5 http://127.0.0.1:${p}/health || exit 1
+              done
           initialDelaySeconds: 1800
           periodSeconds: 60
+          timeoutSeconds: 30
           failureThreshold: 5
+        # Readiness deliberately does NOT AND the engines: it watches only the
+        # foreground prefill. If it also required every engine, one dead
+        # background engine would instantly flip the pod NotReady and stop ALL
+        # traffic (replicas: 1) during the up-to-5-min window before liveness
+        # restarts it — worse than serving degraded until the restart lands.
         readinessProbe:
           httpGet:
             path: /health

--- a/examples/inference/sglang/glm5.2-b300-tp2-dp4/README.md
+++ b/examples/inference/sglang/glm5.2-b300-tp2-dp4/README.md
@@ -1,0 +1,79 @@
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->
+
+# GLM-5.2 (NVFP4) — 4× tp=2 replicas + SGLang router on B300 (EKS / HyperPod)
+
+The NVFP4 checkpoint fits in 2 GPUs, so instead of one big engine the node runs
+**four independent tp=2 engines** (4 × 2 GPUs = 8 GPUs), fronted by an
+**SGLang router** (`lmsysorg/sgl-model-gateway`) that load-balances across them
+with its cache-aware policy. Each engine runs `tp=2, dp=2,
+--enable-dp-attention` internally.
+
+## Why 4× tp=2 replicas instead of one tp=2/dp=4 engine
+
+- **Elastic scaling** — replicas are the scaling unit: `kubectl scale` (or an
+  HPA) adds/removes engines two GPUs at a time, and spilling onto a second
+  node needs no config change. One monolithic engine can only scale by
+  redeploying.
+- **Failure isolation & rolling updates** — one wedged engine restarts alone
+  while the other 3 keep serving; a rolling update keeps 3/4 capacity online
+  (`maxSurge: 0, maxUnavailable: 1`, since all 8 GPUs are taken).
+- **Engine constraint** — with `--enable-dp-attention` SGLang requires `dp` to
+  divide `tp`, so `tp=2, dp=4` is not a valid single-engine config anyway.
+
+## Prerequisites
+
+1. **Provision the B300 node** — on self-managed (eksctl) EKS, create the
+   nodegroup first: see
+   [`../dsv4pro-b300-single-node/NODEGROUP-EKS.md`](../dsv4pro-b300-single-node/NODEGROUP-EKS.md).
+   On HyperPod-on-EKS, nodes are already provisioned.
+2. **Pre-stage the weights** (recommended) — all four replicas share the
+   node's HF cache, so download once instead of having 4 engines race:
+
+   ```bash
+   ../download-model.sh nvidia/GLM-5.2-NVFP4 ml.p6-b300.48xlarge
+   ```
+
+## Deploy
+
+```bash
+kubectl apply -f manifests/glm52-deploy.yaml
+kubectl rollout status deploy/glm52-tp2      # expect 4/4 Running
+kubectl rollout status deploy/glm52-router
+```
+
+The manifest runs on **both** HyperPod-on-EKS and self-managed EKS (same
+`nodeAffinity` + GPU-taint-toleration scheme as the other samples).
+
+The **one** thing you must set per environment is the NVMe `hostPath` near the
+bottom of the manifest — the local disk is mounted at a different path on each
+AMI (`/opt/dlami/nvme/...` on HyperPod, `/mnt/k8s-disks/0/...` on self-managed
+EKS). The default is HyperPod's.
+
+The router exposes an OpenAI-compatible endpoint on `glm52-router:30080`
+(`ClusterIP`) — port-forward to call it:
+
+```bash
+kubectl port-forward svc/glm52-router 30080:30080
+curl http://localhost:30080/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "nvidia/GLM-5.2-NVFP4", "prompt": "The capital of France is", "max_tokens": 32}'
+```
+
+Tear down with `kubectl delete -f manifests/glm52-deploy.yaml`.
+
+## Benchmark
+
+Benchmark through the **router** (not a single engine pod) so all 4 engines
+are exercised:
+
+```bash
+kubectl port-forward svc/glm52-router 30080:30080 &
+python3 -m sglang.bench_serving --backend sglang \
+  --base-url http://localhost:30080 \
+  --dataset-name random --num-prompts 1000 \
+  --random-input 2048 --random-output 256 \
+  --request-rate inf --max-concurrency 100
+```

--- a/examples/inference/sglang/glm5.2-b300-tp2-dp4/README.md
+++ b/examples/inference/sglang/glm5.2-b300-tp2-dp4/README.md
@@ -19,11 +19,15 @@ The NVFP4 checkpoint fits in 2 GPUs, so instead of one big engine the node runs 
 
 1. **Provision the B300 node** — on self-managed (eksctl) EKS, create the nodegroup first: see [`../dsv4pro-b300-single-node/NODEGROUP-EKS.md`](../dsv4pro-b300-single-node/NODEGROUP-EKS.md).
    On HyperPod-on-EKS, nodes are already provisioned.
-2. **Pre-stage the weights** (recommended) — all four replicas share the node's HF cache, so download once instead of having 4 engines race:
-   
+2. **Pre-stage the weights** (recommended) — the downloader is a DaemonSet, so every matching B300 node gets the weights staged into its NVMe HF cache
+   (the same dir the engine pods mount at `/root/.cache/huggingface`); replicas landing on that node then load from local disk instead of downloading:
+
    ```bash
    ../download-model.sh nvidia/GLM-5.2-NVFP4 ml.p6-b300.48xlarge
    ```
+
+   Without pre-staging the engines still come up — replicas sharing a node converge on one download via HF's file locks — but each node pulls the full
+   465 GB itself, so on a multi-node cluster expect one full download per node either way; pre-staging just moves it ahead of pod startup.
 
 ## Deploy
 

--- a/examples/inference/sglang/glm5.2-b300-tp2-dp4/README.md
+++ b/examples/inference/sglang/glm5.2-b300-tp2-dp4/README.md
@@ -5,33 +5,22 @@ SPDX-License-Identifier: MIT-0
 
 # GLM-5.2 (NVFP4) — 4× tp=2 replicas + SGLang router on B300 (EKS / HyperPod)
 
-The NVFP4 checkpoint fits in 2 GPUs, so instead of one big engine the node runs
-**four independent tp=2 engines** (4 × 2 GPUs = 8 GPUs), fronted by an
-**SGLang router** (`lmsysorg/sgl-model-gateway`) that load-balances across them
-with its cache-aware policy. Each engine runs `tp=2, dp=2,
---enable-dp-attention` internally.
+The NVFP4 checkpoint fits in 2 GPUs, so instead of one big engine the node runs **four independent tp=2 engines** (4 × 2 GPUs = 8 GPUs), fronted by an **SGLang router** (`lmsysorg/sgl-model-gateway`) that load-balances across them with its cache-aware policy. Each engine runs `tp=2, dp=2,--enable-dp-attention` internally.
 
 ## Why 4× tp=2 replicas instead of one tp=2/dp=4 engine
 
-- **Elastic scaling** — replicas are the scaling unit: `kubectl scale` (or an
-  HPA) adds/removes engines two GPUs at a time, and spilling onto a second
-  node needs no config change. One monolithic engine can only scale by
-  redeploying.
-- **Failure isolation & rolling updates** — one wedged engine restarts alone
-  while the other 3 keep serving; a rolling update keeps 3/4 capacity online
+- **Elastic scaling** — replicas are the scaling unit: `kubectl scale` (or an HPA) adds/removes engines two GPUs at a time, and spilling onto a second
+  node needs no config change. One monolithic engine can only scale by redeploying.
+- **Failure isolation & rolling updates** — one wedged engine restarts alone while the other 3 keep serving; a rolling update keeps 3/4 capacity online
   (`maxSurge: 0, maxUnavailable: 1`, since all 8 GPUs are taken).
-- **Engine constraint** — with `--enable-dp-attention` SGLang requires `dp` to
-  divide `tp`, so `tp=2, dp=4` is not a valid single-engine config anyway.
+- **Engine constraint** — with `--enable-dp-attention` SGLang requires `dp` to divide `tp`, so `tp=2, dp=4` is not a valid single-engine config anyway.
 
 ## Prerequisites
 
-1. **Provision the B300 node** — on self-managed (eksctl) EKS, create the
-   nodegroup first: see
-   [`../dsv4pro-b300-single-node/NODEGROUP-EKS.md`](../dsv4pro-b300-single-node/NODEGROUP-EKS.md).
+1. **Provision the B300 node** — on self-managed (eksctl) EKS, create the nodegroup first: see [`../dsv4pro-b300-single-node/NODEGROUP-EKS.md`](../dsv4pro-b300-single-node/NODEGROUP-EKS.md).
    On HyperPod-on-EKS, nodes are already provisioned.
-2. **Pre-stage the weights** (recommended) — all four replicas share the
-   node's HF cache, so download once instead of having 4 engines race:
-
+2. **Pre-stage the weights** (recommended) — all four replicas share the node's HF cache, so download once instead of having 4 engines race:
+   
    ```bash
    ../download-model.sh nvidia/GLM-5.2-NVFP4 ml.p6-b300.48xlarge
    ```
@@ -44,16 +33,11 @@ kubectl rollout status deploy/glm52-tp2      # expect 4/4 Running
 kubectl rollout status deploy/glm52-router
 ```
 
-The manifest runs on **both** HyperPod-on-EKS and self-managed EKS (same
-`nodeAffinity` + GPU-taint-toleration scheme as the other samples).
+The manifest runs on **both** HyperPod-on-EKS and self-managed EKS (same `nodeAffinity` + GPU-taint-toleration scheme as the other samples).
 
-The **one** thing you must set per environment is the NVMe `hostPath` near the
-bottom of the manifest — the local disk is mounted at a different path on each
-AMI (`/opt/dlami/nvme/...` on HyperPod, `/mnt/k8s-disks/0/...` on self-managed
-EKS). The default is HyperPod's.
+The **one** thing you must set per environment is the NVMe `hostPath` near the bottom of the manifest — the local disk is mounted at a different path on each AMI (`/opt/dlami/nvme/...` on HyperPod, `/mnt/k8s-disks/0/...` on self-managed EKS). The default is HyperPod's.
 
-The router exposes an OpenAI-compatible endpoint on `glm52-router:30080`
-(`ClusterIP`) — port-forward to call it:
+The router exposes an OpenAI-compatible endpoint on `glm52-router:30080` (`ClusterIP`) — port-forward to call it:
 
 ```bash
 kubectl port-forward svc/glm52-router 30080:30080

--- a/examples/inference/sglang/glm5.2-b300-tp2-dp4/manifests/glm52-deploy.yaml
+++ b/examples/inference/sglang/glm5.2-b300-tp2-dp4/manifests/glm52-deploy.yaml
@@ -199,7 +199,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: sglang
-        image: lmsysorg/sglang:dev-glm52-nvfp4
+        image: lmsysorg/sglang@sha256:bafcd07dbc511ca4cbae8e3865fecca98a0323b777c83c4d3083008228891f65  # dev-glm52-nvfp4, until GLM-5.2 NVFP4 lands in a tagged release
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:

--- a/examples/inference/sglang/glm5.2-b300-tp2-dp4/manifests/glm52-deploy.yaml
+++ b/examples/inference/sglang/glm5.2-b300-tp2-dp4/manifests/glm52-deploy.yaml
@@ -1,0 +1,300 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# GLM-5.2 (NVFP4) multi-replica serving on a single 8-GPU B300 node.
+# The NVFP4 checkpoint is small enough for a 2-GPU engine, so instead of one
+# tp=8 engine spanning the node, FOUR independent tp=2 engines share it
+# (4 replicas x 2 GPUs = 8 GPUs). An SGLang router in front discovers the
+# engine pods via the Kubernetes API (label selector) and load-balances with
+# its cache-aware policy — that is the dp=4 layer; inside each engine attention
+# runs dp=2 (--enable-dp-attention requires dp to divide tp, so tp=2/dp=4 in
+# ONE engine is not a valid combination).
+#
+# Runs on BOTH SageMaker HyperPod-on-EKS and self-managed (eksctl) EKS:
+#
+#   kubectl apply -f glm52-deploy.yaml
+#
+# Scheduling is handled for both cluster types automatically (see nodeAffinity +
+# tolerations below). The ONE thing you must set per environment is the NVMe
+# hostPath at the bottom of this file — see the WARNING there.
+#
+# Pre-stage the weights with ../download-model.sh before applying — otherwise
+# all four replicas cold-start by downloading the same HF repo into the same
+# shared cache at once.
+---
+# Entry point: the router, not the engines. Clients talk to glm52-router:30080;
+# the router forwards to whichever engine its policy picks.
+apiVersion: v1
+kind: Service
+metadata:
+  name: glm52-router
+spec:
+  selector:
+    app: glm52-router
+  ports:
+  - name: http
+    port: 30080
+    targetPort: 30080
+  type: ClusterIP
+---
+# The router discovers engine pods through the Kubernetes API (watch on pods
+# matching --selector), so it needs read access to pods in this namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: glm52-router
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: glm52-router
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: glm52-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: glm52-router
+subjects:
+- kind: ServiceAccount
+  name: glm52-router
+---
+# ---- SGLang router — cache-aware LB across the 4 engines -------------------
+# Unlike the qwen intra-PD sample (router sidecar, engines on 127.0.0.1), the
+# engines here are separate pods with dynamic IPs, so the router runs as its
+# own Deployment and tracks engines via Kubernetes service discovery: pods
+# matching the selector are added/removed as workers automatically — a rolling
+# engine update needs no router config change. Being CPU-only it schedules on
+# any node.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glm52-router
+  labels:
+    app: glm52-router
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: glm52-router
+  template:
+    metadata:
+      labels:
+        app: glm52-router
+    spec:
+      serviceAccountName: glm52-router
+      containers:
+      - name: router
+        image: lmsysorg/sgl-model-gateway:v0.3.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 30080
+          name: http
+        resources:
+          requests:
+            cpu: "2"
+            memory: 4Gi
+          limits:
+            cpu: "4"
+            memory: 8Gi
+        # Liveness is a bare TCP check, not /readiness: the router reports
+        # not-ready whenever its backends are down, and we must not restart the
+        # router for that — only when its own process has wedged.
+        livenessProbe:
+          tcpSocket:
+            port: 30080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 30080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        env:
+        # Scope discovery to the namespace this stack is deployed in, matching
+        # the namespace-scoped Role above (all-namespace watch would need a
+        # ClusterRole).
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+        - python3
+        - -m
+        - sglang_router.launch_router
+        args:
+        - --host
+        - "0.0.0.0"
+        - --port
+        - "30080"
+        - --policy
+        - cache_aware
+        - --service-discovery
+        - --service-discovery-namespace
+        - $(POD_NAMESPACE)
+        - --service-discovery-port
+        - "30000"
+        - --selector
+        - app=glm52-tp2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glm52-tp2
+  labels:
+    app: glm52-tp2
+spec:
+  # 4 x tp=2 engines fill the 8-GPU node; the router above spreads requests
+  # across them (cluster-level dp=4).
+  replicas: 4
+  # All 8 GPUs are taken when the 4 replicas are up, so a surge pod could never
+  # schedule — roll one replica at a time instead, keeping 3/4 serving.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: glm52-tp2
+  template:
+    metadata:
+      labels:
+        app: glm52-tp2
+        sglang-metrics: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "30000"
+        prometheus.io/path: "/metrics"
+    spec:
+      # Target a p6-b300.48xlarge on either cluster type. kubelet always sets
+      # node.kubernetes.io/instance-type; HyperPod instance groups use the
+      # SageMaker-style `ml.` prefix, a plain EKS managed nodegroup uses the
+      # bare EC2 type. A nodeSelector can't express OR, so use nodeAffinity In.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                - p6-b300.48xlarge      # plain EKS managed nodegroup
+                - ml.p6-b300.48xlarge   # SageMaker HyperPod instance group
+      # The eksctl B300 nodegroup taints nodes nvidia.com/gpu=true:NoSchedule to
+      # keep non-GPU pods off; HyperPod nodes have no such taint. A toleration is
+      # a no-op when the taint is absent, so it's safe to always carry it.
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      containers:
+      - name: sglang
+        image: lmsysorg/sglang:dev-glm52-nvfp4
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add: ["IPC_LOCK"]
+        env:
+        # Feeds the subPathExpr below so the four co-located replicas don't
+        # race on the same /tmp compile caches.
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - containerPort: 30000
+          name: http
+        volumeMounts:
+        - name: shm
+          mountPath: /dev/shm
+        - name: nvme-hf
+          mountPath: /root/.cache/huggingface
+        - name: nvme-tmp
+          mountPath: /tmp
+          subPathExpr: $(POD_NAME)
+        resources:
+          limits:
+            nvidia.com/gpu: 2
+        # /health returns 200 once the API server is up, but the engine can still
+        # wedge on a stuck CUDA-graph capture. Restart after 5 consecutive misses;
+        # the 1800s initial delay clears the cold start (weight load + CUDA-graph
+        # capture) so liveness never fires during warmup.
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 30000
+          initialDelaySeconds: 1800
+          periodSeconds: 60
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 30000
+          initialDelaySeconds: 180
+          periodSeconds: 10
+          timeoutSeconds: 5
+        command:
+        - sglang
+        - serve
+        - --trust-remote-code
+        - --model-path
+        - nvidia/GLM-5.2-NVFP4
+        - --tp
+        - "2"
+        - --dp
+        - "2"
+        - --enable-dp-attention
+        - --quantization
+        - modelopt_fp4
+        # Split <think> blocks into reasoning_content and parse GLM-style tool
+        # calls into structured tool_calls in the OpenAI-compatible responses.
+        - --reasoning-parser
+        - glm45
+        - --tool-call-parser
+        - glm47
+        - --max-running-requests
+        - "32"
+        - --chunked-prefill-size
+        - "8192"
+        - --mem-fraction-static
+        - "0.88"
+        - --enable-metrics
+        - --host
+        - 0.0.0.0
+        - --port
+        - "30000"
+      volumes:
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 64Gi
+      # ⚠️  SET THIS PER CLUSTER — the one thing scheduling can't auto-detect.
+      # The node's local NVMe is mounted at different paths on the two AMIs.
+      # Default below is HyperPod's DLAMI mount; for self-managed EKS swap both
+      # paths to the instance-store RAID0 (commented). Picking the WRONG path is
+      # not a hard error: type=DirectoryOrCreate will silently create an empty
+      # dir on the small root disk and the weights will fill it up.
+      #
+      #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
+      #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
+      #
+      # The HF cache is shared by all four replicas on the node — the weights
+      # are downloaded (or pre-staged) once and read by every engine.
+      - name: nvme-hf
+        hostPath:
+          path: /opt/dlami/nvme/huggingface  #For EKS: /mnt/k8s-disks/0/huggingface
+          type: DirectoryOrCreate
+      - name: nvme-tmp
+        hostPath:
+          path: /opt/dlami/nvme/tmp         #For EKS: /mnt/k8s-disks/0/tmp
+          type: DirectoryOrCreate

--- a/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/README.md
+++ b/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/README.md
@@ -37,6 +37,14 @@ Tear down with `kubectl delete -f qwen-pd-deploy.yaml`.
 
 ## Notes
 
+- **Why one pod with eight engine processes** instead of one pod per engine:
+  intra-node NIXL moves KV pages over NVLink via CUDA IPC, which only works
+  between processes that share an IPC namespace and see each other's GPUs —
+  impossible across pods/containers, which each get a disjoint GPU set. The
+  same trade-off is explained in detail in
+  [`../dsv4flash-b300-intra-3p1d`](../dsv4flash-b300-intra-3p1d); the
+  pod-per-role PD shape needs RDMA and is shown in
+  [`../kimi2.6-h200-1p1d`](../kimi2.6-h200-1p1d).
 - Weights are read from the node's NVMe at `/opt/dlami/nvme/huggingface`
   (mounted into the container as `~/.cache/huggingface`). Optionally pre-stage
   them with the shared [`../download-model.sh`](..):

--- a/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/qwen-pd-deploy.yaml
+++ b/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/qwen-pd-deploy.yaml
@@ -9,6 +9,15 @@
 # NIXL, staying intra-node. A router sidecar shares the pod network namespace,
 # so it reaches every engine on 127.0.0.1 (same as the compose host network).
 #
+# Why one pod with 8 engine processes, not one pod per engine? Intra-node KV
+# transfer rides NVLink via CUDA IPC, which requires the prefill and decode
+# processes to see each other's GPUs and share an IPC namespace. Pods (and
+# containers) each get a DISJOINT GPU set from the device plugin and isolated
+# IPC namespaces, so CUDA IPC handles can't be opened across them and NIXL
+# falls back to TCP over the pod network — NVIDIA measures that fallback at
+# 200-500x worse TTFT. Splitting PD across pods is the right shape only with
+# RDMA between them (see ../kimi2.6-h200-1p1d for the EFA-based version).
+#
 #   kubectl apply -f qwen-pd-deploy.yaml
 ---
 apiVersion: v1
@@ -43,6 +52,11 @@ spec:
         app: qwen35-intra-pd
         sglang-metrics: "true"
       annotations:
+        # The prometheus.io annotation convention carries ONE port, but this pod
+        # runs eight engines (30000-30005, 30010-30011), each with its own
+        # /metrics. Annotation-driven scrapers therefore only see prefill-0; to
+        # scrape all eight, target the named container ports (prefill-*/
+        # decode-*) via the sglang-metrics label instead.
         prometheus.io/scrape: "true"
         prometheus.io/port: "30000"
         prometheus.io/path: "/metrics"
@@ -81,11 +95,25 @@ spec:
         env:
         - name: NIXL_LOG_LEVEL
           value: INFO
+        # One named port per engine — exactly what this container listens on.
+        # 30080 belongs to the router sidecar and is declared there, not here.
         ports:
         - containerPort: 30000
-          name: http
-        - containerPort: 30080
-          name: router
+          name: prefill-0
+        - containerPort: 30001
+          name: prefill-1
+        - containerPort: 30002
+          name: prefill-2
+        - containerPort: 30003
+          name: prefill-3
+        - containerPort: 30004
+          name: prefill-4
+        - containerPort: 30005
+          name: prefill-5
+        - containerPort: 30010
+          name: decode-0
+        - containerPort: 30011
+          name: decode-1
         volumeMounts:
         - name: shm
           mountPath: /dev/shm


### PR DESCRIPTION
Follow-up to #1128, adding two more SGLang inference examples for HyperPod EKS:

## dsv4flash-b300-intra-3p1d

Prefill/decode disaggregation on a single 8-GPU B300 node — 3 prefill + 1 decode engines (tp=2 each) in one pod, KV transfer over NIXL, router sidecar on 127.0.0.1.

## glm5.2-b300-tp2-dp4

Four independent tp=2 engines fill the node, fronted by an SGLang router (cache-aware load balancing, Kubernetes service discovery) — cluster-level dp=4 with per-replica scaling and rolling updates.

## Other changes

- Updated the examples table: added both samples and corrected the GLM-5.2 engine image (`dev-glm52-nvfp4`, not yet in a tagged release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)