### PR TITLE
chore(aws-pcs): clean up deploy-all parameter presentation

### DIFF
--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -132,18 +132,28 @@ complete reference see [PARAMETERS.md](./docs/PARAMETERS.md).
 | `PseriesInstanceType` | `p5.48xlarge` | Picks the matching template + EFA NIC count automatically. See [GPU compute](#gpu-compute-p5p6) for the accepted types |
 | `CapacityReservationId` | *(empty)* | Capacity **Block** ID for the GPU queue; empty for On-Demand/ODCR |
 
-**5. Additional Cluster Configuration (Monitoring, Multi-User, Container Runtime)**
+**5.1. Additional Cluster Configuration: Monitoring**
 
 | Parameter | Default | Purpose |
 |---|---|---|
 | `MonitoringStack` | `Prometheus-LoginNode` | Prometheus + Grafana on the login node, DCGM Exporter on GPU nodes. `none` disables it. See [§8.2](#82-monitoring) |
 | `GrafanaAccessCidr` | *(empty)* | Open HTTPS/443 (Grafana) on the login node to a trusted CIDR (default: SSM port-forward only) |
+
+(Group 5.1 also has `MonitoringRepo` / `MonitoringVersion` / `DcgmExporterImage` — pinned defaults, rarely changed; see [PARAMETERS.md](./docs/PARAMETERS.md).)
+
+**5.2. Additional Cluster Configuration: Multi-User Directory**
+
+| Parameter | Default | Purpose |
+|---|---|---|
 | `DirectoryService` | `none` | `OpenLDAP-LoginNode` for a multi-user cluster. See [§8.3](#83-user-management) |
-| `PostInstallScriptUrl` | *(empty → auto)* | First-boot script; empty auto-installs Enroot/Pyxis from your templates bucket. Rarely changed. See [PARAMETERS.md](./docs/PARAMETERS.md) |
 
-(Group 5 also has `MonitoringRepo` / `MonitoringVersion` / `DcgmExporterImage` — pinned defaults, rarely changed; see [PARAMETERS.md](./docs/PARAMETERS.md).)
+**5.3. Additional Cluster Configuration: Post-Install Script**
 
-**See [PARAMETERS.md](./docs/PARAMETERS.md) for the complete parameter reference** (all 7
+| Parameter | Default | Purpose |
+|---|---|---|
+| `PostInstallScriptUrl` | *(empty → auto)* | First-boot script on every node; empty (default) auto-installs the Enroot/Pyxis container runtime from your templates bucket. Point at your own script to customize. See [PARAMETERS.md](./docs/PARAMETERS.md) |
+
+**See [PARAMETERS.md](./docs/PARAMETERS.md) for the complete parameter reference** (all
 console parameter groups, with every default). The concept guides below cover the
 choices that need the most thought.
 

--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -623,8 +623,12 @@ multi-NIC EFA wiring per-family.
 instance type's actual `MaximumEfaInterfaces`, fails at launch.)
 
 **Placement group:** auto-created per-CNG by the template. Override with
-`OnDemandPlacementGroupName=<existing-pg-name>` to share one PG across multiple
-CNGs (e.g. heterogeneous tightly-coupled jobs that span CPU + GPU).
+`OnDemandPlacementGroupName=<existing-pg-name>` to launch the CPU CNG into an
+existing placement group instead — e.g. to share one PG across multiple CPU
+CNGs, or to consume capacity reserved into a customer-owned CPG. (The P5/P6
+GPU templates don't expose an existing-placement-group option: a Capacity
+Block carries its own placement and works as-is; targeting a customer-owned
+CPG from the GPU templates is a future item.)
 
 **Multi-NIC bandwidth needs multiple MPI pairs.** A single MPI pair uses one
 libfabric endpoint and only one NIC. Use `osu_mbw_mr -np 32 -N 16` (or your

--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -622,11 +622,9 @@ multi-NIC EFA wiring per-family.
 (Setting a count > 0 on a non-EFA type, or mismatching the count with the
 instance type's actual `MaximumEfaInterfaces`, fails at launch.)
 
-**Placement group:** auto-created per-CNG by the template. To reuse an existing
-placement group across multiple CNGs (e.g. heterogeneous tightly-coupled jobs
-that span CPU + GPU), deploy the CNG with the modular
-[`add-cng.yaml`](./assets/add-cng.yaml) and set its `PlacementGroupName`
-parameter — deploy-all always auto-creates.
+**Placement group:** auto-created per-CNG by the template. Override with
+`OnDemandPlacementGroupName=<existing-pg-name>` to share one PG across multiple
+CNGs (e.g. heterogeneous tightly-coupled jobs that span CPU + GPU).
 
 **Multi-NIC bandwidth needs multiple MPI pairs.** A single MPI pair uses one
 libfabric endpoint and only one NIC. Use `osu_mbw_mr -np 32 -N 16` (or your

--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -612,9 +612,11 @@ multi-NIC EFA wiring per-family.
 (Setting a count > 0 on a non-EFA type, or mismatching the count with the
 instance type's actual `MaximumEfaInterfaces`, fails at launch.)
 
-**Placement group:** auto-created per-CNG by the template. Override with
-`OnDemandPlacementGroupName=<existing-pg-name>` to share one PG across multiple
-CNGs (e.g. heterogeneous tightly-coupled jobs that span CPU + GPU).
+**Placement group:** auto-created per-CNG by the template. To reuse an existing
+placement group across multiple CNGs (e.g. heterogeneous tightly-coupled jobs
+that span CPU + GPU), deploy the CNG with the modular
+[`add-cng.yaml`](./assets/add-cng.yaml) and set its `PlacementGroupName`
+parameter — deploy-all always auto-creates.
 
 **Multi-NIC bandwidth needs multiple MPI pairs.** A single MPI pair uses one
 libfabric endpoint and only one NIC. Use `osu_mbw_mr -np 32 -N 16` (or your

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -39,7 +39,6 @@ Metadata:
           - OnDemandCngName
           - OnDemandQueueName
           - OnDemandEfaInterfaceCount
-          - OnDemandPlacementGroupName
       - Label:
           default: "4. GPU Compute Node Group - P5/P6 Series (Optional)"
         Parameters:
@@ -132,8 +131,6 @@ Metadata:
         default: "CPU queue name"
       OnDemandEfaInterfaceCount:
         default: "EFA interfaces on CPU queue (0 = off, 1 or 2 for HPC types)"
-      OnDemandPlacementGroupName:
-        default: "Existing placement group name (empty = auto-create when EFA on)"
       DeployPseriesCNG:
         default: "Deploy GPU (P5/P6) queue"
       PseriesInstanceType:
@@ -506,16 +503,6 @@ Parameters:
     Default: 0
     AllowedValues: [0, 1, 2]
 
-  OnDemandPlacementGroupName:
-    Type: String
-    Description: >-
-      (Optional, advanced) Existing cluster placement group name to launch the
-      on-demand CPU nodes into. Leave empty (default) to auto-create a per-CNG
-      cluster placement group when OnDemandEfaInterfaceCount > 0. Set to share one
-      PG across multiple CNGs (e.g. heterogeneous tightly-coupled jobs). Ignored
-      when OnDemandEfaInterfaceCount = 0.
-    Default: ''
-
   # P-series Compute Node Group
   DeployPseriesCNG:
     Type: String
@@ -836,9 +823,9 @@ Resources:
         PostInstallScriptArgs: !Ref PostInstallScriptArgs
         # EFA on CPU HPC instances (hpc8a/hpc7a/hpc6a). add-cng.yaml enables EFA
         # when EfaInterfaceCount > 0 and auto-creates a per-CNG cluster placement
-        # group when PlacementGroupName is empty.
+        # group (reusing an existing PG via PlacementGroupName is a modular
+        # add-cng.yaml-only feature — not exposed on deploy-all).
         EfaInterfaceCount: !Ref OnDemandEfaInterfaceCount
-        PlacementGroupName: !Ref OnDemandPlacementGroupName
         DirectoryRole: !If [DirectoryEnabled, 'client', 'none']
         DirectoryDomainSuffix: !Ref DirectoryDomainSuffix
         S3BucketName: !Ref S3BucketName

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -517,9 +517,10 @@ Parameters:
     Description: >-
       (Optional, advanced) Existing cluster placement group name to launch the
       on-demand CPU nodes into. Leave empty (default) to auto-create a per-CNG
-      cluster placement group when OnDemandEfaInterfaceCount > 0. Set to share one
-      PG across multiple CNGs (e.g. heterogeneous tightly-coupled jobs). Ignored
-      when OnDemandEfaInterfaceCount = 0.
+      cluster placement group when OnDemandEfaInterfaceCount > 0. Set to reuse an
+      existing PG (e.g. shared across multiple CPU CNGs, or a customer-owned CPG
+      holding reserved capacity). CPU CNG only. Ignored when
+      OnDemandEfaInterfaceCount = 0.
     Default: ''
 
   # P-series Compute Node Group

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -106,11 +106,11 @@ Metadata:
       GrafanaAccessCidr:
         default: "Grafana public access CIDR (empty = SSM port-forward only)"
       MonitoringVersion:
-        default: "Advanced: Monitoring version (git ref)"
+        default: "Monitoring version (git ref)"
       MonitoringRepo:
-        default: "Advanced: Monitoring repo (owner/repo)"
+        default: "Monitoring repo (owner/repo)"
       DcgmExporterImage:
-        default: "Advanced: dcgm-exporter image (default covers H100/B200/B300)"
+        default: "dcgm-exporter image (default covers H100/B200/B300)"
       ManagedAccounting:
         default: "Slurm managed accounting"
       AccountingPolicyEnforcement:

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -106,11 +106,11 @@ Metadata:
       GrafanaAccessCidr:
         default: "Grafana public access CIDR (empty = SSM port-forward only)"
       MonitoringVersion:
-        default: "Monitoring version (git ref)"
+        default: "Advanced: Monitoring version (git ref)"
       MonitoringRepo:
-        default: "Monitoring repo (owner/repo)"
+        default: "Advanced: Monitoring repo (owner/repo)"
       DcgmExporterImage:
-        default: "dcgm-exporter image (default covers H100/B200/B300)"
+        default: "Advanced: dcgm-exporter image (default covers H100/B200/B300)"
       ManagedAccounting:
         default: "Slurm managed accounting"
       AccountingPolicyEnforcement:

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -107,11 +107,11 @@ Metadata:
       GrafanaAccessCidr:
         default: "Grafana public access CIDR (empty = SSM port-forward only)"
       MonitoringVersion:
-        default: "Monitoring version (git ref)"
+        default: "Advanced: Monitoring version (git ref)"
       MonitoringRepo:
-        default: "Monitoring repo (owner/repo)"
+        default: "Advanced: Monitoring repo (owner/repo)"
       DcgmExporterImage:
-        default: "dcgm-exporter image (default covers H100/B200/B300)"
+        default: "Advanced: dcgm-exporter image (default covers H100/B200/B300)"
       ManagedAccounting:
         default: "Slurm managed accounting"
       AccountingPolicyEnforcement:

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -50,15 +50,21 @@ Metadata:
           - PseriesCngName
           - PseriesQueueName
       - Label:
-          default: "5. Additional Cluster Configuration (Monitoring, Multi-User, Container Runtime)"
+          default: "5.1. Additional Cluster Configuration: Monitoring"
         Parameters:
           - MonitoringStack
           - GrafanaAccessCidr
           - MonitoringRepo
           - MonitoringVersion
           - DcgmExporterImage
+      - Label:
+          default: "5.2. Additional Cluster Configuration: Multi-User Directory"
+        Parameters:
           - DirectoryService
           - DirectoryDomainSuffix
+      - Label:
+          default: "5.3. Additional Cluster Configuration: Post-Install Script (default: Enroot/Pyxis container runtime)"
+        Parameters:
           - PostInstallScriptUrl
           - PostInstallScriptArgs
       - Label:

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -39,6 +39,7 @@ Metadata:
           - OnDemandCngName
           - OnDemandQueueName
           - OnDemandEfaInterfaceCount
+          - OnDemandPlacementGroupName
       - Label:
           default: "4. GPU Compute Node Group - P5/P6 Series (Optional)"
         Parameters:
@@ -137,6 +138,8 @@ Metadata:
         default: "CPU queue name"
       OnDemandEfaInterfaceCount:
         default: "EFA interfaces on CPU queue (0 = off, 1 or 2 for HPC types)"
+      OnDemandPlacementGroupName:
+        default: "Existing placement group name (empty = auto-create when EFA on)"
       DeployPseriesCNG:
         default: "Deploy GPU (P5/P6) queue"
       PseriesInstanceType:
@@ -509,6 +512,16 @@ Parameters:
     Default: 0
     AllowedValues: [0, 1, 2]
 
+  OnDemandPlacementGroupName:
+    Type: String
+    Description: >-
+      (Optional, advanced) Existing cluster placement group name to launch the
+      on-demand CPU nodes into. Leave empty (default) to auto-create a per-CNG
+      cluster placement group when OnDemandEfaInterfaceCount > 0. Set to share one
+      PG across multiple CNGs (e.g. heterogeneous tightly-coupled jobs). Ignored
+      when OnDemandEfaInterfaceCount = 0.
+    Default: ''
+
   # P-series Compute Node Group
   DeployPseriesCNG:
     Type: String
@@ -829,9 +842,9 @@ Resources:
         PostInstallScriptArgs: !Ref PostInstallScriptArgs
         # EFA on CPU HPC instances (hpc8a/hpc7a/hpc6a). add-cng.yaml enables EFA
         # when EfaInterfaceCount > 0 and auto-creates a per-CNG cluster placement
-        # group (reusing an existing PG via PlacementGroupName is a modular
-        # add-cng.yaml-only feature — not exposed on deploy-all).
+        # group when PlacementGroupName is empty.
         EfaInterfaceCount: !Ref OnDemandEfaInterfaceCount
+        PlacementGroupName: !Ref OnDemandPlacementGroupName
         DirectoryRole: !If [DirectoryEnabled, 'client', 'none']
         DirectoryDomainSuffix: !Ref DirectoryDomainSuffix
         S3BucketName: !Ref S3BucketName

--- a/architectures/aws-pcs/docs/PARAMETERS.md
+++ b/architectures/aws-pcs/docs/PARAMETERS.md
@@ -50,7 +50,8 @@ it directly.
 | `OnDemandMaxCount` | `4` | CPU queue maximum nodes |
 | `OnDemandCngName` | `cpu1` | CPU node-group name |
 | `OnDemandQueueName` | `cpu1` | CPU Slurm queue name |
-| `OnDemandEfaInterfaceCount` | `0` | EFA interfaces on the CPU CNG. **`0` (default) = no EFA** (standard ENA). `1` or `2` = enable EFA with that many interfaces (switches the LaunchTemplate to a `NetworkInterfaces` block with `InterfaceType=efa` + an auto-created per-CNG cluster placement group). Set the count to the instance type's `MaximumEfaInterfaces`: `hpc8a.96xlarge`/`hpc7a.*`/`hpc6id.32xlarge`=2; `hpc6a.48xlarge`/`c7i.metal`=1. **EFA needs an EFA-capable type** — a non-EFA type (e.g. the default `c6i.4xlarge`) fails to launch with count > 0. No effect on the GPU CNG. See [README §8.6 CPU compute node group](../README.md#86-cpu-compute-node-group--advanced-settings) |
+| `OnDemandEfaInterfaceCount` | `0` | EFA interfaces on the CPU CNG. **`0` (default) = no EFA** (standard ENA). `1` or `2` = enable EFA with that many interfaces (switches the LaunchTemplate to a `NetworkInterfaces` block with `InterfaceType=efa` + a cluster placement group). Set the count to the instance type's `MaximumEfaInterfaces`: `hpc8a.96xlarge`/`hpc7a.*`/`hpc6id.32xlarge`=2; `hpc6a.48xlarge`/`c7i.metal`=1. **EFA needs an EFA-capable type** — a non-EFA type (e.g. the default `c6i.4xlarge`) fails to launch with count > 0. No effect on the GPU CNG. See [README §8.6 CPU compute node group](../README.md#86-cpu-compute-node-group--advanced-settings) |
+| `OnDemandPlacementGroupName` | *(empty)* | Existing cluster placement group name to launch nodes into. Empty + `OnDemandEfaInterfaceCount > 0` auto-creates a per-CNG cluster placement group; supplying a name reuses an existing one (e.g. shared across CPU + GPU CNGs for heterogeneous tightly-coupled jobs). Ignored when `OnDemandEfaInterfaceCount = 0` |
 
 ## 4. GPU Compute Node Group — P5/P6 (Optional)
 

--- a/architectures/aws-pcs/docs/PARAMETERS.md
+++ b/architectures/aws-pcs/docs/PARAMETERS.md
@@ -66,7 +66,7 @@ See [GPU compute](../README.md#gpu-compute-p5p6) for instance/EFA/capacity guida
 | `PseriesCngName` | `gpu-p5` | GPU node-group name |
 | `PseriesQueueName` | `gpu-p5` | GPU Slurm queue name |
 
-## 5. Additional Cluster Configuration (Monitoring, Multi-User, Container Runtime)
+## 5.1. Additional Cluster Configuration: Monitoring
 
 | Parameter | Default | Purpose |
 |---|---|---|
@@ -75,8 +75,21 @@ See [GPU compute](../README.md#gpu-compute-p5p6) for instance/EFA/capacity guida
 | `MonitoringRepo` | `aws-samples/aws-parallelcluster-monitoring` | GitHub `owner/repo` for the monitoring stack; override with a fork + a branch in `MonitoringVersion` to test unreleased changes |
 | `MonitoringVersion` | `v2.10.2` | [aws-parallelcluster-monitoring](https://github.com/aws-samples/aws-parallelcluster-monitoring) git ref (release tag, branch, or `latest`). `v2.10.2` adds the `ec2_sd` credential-refresh fix (restarts prometheus on IMDS credential rotation, so compute metrics keep flowing past ~6 h); `v2.9.1` added the `DCGM_EXPORTER_IMAGE` override (needed for B300 GPU metrics) and Grafana 13; `v2.6.4`+ carry the PCS `/opt` install + Docker-29.x DCGM fixes. Pin to a tag for stability. Migration notes: [OPERATIONS.md §3](./OPERATIONS.md#3-monitoring-monitoringversion) |
 | `DcgmExporterImage` | DCGM 4.5.2 by digest | `dcgm-exporter` image used on GPU nodes. Defaults to a DCGM 4.5.2 build pinned by digest (`nvcr.io/nvidia/k8s/dcgm-exporter@sha256:a7ad6547...`) covering Hopper / B200 / B300. The digest pull bypasses the Docker-29.x OCI-index failure on newer NVCR tags. Override (any image reference, ideally also a digest) to pin to a different build — e.g. the monitoring stack's older default 4.2.0. No effect on CPU nodes. See [OPERATIONS.md §3.1](./OPERATIONS.md#31-dcgmexporterimage-the-default-and-when-to-change-it) |
+
+## 5.2. Additional Cluster Configuration: Multi-User Directory
+
+| Parameter | Default | Purpose |
+|---|---|---|
 | `DirectoryService` | `none` | Multi-user directory. `none` = single `ubuntu` user. `OpenLDAP-LoginNode` = slapd on the login node (DB on shared `/home/ldap-db`) + SSSD on all compute nodes. **Single login node only** — keep the login node group at 1 instance while enabled. See [USER-MANAGEMENT.md](./USER-MANAGEMENT.md) |
 | `DirectoryDomainSuffix` | `dc=cluster,dc=internal` | LDAP domain suffix. Only used when `DirectoryService != none` |
+
+## 5.3. Additional Cluster Configuration: Post-Install Script
+
+The first-boot hook that runs on every node. By default it installs the
+Enroot/Pyxis container runtime; point it at your own script to customize.
+
+| Parameter | Default | Purpose |
+|---|---|---|
 | `PostInstallScriptUrl` | *(empty → auto)* | Script run on every node at first boot (PCS equivalent of ParallelCluster `OnNodeConfigured`). **Empty (default) auto-installs Enroot/Pyxis** from `s3://<S3BucketName>/<S3KeyPrefix>scripts/install-enroot-pyxis.sh` (fetched with the instance role, so it works with a **private** bucket — no public S3 needed). Accepts an `s3://` URL (instance-role fetch) or an `http(s)://` URL (curl, public only, e.g. GitHub raw). Set to a single space to skip. Idempotent: a no-op if Enroot/Pyxis is already pre-baked into `AmiId` |
 | `PostInstallScriptArgs` | *(empty)* | Arguments passed to the post-install script. Normally left empty — most users never touch the container-runtime parameters |
 

--- a/architectures/aws-pcs/docs/PARAMETERS.md
+++ b/architectures/aws-pcs/docs/PARAMETERS.md
@@ -50,8 +50,7 @@ it directly.
 | `OnDemandMaxCount` | `4` | CPU queue maximum nodes |
 | `OnDemandCngName` | `cpu1` | CPU node-group name |
 | `OnDemandQueueName` | `cpu1` | CPU Slurm queue name |
-| `OnDemandEfaInterfaceCount` | `0` | EFA interfaces on the CPU CNG. **`0` (default) = no EFA** (standard ENA). `1` or `2` = enable EFA with that many interfaces (switches the LaunchTemplate to a `NetworkInterfaces` block with `InterfaceType=efa` + a cluster placement group). Set the count to the instance type's `MaximumEfaInterfaces`: `hpc8a.96xlarge`/`hpc7a.*`/`hpc6id.32xlarge`=2; `hpc6a.48xlarge`/`c7i.metal`=1. **EFA needs an EFA-capable type** — a non-EFA type (e.g. the default `c6i.4xlarge`) fails to launch with count > 0. No effect on the GPU CNG. See [README §8.6 CPU compute node group](../README.md#86-cpu-compute-node-group--advanced-settings) |
-| `OnDemandPlacementGroupName` | *(empty)* | Existing cluster placement group name to launch nodes into. Empty + `OnDemandEfaInterfaceCount > 0` auto-creates a per-CNG cluster placement group; supplying a name reuses an existing one (e.g. shared across CPU + GPU CNGs for heterogeneous tightly-coupled jobs). Ignored when `OnDemandEfaInterfaceCount = 0` |
+| `OnDemandEfaInterfaceCount` | `0` | EFA interfaces on the CPU CNG. **`0` (default) = no EFA** (standard ENA). `1` or `2` = enable EFA with that many interfaces (switches the LaunchTemplate to a `NetworkInterfaces` block with `InterfaceType=efa` + an auto-created per-CNG cluster placement group). Set the count to the instance type's `MaximumEfaInterfaces`: `hpc8a.96xlarge`/`hpc7a.*`/`hpc6id.32xlarge`=2; `hpc6a.48xlarge`/`c7i.metal`=1. **EFA needs an EFA-capable type** — a non-EFA type (e.g. the default `c6i.4xlarge`) fails to launch with count > 0. No effect on the GPU CNG. See [README §8.6 CPU compute node group](../README.md#86-cpu-compute-node-group--advanced-settings) |
 
 ## 4. GPU Compute Node Group — P5/P6 (Optional)
 

--- a/architectures/aws-pcs/docs/PARAMETERS.md
+++ b/architectures/aws-pcs/docs/PARAMETERS.md
@@ -51,7 +51,7 @@ it directly.
 | `OnDemandCngName` | `cpu1` | CPU node-group name |
 | `OnDemandQueueName` | `cpu1` | CPU Slurm queue name |
 | `OnDemandEfaInterfaceCount` | `0` | EFA interfaces on the CPU CNG. **`0` (default) = no EFA** (standard ENA). `1` or `2` = enable EFA with that many interfaces (switches the LaunchTemplate to a `NetworkInterfaces` block with `InterfaceType=efa` + a cluster placement group). Set the count to the instance type's `MaximumEfaInterfaces`: `hpc8a.96xlarge`/`hpc7a.*`/`hpc6id.32xlarge`=2; `hpc6a.48xlarge`/`c7i.metal`=1. **EFA needs an EFA-capable type** — a non-EFA type (e.g. the default `c6i.4xlarge`) fails to launch with count > 0. No effect on the GPU CNG. See [README §8.6 CPU compute node group](../README.md#86-cpu-compute-node-group--advanced-settings) |
-| `OnDemandPlacementGroupName` | *(empty)* | Existing cluster placement group name to launch nodes into. Empty + `OnDemandEfaInterfaceCount > 0` auto-creates a per-CNG cluster placement group; supplying a name reuses an existing one (e.g. shared across CPU + GPU CNGs for heterogeneous tightly-coupled jobs). Ignored when `OnDemandEfaInterfaceCount = 0` |
+| `OnDemandPlacementGroupName` | *(empty)* | Existing cluster placement group name to launch nodes into. Empty + `OnDemandEfaInterfaceCount > 0` auto-creates a per-CNG cluster placement group; supplying a name reuses an existing one (e.g. shared across multiple CPU CNGs, or a customer-owned CPG holding reserved capacity). CPU CNG only — the P5/P6 GPU templates don't take a placement-group name. Ignored when `OnDemandEfaInterfaceCount = 0` |
 
 ## 4. GPU Compute Node Group — P5/P6 (Optional)
 

--- a/architectures/aws-pcs/tests/hpc-efa-test.md
+++ b/architectures/aws-pcs/tests/hpc-efa-test.md
@@ -8,8 +8,8 @@ group auto-creation, multi-NIC wiring, and OSU MPI benchmark results.
 ## Test 9: EFA on CPU HPC instances (hpc6a / hpc7a / hpc8a)
 
 **When to run:** when `add-cng.yaml`'s EFA wiring (`EfaInterfaceCount`,
-`PlacementGroupName`) or the deploy-all forwarding param
-(`OnDemandEfaInterfaceCount`) changes. Skip if only
+`PlacementGroupName`) or the deploy-all forwarding params
+(`OnDemandEfaInterfaceCount`, `OnDemandPlacementGroupName`) change. Skip if only
 GPU/monitoring/AMI paths were touched.
 
 > **EFA is enabled by the interface count.** `OnDemandEfaInterfaceCount=0`
@@ -51,9 +51,8 @@ aws cloudformation create-stack \
 
 The `OnDemandCNGStack` nested stack auto-creates a cluster placement group and
 exposes the name as a stack output (`PlacementGroupName`). To share the PG across
-multiple CNGs (heterogeneous tightly-coupled jobs), deploy the CNG with the
-modular `add-cng.yaml` and pass `PlacementGroupName=<existing-pg-name>` there
-(not exposed on deploy-all).
+multiple CNGs (heterogeneous tightly-coupled jobs), pass
+`OnDemandPlacementGroupName=<existing-pg-name>` instead.
 
 ### Step 2 — verify EFA visibility on a compute node
 

--- a/architectures/aws-pcs/tests/hpc-efa-test.md
+++ b/architectures/aws-pcs/tests/hpc-efa-test.md
@@ -8,8 +8,8 @@ group auto-creation, multi-NIC wiring, and OSU MPI benchmark results.
 ## Test 9: EFA on CPU HPC instances (hpc6a / hpc7a / hpc8a)
 
 **When to run:** when `add-cng.yaml`'s EFA wiring (`EfaInterfaceCount`,
-`PlacementGroupName`) or the deploy-all forwarding params
-(`OnDemandEfaInterfaceCount`, `OnDemandPlacementGroupName`) change. Skip if only
+`PlacementGroupName`) or the deploy-all forwarding param
+(`OnDemandEfaInterfaceCount`) changes. Skip if only
 GPU/monitoring/AMI paths were touched.
 
 > **EFA is enabled by the interface count.** `OnDemandEfaInterfaceCount=0`
@@ -51,8 +51,9 @@ aws cloudformation create-stack \
 
 The `OnDemandCNGStack` nested stack auto-creates a cluster placement group and
 exposes the name as a stack output (`PlacementGroupName`). To share the PG across
-multiple CNGs (heterogeneous tightly-coupled jobs), pass
-`OnDemandPlacementGroupName=<existing-pg-name>` instead.
+multiple CNGs (heterogeneous tightly-coupled jobs), deploy the CNG with the
+modular `add-cng.yaml` and pass `PlacementGroupName=<existing-pg-name>` there
+(not exposed on deploy-all).
 
 ### Step 2 — verify EFA visibility on a compute node
 


### PR DESCRIPTION
## What

Console-presentation cleanup of `pcs-ml-cluster-deploy-all.yaml`'s parameters.
No behavior change; nested templates untouched.

- **Split parameter group 5 by purpose** — the 9-parameter "Additional Cluster
  Configuration" group is now 5.1 Monitoring / 5.2 Multi-User Directory /
  5.3 Post-Install Script (default: Enroot/Pyxis container runtime).
- **`Advanced:` label prefix** on the pinned monitoring params
  (`MonitoringRepo` / `MonitoringVersion` / `DcgmExporterImage`).
- **Doc-accuracy fix:** scope the placement-group reuse docs to the CPU CNG
  (multiple CPU CNGs, or a customer-owned CPG holding reserved capacity) —
  the P5/P6 GPU templates expose no placement-group option. Applied to
  README §8.6, PARAMETERS.md, and the template description.

Docs (PARAMETERS.md, README, tests) updated to match; `tests/lint-docs.sh` passes.

## Testing

`validate-template` + params ⇄ groups ⇄ labels consistency check pass. e2e on
real hardware (us-east-2, `DirectoryService=OpenLDAP-LoginNode`):
CREATE_COMPLETE, Pyxis container job OK, LDAP user runs `srun` on a compute
node as uid=10001.