### PR TITLE
fix(aws-pcs): keep needrestart guard in lock-step across CNG templates

### DIFF
--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -405,8 +405,8 @@ Resources:
             # also covers the versioned units, e.g. slurmd-25.11.)
             # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
             - |
-              mkdir -p /etc/needrestart/conf.d
-              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
+              mkdir -p /etc/needrestart/conf.d &&
+              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF' &&
               # AWS PCS: never auto-restart slurmd - restarting it kills
               # the jobs running under it. Managed by add-cng UserData.
               $nrconf{override_rc} = { qr(^slurmd) => 0 };

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -392,8 +392,8 @@ Resources:
             # also covers the versioned units, e.g. slurmd-25.11.)
             # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
             - |
-              mkdir -p /etc/needrestart/conf.d
-              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
+              mkdir -p /etc/needrestart/conf.d &&
+              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF' &&
               # AWS PCS: never auto-restart slurmd - restarting it kills
               # the jobs running under it. Managed by add-cng UserData.
               $nrconf{override_rc} = { qr(^slurmd) => 0 };

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -395,8 +395,8 @@ Resources:
             # also covers the versioned units, e.g. slurmd-25.11.)
             # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
             - |
-              mkdir -p /etc/needrestart/conf.d
-              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
+              mkdir -p /etc/needrestart/conf.d &&
+              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF' &&
               # AWS PCS: never auto-restart slurmd - restarting it kills
               # the jobs running under it. Managed by add-cng UserData.
               $nrconf{override_rc} = { qr(^slurmd) => 0 };

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -461,12 +461,12 @@ Resources:
             # slurmd auto-restart is suppressed. (PCS runs the controller managed-side;
             # slurmd is the only Slurm systemd service on login/compute nodes. qr(^slurmd)
             # also covers the versioned units, e.g. slurmd-25.11.)
-            # runcmd runs under /bin/sh (dash) — keep this POSIX-clean, no bashisms.
+            # runcmd runs under /bin/sh (dash) - keep this POSIX-clean, no bashisms.
             - |
-              mkdir -p /etc/needrestart/conf.d
-              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF'
+              mkdir -p /etc/needrestart/conf.d &&
+              cat > /etc/needrestart/conf.d/90-pcs-slurm.conf <<'NRCONF' &&
               # AWS PCS: never auto-restart slurmd - restarting it kills
-              # the jobs running under it. Managed by add-cng.yaml UserData.
+              # the jobs running under it. Managed by add-cng UserData.
               $nrconf{override_rc} = { qr(^slurmd) => 0 };
               NRCONF
               echo "needrestart: slurmd excluded from auto-restart" | tee /var/log/pcs-needrestart-guard.log

--- a/architectures/aws-pcs/tests/lint-docs.sh
+++ b/architectures/aws-pcs/tests/lint-docs.sh
@@ -68,6 +68,11 @@ done
 #    CNG templates. It is hand-duplicated (no shared include), so an edit that
 #    lands in only some of the copies is exactly the drift this catches.
 guard_extract() {  # print the guard block: comment header through the log line
+  # Leading whitespace is stripped because the four templates legitimately nest
+  # the block at different depths. Side effect: the check cannot see RELATIVE
+  # indentation drift inside the block (e.g. an indented NRCONF terminator, or
+  # <<'NRCONF' switched to the tab-stripping <<-'NRCONF' in one template) —
+  # those would change deployed behavior while still comparing as identical.
   awk '/--- Protect running jobs from unattended-upgrades \/ needrestart ---/{p=1}
        p{print}
        p&&/pcs-needrestart-guard\.log/{exit}' "$1" | sed -E 's/^[[:space:]]+//'
@@ -80,7 +85,7 @@ else
     other=$(guard_extract "assets/$t.yaml")
     if [ "$other" != "$ref" ]; then
       report "needrestart guard block in assets/$t.yaml differs from assets/add-cng.yaml (keep the four copies byte-identical):"
-      diff <(echo "$ref") <(echo "$other") | sed 's/^/    /'
+      diff <(printf '%s\n' "$ref") <(printf '%s\n' "$other") | sed 's/^/    /'
     fi
   done
 fi

--- a/architectures/aws-pcs/tests/lint-docs.sh
+++ b/architectures/aws-pcs/tests/lint-docs.sh
@@ -64,7 +64,28 @@ for prm in $params; do
   grep -q "\`$prm\`" docs/PARAMETERS.md || report "deploy-all parameter '$prm' is not documented in docs/PARAMETERS.md"
 done
 
-# 4. Same-file Markdown anchor links in README.md resolve to a real heading.
+# 4. The needrestart/slurmd guard block must be byte-identical across the four
+#    CNG templates. It is hand-duplicated (no shared include), so an edit that
+#    lands in only some of the copies is exactly the drift this catches.
+guard_extract() {  # print the guard block: comment header through the log line
+  awk '/--- Protect running jobs from unattended-upgrades \/ needrestart ---/{p=1}
+       p{print}
+       p&&/pcs-needrestart-guard\.log/{exit}' "$1" | sed -E 's/^[[:space:]]+//'
+}
+ref=$(guard_extract assets/add-cng.yaml)
+if [ -z "$ref" ]; then
+  report "needrestart guard block not found in assets/add-cng.yaml"
+else
+  for t in add-cng-p5 add-cng-p6-b200 add-cng-p6-b300; do
+    other=$(guard_extract "assets/$t.yaml")
+    if [ "$other" != "$ref" ]; then
+      report "needrestart guard block in assets/$t.yaml differs from assets/add-cng.yaml (keep the four copies byte-identical):"
+      diff <(echo "$ref") <(echo "$other") | sed 's/^/    /'
+    fi
+  done
+fi
+
+# 5. Same-file Markdown anchor links in README.md resolve to a real heading.
 #    (Cross-file and external links are out of scope — kept simple on purpose.)
 while IFS= read -r anchor; do
   # build the set of heading slugs in README
@@ -76,6 +97,6 @@ while IFS= read -r anchor; do
 done < <(grep -oE '\]\(#[a-z0-9-]+\)' README.md | sed -E 's/\]\(#//; s/\)//' | sort -u)
 
 if [ "$fail" -eq 0 ]; then
-  echo "docs lint: PASS (no stale parameter references, no empty=skip wording, all deploy-all params documented, README anchors resolve)"
+  echo "docs lint: PASS (no stale parameter references, no empty=skip wording, all deploy-all params documented, needrestart guard in lock-step, README anchors resolve)"
 fi
 exit $fail


### PR DESCRIPTION
## What

Follow-up to #1165 review (non-blocking nits):

- **Normalize the guard block** — `add-cng.yaml`'s copy had drifted cosmetically
  (em-dash vs ASCII, `add-cng.yaml` vs `add-cng` in the drop-in comment); now
  byte-identical with the other three templates.
- **Lint check for future drift** — `tests/lint-docs.sh` now asserts the
  needrestart guard block is byte-identical across `add-cng` / `add-cng-p5` /
  `add-cng-p6-b200` / `add-cng-p6-b300`, so an edit landing in only some of the
  four hand-maintained copies fails the lint. The whitespace-normalization
  blind spot (relative intra-block indentation drift) is documented in the
  extractor, and the failure diff is fed via `printf` (review feedback).
- **Truthful success log** — chain the guard's `mkdir`/`cat` with `&&` so
  `needrestart: slurmd excluded from auto-restart` is only logged when the
  drop-in was actually written.

## Testing

- Lint passes on the normalized templates; injecting a 1-char divergence into
  `add-cng-p5.yaml` makes it FAIL with a diff (re-verified after the printf
  change).
- The chained heredoc block runs clean under dash (exit 0, conf + log written);
  with an unwritable target it exits 1 and writes no log line.
- `validate-template` passes on all four templates.