### PR TITLE
docs(aws-pcs): expand region coverage to 16 of 20 PCS regions (docs only)

### DIFF
--- a/architectures/aws-pcs/tests/README.md
+++ b/architectures/aws-pcs/tests/README.md
@@ -12,10 +12,14 @@ FSx tuning), see [`../docs/OPERATIONS.md`](../docs/OPERATIONS.md).
 
 Run this **complete set** before merging template or script changes.
 
+Unless a test says otherwise, commands run from the login node (SSM or SSH) as
+`ubuntu`, the PCS-Ready DLAMI default user (the multi-user tests submit as
+LDAP users).
+
 | # | Category | Tests | File | When to run |
 |---|---|---|---|---|
 | 0 | **Docs lint** | `bash tests/lint-docs.sh` — no stale/renamed param refs in docs, every deploy-all param documented, README anchors resolve (the docs counterpart of template-lint; runs in seconds, no AWS) | [`lint-docs.sh`](./lint-docs.sh) | Every PR (esp. param renames) |
-| 1-3, 8 | **Infrastructure** | Monitoring stack, container runtime (first-boot + AMI build), template lint | [`infra-test.md`](./infra-test.md) | Every PR |
+| 1-3, 8 | **Infrastructure** | Template lint, monitoring stack, container runtime (first-boot + AMI build) | [`infra-test.md`](./infra-test.md) | Every PR |
 | 4-6 | **Compute** | CPU queue, GPU families (G/P5/P6), NCCL multi-node EFA | [`compute-test.md`](./compute-test.md) | Every PR |
 | 7, 7b | **Training** | FSDP Llama-2 7B (HF-streamed) + Megatron-LM GPT-3 (TP/PP/DP, local data) | [`training-test.md`](./training-test.md) | GPU PRs |
 | 9 | **HPC EFA** | EFA on CPU instances (hpc6a/hpc7a/hpc8a), OSU benchmarks | [`hpc-efa-test.md`](./hpc-efa-test.md) | EFA wiring changes |
@@ -66,66 +70,83 @@ MonitoringStack=Prometheus-LoginNode
 
 ## Region coverage
 
-The templates fetch nested stacks + boot scripts from a single S3 bucket
-(`S3BucketName`) and resolve the PCS-Ready DLAMI from SSM per region.
+The table lists **all 20 regions where AWS PCS is available** (per
+`/aws/service/global-infrastructure/services/pcs/regions`) — 16 verified,
+4 not yet run.
 
-Columns: **Deploy** (deploy-all → CREATE_COMPLETE), **Mon** (6 monitoring
-containers up on the login node), **Storage** (FSx Lustre `/fsx` + OpenZFS
-`/home` created & mounted — with the OpenZFS deployment type that worked),
-**Pyxis** (Enroot/Pyxis container job runs), **GPU** (a GPU CNG launched and ran
-on reserved capacity — Capacity Block or ODCR; ✅ marks regions where this was
-exercised in **earlier** GPU validation rounds, not necessarily on the row's
-deploy/monitoring/storage verification date), **Verified** (date, UTC).
+| Region (AZ ID) ¹ | Verified ² | Storage ³ (Lustre<br>/ OpenZFS) | GPU verified ⁴ | *(ref) CBML GPUs offered* ⁵ | Date (UTC) |
+|---|---|---|---|---|---|
+| **N. Virginia**<br>(`use1-az1`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ | P6-B300, P6-B200, P5, P5e, P5en, P4d, P4de | 2026-06-17 |
+| **Ohio**<br>(`use2-az3`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ | P6-B200, P5, P5e, P5en, P4d | 2026-06-17 |
+| **Oregon**<br>(`usw2-az3`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ P6-B300 | P6-B300, P6-B200, P5, P5e, P5en, P4d, P4de | 2026-06-17 |
+| **Tokyo**<br>(`apne1-az1`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | — | P5, P5e, P5en | 2026-06-17 |
+| **Mumbai**<br>(`aps1-az2`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ P6-B200 | P6-B200, P5, P5e, P5en | 2026-06-17 |
+| **Osaka**<br>(`apne3-az2`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_1` ⁶ | — | — | 2026-06-17 |
+| **Singapore**<br>(`apse1-az1`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | — | — | 2026-06-17 |
+| **Sydney**<br>(`apse2-az2`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | — | P5, P5e, P5en | 2026-06-17 |
+| **Frankfurt**<br>(`euc1-az2`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | — | — | 2026-06-17 |
+| **Stockholm**<br>(`eun1-az2`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | — | P5, P5e, P5en | 2026-06-17 |
+| **Ireland**<br>(`euw1-az1`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | — | — | 2026-07-07 |
+| **Spain**<br>(`eus2-az1`) | ✅<br>(m7i/c7i) ⁷ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | — | P5en | 2026-07-07 |
+| **London**<br>(`euw2-az2`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_1` ⁶ | — | P5, P5e, P5en | 2026-07-08 |
+| **Paris**<br>(`euw3-az1`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_1` ⁶ | — | — | 2026-07-08 |
+| **São Paulo**<br>(`sae1-az1`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_1` ⁶ | — | P5, P5e | 2026-07-08 |
+| **Jakarta**<br>(`apse3-az1`) | ✅<br>(c7i) ⁷ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_1` ⁶ | — | P5, P5e, P5en | 2026-07-08 |
+| **Cape Town**<br>(af-south-1) | — | — | — | — | not yet run |
+| **Milan**<br>(eu-south-1) | — | — | — | — | not yet run |
+| **GovCloud US-East**<br>(us-gov-east-1) | — | — | — | P6-B300, P6-B200 | not yet run |
+| **GovCloud US-West**<br>(us-gov-west-1) | — | — | — | P6-B200 | not yet run |
 
-| Region | Deploy | Mon | Storage (OpenZFS type) | Pyxis | GPU | Verified |
-|---|---|---|---|---|---|---|
-| **us-east-1** (N. Virginia) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | ✅ | 2026-06-17 |
-| **us-east-2** (Ohio) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | ✅ | 2026-06-17 |
-| **us-west-2** (Oregon) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | ✅ | 2026-06-17 |
-| **ap-northeast-1** (Tokyo) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | — | 2026-06-17 |
-| **ap-south-1** (Mumbai) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | ✅ | 2026-06-17 |
-| **ap-northeast-3** (Osaka) | ✅ | ✅ | ✅ `SINGLE_AZ_1` ¹ | ✅ | — | 2026-06-17 |
-| **ap-southeast-1** (Singapore) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | — | 2026-06-17 |
-| **ap-southeast-2** (Sydney) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | — | 2026-06-17 |
-| **eu-central-1** (Frankfurt) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | — | 2026-06-17 |
-| **eu-north-1** (Stockholm) | ✅ | ✅ | ✅ `SINGLE_AZ_HA_2` | ✅ | — | 2026-06-17 |
+¹ **Region (AZ ID)** — the [AZ ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html)
+of the `PrimarySubnetAZ` the run used. AZ IDs identify the same physical
+location in every account, unlike AZ *names* such as `us-east-1a`, whose
+mapping is randomized per account.
 
-¹ **Osaka (ap-northeast-3) does not support the default `OpenZFSDeploymentType=SINGLE_AZ_HA_2`**
-— the default deploy fails at the OpenZFS filesystem with
-`Invalid deploymentType (BadRequest)`. Deploy there with
-`OpenZFSDeploymentType=SINGLE_AZ_1` (+ a valid `HomeThroughput`, e.g. 256). This
-is the documented "not available in every Region" case (see the parameter's
-description in `ml-cluster-prerequisites.yaml`); `SINGLE_AZ_1` is available in
-all regions and is the safe fallback.
+² **Verified (E2E)** — the `deploy-all` stack reaches CREATE_COMPLETE, the 6 monitoring
+containers come up on the login node, and an Enroot/Pyxis container job runs
+(`srun --container-image=ubuntu:22.04`). These three always pass or fail
+together, so they are reported as one column.
 
-### Remaining PCS launch regions (not yet run)
+³ **Storage** — FSx Lustre `/fsx` and FSx OpenZFS `/home` created & mounted,
+with the deployment type that worked (Lustre on the first line of each cell,
+OpenZFS on the second). Deployment-type support varies by region — check the
+official per-region tables before deploying:
+[FSx for Lustre deployment types](https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-fsx-lustre.html)
+and [FSx for OpenZFS availability by Region](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/available-aws-regions.html).
 
-AWS PCS is available in 18 regions total (per
-`/aws/service/global-infrastructure/services/pcs/regions`). Beyond the 10 tested
-above, these are expected to work but have not been run — confirm
-`LustreDeploymentType` / `OpenZFSDeploymentType` availability before relying on
-the defaults (`PERSISTENT_2` / `SINGLE_AZ_HA_2`), as Osaka above shows:
-`eu-south-1` (Milan), `eu-south-2` (Spain), `eu-west-1` (Ireland), `eu-west-2`
-(London), `eu-west-3` (Paris), `sa-east-1` (São Paulo), `us-gov-east-1`,
-`us-gov-west-1` (GovCloud).
+⁴ **GPU verified** — a GPU CNG launched and ran on reserved capacity (Capacity
+Block or ODCR); the instance family is noted where a test file records it.
+**A "—" does NOT mean GPUs are unsupported there.** It only means a
+reserved-capacity GPU run has not been exercised in that region yet — GPU
+capacity is scarce and expensive, so GPU runs are done opportunistically where
+capacity was purchased, not per-region. The GPU CNG templates are
+region-agnostic; wherever the *(ref) CBML GPUs offered* column (or an ODCR)
+provides capacity, they are expected to work as-is.
 
-Cross-region note: nested-stack `TemplateURL` and the in-instance
-`aws s3 cp` of boot scripts both work against an S3 bucket in a **different**
-region (S3 global namespace; no `--region` needed) — verified ap-south-1 →
-us-east-1 bucket. The PCS-Ready DLAMI SSM parameter
-(`/aws/service/pcs/ami/dlami-base-ubuntu2404/x86_64/latest/ami-id`) resolves in
-every region tested. `OpenZFSDeploymentType=SINGLE_AZ_HA_2` and
-`LustreDeploymentType=PERSISTENT_2` (the defaults) were available in all five.
+⁵ ***(ref) CBML GPUs offered*** — supplemental reference, not a test result:
+P-family instance types purchasable as
+[Capacity Blocks for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html)
+in that region, per the EC2 docs as of 2026-07-08. PCS supports CBML with
+P6-B300 / P6-B200 / P5en / P5e / P5 / P4d.
 
-> **Testing unpublished templates:** an empty `PostInstallScriptUrl` (the default)
-> resolves to `s3://<S3BucketName>/<S3KeyPrefix>scripts/install-enroot-pyxis.sh` — i.e.
-> the boot script comes from the **same bucket as the nested templates**. So when
-> testing changes that aren't in the public bucket yet, point `S3BucketName` at your own
-> bucket **and** sync the scripts there (the `aws s3 sync assets/ …` step covers both);
-> otherwise the first-boot fetch fails and nodes come up without Enroot/Pyxis
-> (`/var/log/pcs-post-install.log` shows the failed `aws s3 cp`). The cluster still
-> reaches CREATE_COMPLETE; only the container runtime is missing. See
-> [docs/DEPLOY-TESTING.md](../docs/DEPLOY-TESTING.md).
+⁶ **These regions do not support the default `OpenZFSDeploymentType=SINGLE_AZ_HA_2`**
+(ap-northeast-3, eu-west-2, eu-west-3, sa-east-1, ap-southeast-3) — the default
+deploy fails at the OpenZFS filesystem with `Invalid deploymentType (BadRequest)`.
+Deploy there with `OpenZFSDeploymentType=SINGLE_AZ_1` (+ a valid
+`HomeThroughput`, e.g. 256). This is the documented "not available in every
+Region" case (see the parameter's description in `ml-cluster-prerequisites.yaml`);
+`SINGLE_AZ_1` is available in all regions and is the safe fallback. FSx Lustre
+showed no such regional variation — `LustreDeploymentType=PERSISTENT_2` (the
+default) worked in all 16 regions, as the Lustre column shows.
+
+⁷ **The default instance types are not offered in every region** — the
+parenthesized types in the Verified column are what the run used instead:
+eu-south-2 has no m6i/c6i (`LoginNodeInstanceType=m7i.4xlarge`,
+`OnDemandInstanceType=c7i.4xlarge`), and ap-southeast-3 has no c6i
+(`OnDemandInstanceType=c7i.4xlarge`). Rows without a parenthesis ran the
+defaults. Check with
+`aws ec2 describe-instance-type-offerings --location-type availability-zone`
+before deploying.
 
 ---
 
@@ -137,15 +158,6 @@ every region tested. `OpenZFSDeploymentType=SINGLE_AZ_HA_2` and
 | FSDP Llama-2 7B | [`3.test_cases/pytorch/FSDP`](../../../3.test_cases/pytorch/FSDP) | Cache on `/fsx`, 2 nodes |
 | Megatron-LM GPT-3 (TP/PP/DP) | [`3.test_cases/megatron/megatron-lm`](../../../3.test_cases/megatron/megatron-lm) | Import `.sqsh` to `/fsx`, data under `/fsx/gpt2/`, 4 nodes |
 | GPU Health Check | [`4.validation_and_observability/2.gpu-cluster-healthcheck`](../../../4.validation_and_observability/2.gpu-cluster-healthcheck) | sbatch wrapper, partition name |
-
----
-
-## Notes
-
-- All Slurm commands run as `ubuntu` from the login node (SSM or SSH)
-- Slurm binaries: `export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH`
-- Template lint: `aws cloudformation validate-template --template-body file://assets/<name>.yaml`
-- Regression criteria (storage): >10% degradation blocks the change
 
 ---
 

--- a/architectures/aws-pcs/tests/hpc-efa-test.md
+++ b/architectures/aws-pcs/tests/hpc-efa-test.md
@@ -17,9 +17,10 @@ GPU/monitoring/AMI paths were touched.
 > separate `OnDemandEnableEfa` flag (removed — the count alone drives it).
 
 This validates that the on-demand CPU CNG actually launches with EFA NICs in a
-cluster placement group, and that MPI / libfabric over EFA works end-to-end. The
-verified-configurations table above documents the bandwidth numbers; this section
-documents the **how-to** so a contributor can reproduce.
+cluster placement group, and that MPI / libfabric over EFA works end-to-end.
+Verified bandwidth numbers are recorded in
+[tests/README.md](./README.md#major-update-pr--configurations-run-end-to-end-on-real-hardware);
+this section documents the **how-to** so a contributor can reproduce.
 
 ### Step 1 — deploy with EFA on the CPU CNG
 
@@ -85,8 +86,7 @@ PATH=/opt/amazon/openmpi/bin:$PATH ./configure CC=mpicc CXX=mpicxx --prefix=/fsx
 PATH=/opt/amazon/openmpi/bin:$PATH make -j8
 ```
 
-Submit a 2-node sbatch with the AWS-tuned EFA env (the canonical reference
-parameters, see "Tuning notes" in the verified-configuration numbers in [tests/README.md](./README.md)):
+Submit a 2-node sbatch with the AWS-tuned EFA env:
 
 ```bash
 cat > /fsx/osu/osu-bench.sbatch <<'EOF'
@@ -123,8 +123,8 @@ mkdir -p /fsx/osu/logs
 sbatch -p hpc /fsx/osu/osu-bench.sbatch
 ```
 
-The reference numbers per instance type are in
-the verified-configuration numbers in [tests/README.md](./README.md) above.
+Reference numbers (hpc8a, 2 nodes) are in
+[tests/README.md](./README.md#major-update-pr--configurations-run-end-to-end-on-real-hardware).
 
 ### Step 4 — observe NIC-level traffic in Grafana (optional)
 

--- a/architectures/aws-pcs/tests/hpc-efa-test.md
+++ b/architectures/aws-pcs/tests/hpc-efa-test.md
@@ -18,7 +18,7 @@ GPU/monitoring/AMI paths were touched.
 
 This validates that the on-demand CPU CNG actually launches with EFA NICs in a
 cluster placement group, and that MPI / libfabric over EFA works end-to-end.
-Verified bandwidth numbers are recorded in
+Verified **hpc8a** bandwidth numbers are recorded in
 [tests/README.md](./README.md#major-update-pr--configurations-run-end-to-end-on-real-hardware);
 this section documents the **how-to** so a contributor can reproduce.
 

--- a/architectures/aws-pcs/tests/infra-test.md
+++ b/architectures/aws-pcs/tests/infra-test.md
@@ -37,7 +37,7 @@ curl -s http://localhost:6817/metrics | head               # Slurm OpenMetrics
 **Expected:** the six login containers are `Up`; install log exits 0; the tree is under
 `/opt`; all Prometheus targets `up`; Slurm OpenMetrics returns Prometheus-format text.
 For dashboard access (SSM port-forward or public CIDR) see
-[README §8 Monitoring](../README.md#8-monitoring). Use `MonitoringVersion=v2.10.2`+
+[README §8.2 Monitoring](../README.md#82-monitoring). Use `MonitoringVersion=v2.10.2`+
 on PCS (earlier tags have the ec2_sd credential-expiry bug — see
 [OPERATIONS.md §3](../docs/OPERATIONS.md#3-monitoring-monitoringversion)).
 

--- a/architectures/aws-pcs/tests/infra-test.md
+++ b/architectures/aws-pcs/tests/infra-test.md
@@ -37,7 +37,9 @@ curl -s http://localhost:6817/metrics | head               # Slurm OpenMetrics
 **Expected:** the six login containers are `Up`; install log exits 0; the tree is under
 `/opt`; all Prometheus targets `up`; Slurm OpenMetrics returns Prometheus-format text.
 For dashboard access (SSM port-forward or public CIDR) see
-[README §8 Monitoring](../README.md#8-monitoring). Use `MonitoringVersion=v2.9.1`+ on PCS.
+[README §8 Monitoring](../README.md#8-monitoring). Use `MonitoringVersion=v2.10.2`+
+on PCS (earlier tags have the ec2_sd credential-expiry bug — see
+[OPERATIONS.md §3](../docs/OPERATIONS.md#3-monitoring-monitoringversion)).
 
 ---
 

--- a/architectures/aws-pcs/tests/infra-test.md
+++ b/architectures/aws-pcs/tests/infra-test.md
@@ -1,7 +1,21 @@
 # Infrastructure Tests (Tests 1-3, 8)
 
-Validates cluster infrastructure: monitoring stack, container runtime (Enroot/Pyxis)
-first-boot install, and the pre-baked AMI build path.
+Validates cluster infrastructure: template lint, monitoring stack, container
+runtime (Enroot/Pyxis) first-boot install, and the pre-baked AMI build path.
+
+---
+
+## Template lint
+
+Run on every edited template before any deploy (no AWS resources created;
+catches YAML/CFN syntax errors in seconds):
+
+```bash
+aws cloudformation validate-template --template-body file://assets/<name>.yaml
+```
+
+**Expected:** the parameter list is returned with no error, for every edited
+`assets/*.yaml`.
 
 ---
 

--- a/architectures/aws-pcs/tests/multi-user-test.md
+++ b/architectures/aws-pcs/tests/multi-user-test.md
@@ -69,7 +69,7 @@ export LDAP_ADMIN_PASSWORD=$(aws ssm get-parameter \
 export LDAP_DOMAIN_SUFFIX="dc=cluster,dc=internal"
 
 # Using the helper script
-sudo -E bash /usr/local/bin/ldap-add-user.sh testuser1 10001 3000
+sudo -E ldap-add-user.sh testuser1 10001 3000
 ```
 
 (For the manual `ldapadd`/`ldappasswd` equivalent, see
@@ -118,7 +118,7 @@ srun -N 1 -n 1 -p cpu1 bash -c 'ls -la /home/testuser1'
 ### B5. Create a second user
 
 ```bash
-sudo -E bash /usr/local/bin/ldap-add-user.sh testuser2 10002 3000
+sudo -E ldap-add-user.sh testuser2 10002 3000
 ```
 
 ### B6. Delete a user
@@ -351,8 +351,8 @@ sacctmgr -i add account default Description="Default account"
 ADMIN_PW=$(aws ssm get-parameter --name "/pcs/${CLUSTER_ID}/ldap/admin-password" \
   --with-decryption --query 'Parameter.Value' --output text --region <region>)
 
-sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" bash /usr/local/bin/ldap-add-user.sh alice 10001 3000
-sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" bash /usr/local/bin/ldap-add-user.sh bob 10002 3000
+sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user.sh alice 10001 3000
+sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user.sh bob 10002 3000
 ```
 
 ### B2. Register users in Slurm accounting
@@ -466,7 +466,7 @@ sshare -a --format=Account,User,RawShares,NormShares,RawUsage,FairShare
 An unregistered user can still submit jobs:
 ```bash
 # Create a user NOT in sacctmgr
-sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" bash /usr/local/bin/ldap-add-user.sh charlie 10003 3000
+sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user.sh charlie 10003 3000
 sudo su - charlie -c 'export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH; \
   srun -p cpu1 -N1 -n1 hostname'
 ```

--- a/architectures/aws-pcs/tests/multi-user-test.md
+++ b/architectures/aws-pcs/tests/multi-user-test.md
@@ -72,25 +72,8 @@ export LDAP_DOMAIN_SUFFIX="dc=cluster,dc=internal"
 sudo -E bash /usr/local/bin/ldap-add-user.sh testuser1 10001 3000
 ```
 
-Or manually:
-```bash
-ldapadd -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -w "$LDAP_ADMIN_PASSWORD" <<EOF
-dn: uid=testuser1,ou=People,dc=cluster,dc=internal
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: testuser1
-cn: Test User 1
-sn: User1
-uidNumber: 10001
-gidNumber: 3000
-homeDirectory: /home/testuser1
-loginShell: /bin/bash
-EOF
-
-ldappasswd -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" \
-  -w "$LDAP_ADMIN_PASSWORD" -s "testpass123" "uid=testuser1,ou=People,dc=cluster,dc=internal"
-```
+(For the manual `ldapadd`/`ldappasswd` equivalent, see
+[USER-MANAGEMENT.md](../docs/USER-MANAGEMENT.md).)
 
 ### B2. Verify user visible on login node
 
@@ -318,29 +301,6 @@ Expected: the job reaches `COMPLETED` (ExitCode `0:0`) even though
 `id <user>` / `getent passwd <user>` returns "no such user" on that node —
 name resolution is degraded, the job is not.
 
----
-
-## Verdict checklist
-
-| Check | Expected |
-|---|---|
-| slapd running on login node | ✅ |
-| LDAP DB on /home/ldap-db (shared OpenZFS) | ✅ |
-| Admin password in SSM Parameter Store | ✅ |
-| User created via ldapadd/helper script | ✅ |
-| User visible on login node (`getent passwd`) | ✅ |
-| User visible on compute node (`srun getent passwd`) | ✅ |
-| Home dir auto-created on first login | ✅ |
-| User deleted, no longer resolvable | ✅ |
-| Slurm job runs as LDAP user | ✅ |
-| Multiple nodes resolve same UID | ✅ |
-| Home dir accessible from all nodes | ✅ |
-| New compute node resolves existing users | ✅ |
-| SSSD cache works during brief LDAP outage | ✅ |
-| LDAP DB survives login node replacement | ✅ |
-| Admin password preserved across replacement (same SHA-256) | ✅ |
-| Stale-ldap_uri recovery on running compute is non-disruptive | ✅ |
-| Job runs by UID even when user unresolvable on the node | ✅ |
 
 ---
 
@@ -389,10 +349,10 @@ sacctmgr -i add account default Description="Default account"
 
 ```bash
 ADMIN_PW=$(aws ssm get-parameter --name "/pcs/${CLUSTER_ID}/ldap/admin-password" \
-  --with-decryption --query 'Parameter.Value' --output text --region us-east-2)
+  --with-decryption --query 'Parameter.Value' --output text --region <region>)
 
-sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user alice 10001 3000
-sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user bob 10002 3000
+sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" bash /usr/local/bin/ldap-add-user.sh alice 10001 3000
+sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" bash /usr/local/bin/ldap-add-user.sh bob 10002 3000
 ```
 
 ### B2. Register users in Slurm accounting
@@ -506,7 +466,7 @@ sshare -a --format=Account,User,RawShares,NormShares,RawUsage,FairShare
 An unregistered user can still submit jobs:
 ```bash
 # Create a user NOT in sacctmgr
-sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user charlie 10003 3000
+sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" bash /usr/local/bin/ldap-add-user.sh charlie 10003 3000
 sudo su - charlie -c 'export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH; \
   srun -p cpu1 -N1 -n1 hostname'
 ```
@@ -525,16 +485,3 @@ sudo su - charlie -c 'export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH; 
 
 Expected: `error: Unable to allocate resources: Invalid account or account/partition combination specified`
 
----
-
-## Verdict checklist
-
-| Check | Expected |
-|---|---|
-| sacctmgr show cluster → cluster listed | ✅ |
-| Users registered in accounting (alice, bob) | ✅ |
-| Jobs run as LDAP users complete successfully | ✅ |
-| sacct shows correct user/account/state per job | ✅ |
-| sreport shows per-user utilization | ✅ |
-| Resource limit enforcement (if set) blocks over-limit jobs | ✅ |
-| Unregistered user behavior matches AccountingPolicyEnforcement setting | ✅ |

--- a/architectures/aws-pcs/tests/multi-user-test.md
+++ b/architectures/aws-pcs/tests/multi-user-test.md
@@ -426,6 +426,9 @@ sreport cluster AccountUtilizationByUser \
   format="Account,Login,Used"
 ```
 
+Expected: `sacct -u alice` lists alice's jobs; `sreport` shows alice and bob
+under `ml-team` with non-zero `Used`.
+
 ### C4. Resource limit enforcement (if B3 was set)
 
 ```bash

--- a/architectures/aws-pcs/tests/storage-test.md
+++ b/architectures/aws-pcs/tests/storage-test.md
@@ -128,4 +128,12 @@ The FSx-side EFA endpoints are usable from EFA-capable clients (CPU CNGs
 deployed with `OnDemandEfaInterfaceCount > 0`, P5/P6 GPU CNGs). Plain Lustre client
 mounts continue to work over TCP for non-EFA nodes; EFA support is additive.
 
+### Performance regression criteria
+
+For changes that touch mount options or FSx parameters, re-run the throughput
+benchmark documented in
+[OPERATIONS.md §4.1](../docs/OPERATIONS.md#41-lustre-mount-options--noatime)
+(the `noatime` benchmark) and compare against the recorded baseline.
+**A >10% degradation blocks the change.**
+
 ---


### PR DESCRIPTION
## Summary

**Documentation-only PR — no template or script changes.** Every file touched
is a Markdown file under `architectures/aws-pcs/tests/`; `assets/` is
untouched. The deployments below used the templates on `main` **as-is**; this
PR records the results.

Verified the `pcs-ml-cluster-deploy-all.yaml` deployment end-to-end in 6
additional regions — eu-west-1 (Ireland), eu-west-2 (London), eu-west-3
(Paris), eu-south-2 (Spain), sa-east-1 (São Paulo), and ap-southeast-3
(Jakarta) — bringing coverage to **16 of the 20 regions where AWS PCS is
available**. Each run confirmed: stack CREATE_COMPLETE, the monitoring
containers up on the login node, FSx Lustre `/fsx` + OpenZFS `/home` mounted,
and an Enroot/Pyxis container job completing.

The region coverage table in `tests/README.md` now lists all 20 PCS launch
regions with per-region results, the AZ ID each run used, and the Capacity
Blocks for ML GPU availability as supplemental reference.

## Region-specific findings

- **OpenZFS**: the default `OpenZFSDeploymentType=SINGLE_AZ_HA_2` is not
  available in eu-west-2, eu-west-3, sa-east-1, or ap-southeast-3 (same
  `Invalid deploymentType (BadRequest)` failure as ap-northeast-3) → deploy
  there with `OpenZFSDeploymentType=SINGLE_AZ_1` + `HomeThroughput=256`.
  Matches the official FSx for OpenZFS per-region availability table.
- **Lustre**: the default `LustreDeploymentType=PERSISTENT_2` worked in all
  16 regions, consistent with the official FSx for Lustre availability table.
- **Instance types**: eu-south-2 offers no m6i/c6i (verified with
  `LoginNodeInstanceType=m7i.4xlarge`, `OnDemandInstanceType=c7i.4xlarge`);
  ap-southeast-3 offers no c6i (verified with c7i.4xlarge). Noted per row.

All three are existing parameters doing their job in new regions — no
template behavior changes, and none needed.

## Testing

- 6 × `pcs-ml-cluster-deploy-all.yaml` deployments on real infrastructure
  (2026-07-07/08), verified via SSM; all stacks deleted after verification.
- `bash tests/lint-docs.sh` passes. Since this PR changes documentation only,
  the full pre-merge test matrix is not applicable.
