### PR TITLE
feat(aws-pcs): add Jupyter-on-compute-node guide with verification procedure

### DIFF
--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -746,6 +746,7 @@ In this repo:
 - [Parameter reference](./docs/PARAMETERS.md) — every deploy-all parameter and default
 - [Operations guide](./docs/OPERATIONS.md) — version trade-offs, AMI pinning, monitoring/DCGM, FSx coupling, Lustre tuning, production settings
 - [User management guide](./docs/USER-MANAGEMENT.md) — multi-user setup with OpenLDAP (add/remove users, groups, Slurm accounting)
+- [Jupyter on a compute node](./docs/JUPYTER.md) — run Jupyter as a Slurm job, browser access via SSM port forwarding
 - [IAM permissions guide](./docs/IAM.md) — cluster admin / cluster user roles, policy deploy, security considerations
 - [Deploy & testing procedures](./docs/DEPLOY-TESTING.md) — development deploy workflow with test S3 bucket
 - [Test & Validation Guide](./tests/README.md) — reproducible matrix with measured numbers

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -88,24 +88,12 @@ openssl rand -hex 24 > "$TOKEN_FILE"
 
 cat <<EOM
 ======================================================================
-Jupyter starting on $(hostname) ($NODE_IP), port $PORT.
-
-1. From your workstation, forward localhost:8888 to the server:
-
-  LOGIN_ID=\$(aws ec2 describe-instances \\
-    --filters "Name=tag:Name,Values=*login" \\
-              "Name=instance-state-name,Values=running" \\
-    --query 'Reservations[0].Instances[0].InstanceId' --output text)
-
-  aws ssm start-session --target \$LOGIN_ID \\
-    --document-name AWS-StartPortForwardingSessionToRemoteHost \\
-    --parameters host=$NODE_IP,portNumber=$PORT,localPortNumber=8888
-
-2. Get the token (on the login node):  cat $TOKEN_FILE
-
-3. Open:  http://localhost:8888/?token=<token>
-
-Stop the server with:  scancel $SLURM_JOB_ID
+Jupyter is running on compute node $NODE_IP, port $PORT (job $SLURM_JOB_ID).
+To connect, follow "Step 3" in JUPYTER.md with these values:
+    NODE_IP = $NODE_IP
+    PORT    = $PORT
+    token   = run  cat $TOKEN_FILE  on the login node
+Stop the server:  scancel $SLURM_JOB_ID
 ======================================================================
 EOM
 
@@ -121,69 +109,41 @@ Enroot/Pyxis install).
 
 ## Step 3 — connect
 
-### 3a. Read the connection details from the job log (on the login node)
+The job log (`~/<user>-jupyter-<jobid>.log`, printed by the running job) gives
+you the compute node's `NODE_IP` and `PORT`. With those two values:
+
+**1. On your workstation** — open the SSM tunnel (fill in your Region and the
+`NODE_IP` / `PORT` from the log):
 
 ```bash
-cat ~/<username>-jupyter-<jobid>.log   # %u = your username, e.g. ubuntu-jupyter-3.log
-```
-
-The log prints the compute node IP and port (e.g. `10.1.8.103`, port `8003`)
-and reminds you where the token file is.
-
-### 3b. Open the SSM port-forward tunnel (on your workstation)
-
-```bash
-# 1. Find the login-node instance ID
-LOGIN_ID=$(aws ec2 describe-instances \
-  --region <region> \
+LOGIN_ID=$(aws ec2 describe-instances --region <region> \
   --filters "Name=tag:Name,Values=*login" \
             "Name=instance-state-name,Values=running" \
   --query 'Reservations[0].Instances[0].InstanceId' --output text)
 
-# If you run more than one cluster in the same account, pin by stack name:
-# --filters "Name=tag:Name,Values=*login" \
-#           "Name=tag:ClusterName,Values=<your-stack-name>" \
-#           "Name=instance-state-name,Values=running"
-
-# 2. Forward localhost:8888 → compute node
-aws ssm start-session \
-  --region <region> \
-  --target "$LOGIN_ID" \
+aws ssm start-session --region <region> --target "$LOGIN_ID" \
   --document-name AWS-StartPortForwardingSessionToRemoteHost \
   --parameters "host=<NODE_IP>,portNumber=<PORT>,localPortNumber=8888"
 ```
 
-The session stays in the foreground; **Ctrl-C closes the tunnel** (the Jupyter
-job keeps running — reconnect any time until the job ends).
+Leave this running — **Ctrl-C closes the tunnel** (the Jupyter job keeps
+running; reconnect any time until the job ends).
 
-### 3c. Get the token and open the browser
-
-On the login node:
+**2. On the login node** — read the token:
 
 ```bash
 cat ~/.jupyter-token-<jobid>
 ```
 
-Then open in your browser: `http://localhost:8888/?token=<token>`
+**3. In your browser** — open `http://localhost:8888/?token=<token>`.
 
-### Required IAM permissions
-
-The two AWS CLI calls above require the following actions, all of which are
-already included in the stock
-[`cluster-user-iam.yaml`](../assets/cluster-user-iam.yaml) policy:
-
-| Call | Action(s) required |
-|---|---|
-| `aws ec2 describe-instances` | `ec2:DescribeInstances`, `ec2:DescribeInstanceStatus`, `ec2:DescribeTags` |
-| `aws ssm start-session` (instance target) | `ssm:StartSession` on `ec2:instance/*` with condition `ssm:resourceTag/Name = PCS-login*` |
-| `aws ssm start-session` (document) | `ssm:StartSession` on `arn:aws:ssm:*:*:document/AWS-StartPortForwardingSessionToRemoteHost` |
-| Session lifecycle | `ssm:DescribeSessions`, `ssm:GetConnectionStatus`, `ssm:DescribeInstanceProperties`, `ssm:TerminateSession` |
-
-If you are using the cluster-admin policy (`cluster-admin-iam.yaml`) or an
-account with broad permissions, these are implicitly covered. If you are
-operating under a restricted IAM role, attach the `cluster-user-iam.yaml`
-stack output policy (or an equivalent inline policy) before running the
-commands above.
+> **Required IAM.** The two CLI calls above are already permitted by the stock
+> [`cluster-user-iam.yaml`](../assets/cluster-user-iam.yaml) policy (and by any
+> broader admin credentials). Under a restricted role, ensure it grants:
+> `ec2:DescribeInstances` (find the login node); `ssm:StartSession` on the
+> login instance (`ssm:resourceTag/Name = PCS-login*`) and on the
+> `AWS-StartPortForwardingSessionToRemoteHost` document; and
+> `ssm:TerminateSession` / `ssm:DescribeSessions` to end the tunnel.
 
 ## Stopping
 
@@ -229,9 +189,7 @@ How the GPU allocation behaves:
   plenty for most exploration) and keep `--time` tight — an idle notebook
   holds its GPUs until the job ends. For multi-hour *training*, prefer a
   batch job over a notebook so the GPUs free up when the run finishes.
-- **Set `HF_HOME=/fsx/$USER/.hf-cache`** (e.g. in the sbatch script before
-  starting Jupyter, or per notebook) — model downloads must not go to NFS
-  `/home`, and a per-user path avoids cache-ownership clashes between users.
+  (Remember `HF_HOME=/fsx/$USER/.hf-cache` from Step 1 for model downloads.)
 - **Multi-NIC GPU nodes (P5/P6) work as-is.** On these instances `hostname -I`
   returns dozens of addresses (one per EFA NIC). The script binds Jupyter to
   the first entry, which in practice is the primary interface's IP (verified

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -121,17 +121,69 @@ Enroot/Pyxis install).
 
 ## Step 3 — connect
 
+### 3a. Read the connection details from the job log (on the login node)
+
 ```bash
-# On the login node: connection instructions are in the job log
-cat ~/ubuntu-jupyter-<jobid>.log      # (%u = your username)
+cat ~/<username>-jupyter-<jobid>.log   # %u = your username, e.g. ubuntu-jupyter-3.log
 ```
 
-Run the `aws ssm start-session …` command from the log on your **local
-workstation**, read the token (`cat ~/.jupyter-token-<jobid>` on the login
-node), then open `http://localhost:8888/?token=<token>` in your browser.
+The log prints the compute node IP and port (e.g. `10.1.8.103`, port `8003`)
+and reminds you where the token file is.
 
-The SSM session stays in the foreground; Ctrl-C closes the tunnel (the
-Jupyter job keeps running — reconnect any time until the job ends).
+### 3b. Open the SSM port-forward tunnel (on your workstation)
+
+```bash
+# 1. Find the login-node instance ID
+LOGIN_ID=$(aws ec2 describe-instances \
+  --region <region> \
+  --filters "Name=tag:Name,Values=*login" \
+            "Name=instance-state-name,Values=running" \
+  --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+# If you run more than one cluster in the same account, pin by stack name:
+# --filters "Name=tag:Name,Values=*login" \
+#           "Name=tag:ClusterName,Values=<your-stack-name>" \
+#           "Name=instance-state-name,Values=running"
+
+# 2. Forward localhost:8888 → compute node
+aws ssm start-session \
+  --region <region> \
+  --target "$LOGIN_ID" \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters "host=<NODE_IP>,portNumber=<PORT>,localPortNumber=8888"
+```
+
+The session stays in the foreground; **Ctrl-C closes the tunnel** (the Jupyter
+job keeps running — reconnect any time until the job ends).
+
+### 3c. Get the token and open the browser
+
+On the login node:
+
+```bash
+cat ~/.jupyter-token-<jobid>
+```
+
+Then open in your browser: `http://localhost:8888/?token=<token>`
+
+### Required IAM permissions
+
+The two AWS CLI calls above require the following actions, all of which are
+already included in the stock
+[`cluster-user-iam.yaml`](../assets/cluster-user-iam.yaml) policy:
+
+| Call | Action(s) required |
+|---|---|
+| `aws ec2 describe-instances` | `ec2:DescribeInstances`, `ec2:DescribeInstanceStatus`, `ec2:DescribeTags` |
+| `aws ssm start-session` (instance target) | `ssm:StartSession` on `ec2:instance/*` with condition `ssm:resourceTag/Name = PCS-login*` |
+| `aws ssm start-session` (document) | `ssm:StartSession` on `arn:aws:ssm:*:*:document/AWS-StartPortForwardingSessionToRemoteHost` |
+| Session lifecycle | `ssm:DescribeSessions`, `ssm:GetConnectionStatus`, `ssm:DescribeInstanceProperties`, `ssm:TerminateSession` |
+
+If you are using the cluster-admin policy (`cluster-admin-iam.yaml`) or an
+account with broad permissions, these are implicitly covered. If you are
+operating under a restricted IAM role, attach the `cluster-user-iam.yaml`
+stack output policy (or an equivalent inline policy) before running the
+commands above.
 
 ## Stopping
 

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -177,6 +177,12 @@ How the GPU allocation behaves:
   batch job over a notebook so the GPUs free up when the run finishes.
 - **Set `HF_HOME=/fsx/.hf-cache`** (e.g. in the sbatch script before starting
   Jupyter, or per notebook) — model downloads must not go to NFS `/home`.
+- **Multi-NIC GPU nodes (P5/P6) work as-is.** On these instances `hostname -I`
+  returns dozens of addresses (one per EFA NIC), but the first entry is always
+  the primary interface's IP — which is what the sbatch script binds Jupyter
+  to, and the address the login node can reach. Verified on p5.48xlarge
+  (32 NICs): server bound to the primary IP, port-forward path worked
+  unchanged, and the kernel saw all 8 H100s with `--gres=gpu:8`.
 - **Containerized kernels (optional):** to use an NGC image as the notebook
   environment instead of a venv, wrap the server in Pyxis:
   `srun --container-image=<image> --container-mounts=/fsx,$HOME …` around the

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -63,13 +63,13 @@ $HOME/jupyter-env/bin/pip install --upgrade pip jupyterlab
 
 ## Step 2 — submit the Jupyter job
 
-Save as `$HOME/jupyter.sbatch` and submit **from your home directory** with
-`sbatch jupyter.sbatch`:
+Save the following as `$HOME/jupyter.sbatch`. It has **no `--partition` line on
+purpose** — you pick the queue (and, for GPUs, the GPU count) at submit time,
+so the *same* script serves both CPU and GPU sessions:
 
 ```bash
 #!/bin/bash
 #SBATCH --job-name=jupyter
-#SBATCH --partition=cpu1          # or your GPU queue; then add e.g. --gres=gpu:1
 #SBATCH --nodes=1
 #SBATCH --time=8:00:00            # auto-terminate after 8 h — adjust to taste
 #SBATCH --output=%u-jupyter-%j.log
@@ -102,6 +102,22 @@ exec jupyter lab --no-browser --ip="$NODE_IP" --port="$PORT" \
   --ServerApp.token="$(cat "$TOKEN_FILE")" \
   --notebook-dir="$HOME"
 ```
+
+Then submit it with `sbatch`. **`-p <queue>` is required** — Slurm has no
+default partition, so a bare `sbatch jupyter.sbatch` is rejected with
+*"invalid partition specified"*. Run `sinfo` to list your queues, then:
+
+```bash
+# CPU session — pick a CPU queue (e.g. cpu1)
+sbatch -p cpu1 jupyter.sbatch
+
+# GPU session — pick a GPU queue and request GPUs with --gres
+sbatch -p gpu-g6 --gres=gpu:1 jupyter.sbatch
+```
+
+For GPU work, add the ML stack to the venv from Step 1 once
+(`$HOME/jupyter-env/bin/pip install torch  # + transformers, etc.`); the GPU
+allocation behaviour is detailed in [Using GPUs](#using-gpus) below.
 
 The first submission on an idle queue waits ~2–3 minutes for the node to
 scale up (8–12 minutes if the node is also running its first-boot
@@ -157,22 +173,9 @@ costs nothing.
 
 ## Using GPUs
 
-The same sbatch script works on a GPU queue — change the `#SBATCH` header, and
-request GPUs with `--gres`:
-
-```bash
-#SBATCH --partition=gpu-g6        # your GPU queue name
-#SBATCH --gres=gpu:1              # GPUs for this Jupyter session
-#SBATCH --time=8:00:00
-```
-
-Add the ML stack to the venv from Step 1 (once):
-
-```bash
-$HOME/jupyter-env/bin/pip install torch   # + transformers, etc.
-```
-
-How the GPU allocation behaves:
+You launch a GPU session with the same script and the `sbatch -p <gpu-queue>
+--gres=gpu:N` form shown in Step 2 — nothing else changes. How the GPU
+allocation behaves:
 
 - **Slurm enforces the `--gres` count.** The job gets `CUDA_VISIBLE_DEVICES`
   set to its allocated GPUs (e.g. `0,1` for `--gres=gpu:2` on a 4-GPU

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -56,9 +56,10 @@ python3 -m venv $HOME/jupyter-env
 $HOME/jupyter-env/bin/pip install --upgrade pip jupyterlab
 ```
 
-> For ML work, also set `HF_HOME=/fsx/.hf-cache` in your notebooks/jobs — the
-> HuggingFace cache must not live on NFS `/home` (file-locking errors under
-> concurrent access).
+> For ML work, also set `HF_HOME=/fsx/$USER/.hf-cache` in your notebooks/jobs —
+> the HuggingFace cache must not live on NFS `/home` (file-locking errors under
+> concurrent access), and a per-user path avoids ownership clashes on
+> multi-user clusters.
 
 ## Step 2 — submit the Jupyter job
 
@@ -75,7 +76,8 @@ Save as `$HOME/jupyter.sbatch` and submit **from your home directory** with
 
 umask 077   # everything this job writes is owner-only
 
-# Port derived from the job ID → no collisions between concurrent servers
+# Port derived from the job ID (range 8000-8999). Collisions are unlikely but
+# possible if two servers share a node with job IDs differing by a multiple of 1000.
 PORT=$((8000 + SLURM_JOB_ID % 1000))
 NODE_IP=$(hostname -I | awk '{print $1}')
 
@@ -91,7 +93,7 @@ Jupyter starting on $(hostname) ($NODE_IP), port $PORT.
 1. From your workstation, forward localhost:8888 to the server:
 
   LOGIN_ID=\$(aws ec2 describe-instances \\
-    --filters "Name=tag:aws:pcs:compute-node-group-name,Values=login" \\
+    --filters "Name=tag:Name,Values=*login" \\
               "Name=instance-state-name,Values=running" \\
     --query 'Reservations[0].Instances[0].InstanceId' --output text)
 
@@ -175,14 +177,15 @@ How the GPU allocation behaves:
   plenty for most exploration) and keep `--time` tight — an idle notebook
   holds its GPUs until the job ends. For multi-hour *training*, prefer a
   batch job over a notebook so the GPUs free up when the run finishes.
-- **Set `HF_HOME=/fsx/.hf-cache`** (e.g. in the sbatch script before starting
-  Jupyter, or per notebook) — model downloads must not go to NFS `/home`.
+- **Set `HF_HOME=/fsx/$USER/.hf-cache`** (e.g. in the sbatch script before
+  starting Jupyter, or per notebook) — model downloads must not go to NFS
+  `/home`, and a per-user path avoids cache-ownership clashes between users.
 - **Multi-NIC GPU nodes (P5/P6) work as-is.** On these instances `hostname -I`
-  returns dozens of addresses (one per EFA NIC), but the first entry is always
-  the primary interface's IP — which is what the sbatch script binds Jupyter
-  to, and the address the login node can reach. Verified on p5.48xlarge
-  (32 NICs): server bound to the primary IP, port-forward path worked
-  unchanged, and the kernel saw all 8 H100s with `--gres=gpu:8`.
+  returns dozens of addresses (one per EFA NIC). The script binds Jupyter to
+  the first entry, which in practice is the primary interface's IP (verified
+  on p5.48xlarge, 32 NICs) — and any entry is same-VPC-reachable from the
+  login node, so the port-forward path works regardless. The kernel saw all
+  8 H100s with `--gres=gpu:8`.
 - **Containerized kernels (optional):** to use an NGC image as the notebook
   environment instead of a venv, wrap the server in Pyxis:
   `srun --container-image=<image> --container-mounts=/fsx,$HOME …` around the
@@ -193,10 +196,14 @@ How the GPU allocation behaves:
 ## Notes
 
 - **Multi-user:** each user runs their own server job under their own UID; the
-  job-ID-derived port avoids collisions when several servers share a node.
-  Keep tokens in `$HOME` (created mode 600 by the script) — treat the token
-  like a password to your account, since the SSM/IAM layer alone does not
-  distinguish cluster users.
+  job-ID-derived port makes same-node collisions unlikely (see the comment in
+  the script). Keep tokens in `$HOME` (created mode 600 by the script) — treat
+  the token like a password to your account, since the SSM/IAM layer alone
+  does not distinguish cluster users.
+- **Multiple clusters in one account:** the `Name=*login` tag filter in the
+  connect snippet matches the login node of *every* PCS cluster that follows
+  the naming convention — add a `"Name=tag:ClusterName,Values=<your-stack>"`
+  filter to pin it when you run more than one.
 - **Alternative when `SSHAccessCidr` is set:** a plain SSH tunnel also works —
   `ssh -L 8888:<compute-node-ip>:<port> <user>@<login-public-ip>` — useful for
   users who cannot install the Session Manager plugin.

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -1,0 +1,159 @@
+# Running Jupyter on a Compute Node
+
+How to run a Jupyter (Lab/Notebook) server on a compute node as a **Slurm job**
+and reach it from your local browser, with no inbound ports opened on the
+cluster. Works for the single-`ubuntu`-user default cluster and for
+[multi-user (OpenLDAP)](./USER-MANAGEMENT.md) clusters — the per-user notes are
+called out inline.
+
+## How it works
+
+```
+Browser (http://localhost:8888)
+   │
+   │  aws ssm start-session … AWS-StartPortForwardingSessionToRemoteHost
+   ▼
+Login node  (SSM session entry point)
+   │  forwards to <compute-node-ip>:<port> inside the cluster security group
+   ▼
+Compute node — Jupyter server, launched as an sbatch job
+```
+
+- **Jupyter runs as a Slurm job** (not hand-started on a node): submitting the
+  job wakes the queue from 0 nodes, GPU allocation (`--gres`) and accounting
+  work as usual, and the `--time` limit auto-terminates a forgotten server.
+  Anything installed by hand on a node would also be lost when PCS replaces
+  the node — a job is re-submittable.
+- **Access goes through the login node over SSM.** The
+  `AWS-StartPortForwardingSessionToRemoteHost` document opens the session on
+  the *login* node and forwards to the compute node inside the cluster
+  security group. No `SSHAccessCidr`, no SSH keys, nothing exposed — and it is
+  already permitted by the stock
+  [`cluster-user-iam.yaml`](../assets/cluster-user-iam.yaml) policy (which
+  allows `ssm:StartSession` on the login node only, plus the port-forwarding
+  documents).
+- **The Jupyter token is the user boundary.** The server binds to the node's
+  private IP, so any cluster user could reach the port; the token (stored
+  under `$HOME`, mode 600) is what keeps a session private to its owner.
+
+## Prerequisites
+
+- On your workstation: AWS CLI + the
+  [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html),
+  and either cluster-admin credentials or the
+  [cluster-user policy](./IAM.md).
+- **Multi-user clusters:** your `$HOME` must exist before the first job — log
+  in to the login node (SSH or SSM) once so `pam_mkhomedir` creates it. Slurm
+  jobs do not create home directories.
+
+## Step 1 — one-time: create a Jupyter environment on `/home`
+
+On the login node (as the user who will run Jupyter). `/home` is shared
+FSx for OpenZFS, so every compute node sees the venv:
+
+```bash
+python3 -m venv $HOME/jupyter-env
+$HOME/jupyter-env/bin/pip install --upgrade pip jupyterlab
+```
+
+> For ML work, also set `HF_HOME=/fsx/.hf-cache` in your notebooks/jobs — the
+> HuggingFace cache must not live on NFS `/home` (file-locking errors under
+> concurrent access).
+
+## Step 2 — submit the Jupyter job
+
+Save as `$HOME/jupyter.sbatch` and submit **from your home directory** with
+`sbatch jupyter.sbatch`:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=jupyter
+#SBATCH --partition=cpu1          # or your GPU queue; then add e.g. --gres=gpu:1
+#SBATCH --nodes=1
+#SBATCH --time=8:00:00            # auto-terminate after 8 h — adjust to taste
+#SBATCH --output=%u-jupyter-%j.log
+
+umask 077   # everything this job writes is owner-only
+
+# Port derived from the job ID → no collisions between concurrent servers
+PORT=$((8000 + SLURM_JOB_ID % 1000))
+NODE_IP=$(hostname -I | awk '{print $1}')
+
+# Token kept out of the job log on purpose (the log may be readable by others
+# depending on where you submit from); mode-600 file under $HOME instead.
+TOKEN_FILE=$HOME/.jupyter-token-$SLURM_JOB_ID
+openssl rand -hex 24 > "$TOKEN_FILE"
+
+cat <<EOM
+======================================================================
+Jupyter starting on $(hostname) ($NODE_IP), port $PORT.
+
+1. From your workstation, forward localhost:8888 to the server:
+
+  LOGIN_ID=\$(aws ec2 describe-instances \\
+    --filters "Name=tag:aws:pcs:compute-node-group-name,Values=login" \\
+              "Name=instance-state-name,Values=running" \\
+    --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+  aws ssm start-session --target \$LOGIN_ID \\
+    --document-name AWS-StartPortForwardingSessionToRemoteHost \\
+    --parameters host=$NODE_IP,portNumber=$PORT,localPortNumber=8888
+
+2. Get the token (on the login node):  cat $TOKEN_FILE
+
+3. Open:  http://localhost:8888/?token=<token>
+
+Stop the server with:  scancel $SLURM_JOB_ID
+======================================================================
+EOM
+
+source $HOME/jupyter-env/bin/activate
+exec jupyter lab --no-browser --ip="$NODE_IP" --port="$PORT" \
+  --ServerApp.token="$(cat "$TOKEN_FILE")" \
+  --notebook-dir="$HOME"
+```
+
+The first submission on an idle queue waits ~2–3 minutes for the node to
+scale up (8–12 minutes if the node is also running its first-boot
+Enroot/Pyxis install).
+
+## Step 3 — connect
+
+```bash
+# On the login node: connection instructions are in the job log
+cat ~/ubuntu-jupyter-<jobid>.log      # (%u = your username)
+```
+
+Run the `aws ssm start-session …` command from the log on your **local
+workstation**, read the token (`cat ~/.jupyter-token-<jobid>` on the login
+node), then open `http://localhost:8888/?token=<token>` in your browser.
+
+The SSM session stays in the foreground; Ctrl-C closes the tunnel (the
+Jupyter job keeps running — reconnect any time until the job ends).
+
+## Stopping
+
+```bash
+scancel <jobid>            # or let the --time limit expire
+rm ~/.jupyter-token-<jobid>
+```
+
+The queue scales back to 0 after the idle timeout, so a stopped Jupyter job
+costs nothing.
+
+## Notes
+
+- **Multi-user:** each user runs their own server job under their own UID; the
+  job-ID-derived port avoids collisions when several servers share a node.
+  Keep tokens in `$HOME` (created mode 600 by the script) — treat the token
+  like a password to your account, since the SSM/IAM layer alone does not
+  distinguish cluster users.
+- **GPU:** switch `--partition` to your GPU queue and add `--gres=gpu:1` (or
+  more). For a containerized kernel environment (e.g. an NGC PyTorch image),
+  run the same pattern with Pyxis: `srun --container-image=… --container-mounts=/fsx,$HOME`
+  around the `jupyter lab` command.
+- **Alternative when `SSHAccessCidr` is set:** a plain SSH tunnel also works —
+  `ssh -L 8888:<compute-node-ip>:<port> <user>@<login-public-ip>` — useful for
+  users who cannot install the Session Manager plugin.
+- **Do not run Jupyter on the login node.** It has no GPUs, and it is shared
+  by every user (and hosts the monitoring stack).

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -141,6 +141,49 @@ rm ~/.jupyter-token-<jobid>
 The queue scales back to 0 after the idle timeout, so a stopped Jupyter job
 costs nothing.
 
+## Using GPUs
+
+The same sbatch script works on a GPU queue — change the `#SBATCH` header, and
+request GPUs with `--gres`:
+
+```bash
+#SBATCH --partition=gpu-g6        # your GPU queue name
+#SBATCH --gres=gpu:1              # GPUs for this Jupyter session
+#SBATCH --time=8:00:00
+```
+
+Add the ML stack to the venv from Step 1 (once):
+
+```bash
+$HOME/jupyter-env/bin/pip install torch   # + transformers, etc.
+```
+
+How the GPU allocation behaves:
+
+- **Slurm enforces the `--gres` count.** The job gets `CUDA_VISIBLE_DEVICES`
+  set to its allocated GPUs (e.g. `0,1` for `--gres=gpu:2` on a 4-GPU
+  g6.12xlarge), so frameworks like PyTorch see exactly the requested GPUs —
+  `torch.cuda.device_count()` matches the `--gres` count. GPU node groups
+  configure gres automatically (e.g. `Gres=gpu:L4:4`; check with
+  `scontrol show node <node>`).
+- **Multi-GPU works inside one notebook.** All allocated GPUs are visible to
+  the kernel, so `DataParallel` / FSDP / `accelerate` with
+  `num_processes=<gres count>` run as usual. Leave GPUs you don't need
+  unrequested — on multi-GPU nodes Slurm can schedule other jobs (another
+  user's Jupyter, batch training) onto the remaining GPUs.
+- **Sizing:** request only what you interactively need (`--gres=gpu:1` is
+  plenty for most exploration) and keep `--time` tight — an idle notebook
+  holds its GPUs until the job ends. For multi-hour *training*, prefer a
+  batch job over a notebook so the GPUs free up when the run finishes.
+- **Set `HF_HOME=/fsx/.hf-cache`** (e.g. in the sbatch script before starting
+  Jupyter, or per notebook) — model downloads must not go to NFS `/home`.
+- **Containerized kernels (optional):** to use an NGC image as the notebook
+  environment instead of a venv, wrap the server in Pyxis:
+  `srun --container-image=<image> --container-mounts=/fsx,$HOME …` around the
+  `jupyter lab` command inside the job. Import large images once to
+  `/fsx/*.sqsh` (see the [README §7](../README.md#7-running-a-job) enroot
+  note) and pass the `.sqsh` path as the image.
+
 ## Notes
 
 - **Multi-user:** each user runs their own server job under their own UID; the
@@ -148,12 +191,11 @@ costs nothing.
   Keep tokens in `$HOME` (created mode 600 by the script) — treat the token
   like a password to your account, since the SSM/IAM layer alone does not
   distinguish cluster users.
-- **GPU:** switch `--partition` to your GPU queue and add `--gres=gpu:1` (or
-  more). For a containerized kernel environment (e.g. an NGC PyTorch image),
-  run the same pattern with Pyxis: `srun --container-image=… --container-mounts=/fsx,$HOME`
-  around the `jupyter lab` command.
 - **Alternative when `SSHAccessCidr` is set:** a plain SSH tunnel also works —
   `ssh -L 8888:<compute-node-ip>:<port> <user>@<login-public-ip>` — useful for
   users who cannot install the Session Manager plugin.
 - **Do not run Jupyter on the login node.** It has no GPUs, and it is shared
   by every user (and hosts the monitoring stack).
+- **Scripts on `/fsx` can't be exec'd directly** (Lustre blocks `execve` on
+  some paths) — keep the sbatch file under `$HOME`, or invoke via
+  `bash /fsx/script.sh`.

--- a/architectures/aws-pcs/tests/README.md
+++ b/architectures/aws-pcs/tests/README.md
@@ -78,7 +78,7 @@ The table lists **all 20 regions where AWS PCS is available** (per
 | Region (AZ ID) ¹ | Verified ² | Storage ³ (Lustre<br>/ OpenZFS) | GPU verified ⁴ | *(ref) CBML GPUs offered* ⁵ | Date (UTC) |
 |---|---|---|---|---|---|
 | **N. Virginia**<br>(`use1-az1`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ | P6-B300, P6-B200, P5, P5e, P5en, P4d, P4de | 2026-06-17 |
-| **Ohio**<br>(`use2-az3`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ | P6-B200, P5, P5e, P5en, P4d | 2026-06-17 |
+| **Ohio**<br>(`use2-az3`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ P5 | P6-B200, P5, P5e, P5en, P4d | 2026-07-08 |
 | **Oregon**<br>(`usw2-az3`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ P6-B300 | P6-B300, P6-B200, P5, P5e, P5en, P4d, P4de | 2026-06-17 |
 | **Tokyo**<br>(`apne1-az1`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | — | P5, P5e, P5en | 2026-06-17 |
 | **Mumbai**<br>(`aps1-az2`) | ✅ | ✅ `PERSISTENT_2`<br>✅ `SINGLE_AZ_HA_2` | ✅ P6-B200 | P6-B200, P5, P5e, P5en | 2026-06-17 |

--- a/architectures/aws-pcs/tests/README.md
+++ b/architectures/aws-pcs/tests/README.md
@@ -27,6 +27,7 @@ LDAP users).
 | 11-12 | **Multi-user** | OpenLDAP directory + Slurm managed accounting | [`multi-user-test.md`](./multi-user-test.md) | Directory / accounting changes |
 | 13 | **GPU health** | GPU Cluster Health Check suite (DCGM, EFA, NVLink, NCCL thresholds) | [`gpu-healthcheck-test.md`](./gpu-healthcheck-test.md) | GPU CNG deploys |
 | 14 | **IAM** | cluster-admin deploys+deletes (no `iam:CreatePolicy`); cluster-user is SSM-login-only and can't read the LDAP password | [`iam-test.md`](./iam-test.md) | IAM policy changes |
+| 15 | **Jupyter** | Jupyter server as a Slurm job on CPU + GPU queues; token auth, SSM tunnel, GPU visible from the notebook kernel (self-contained — portable to any Slurm cluster) | [`jupyter-notebook-test.md`](./jupyter-notebook-test.md) | JUPYTER.md changes |
 
 ---
 

--- a/architectures/aws-pcs/tests/jupyter-notebook-test.md
+++ b/architectures/aws-pcs/tests/jupyter-notebook-test.md
@@ -1,0 +1,220 @@
+# Jupyter Notebook on a Compute Node — Verification Procedure
+
+Verifies that a Jupyter (Lab) server runs on a Slurm compute node as a batch
+job, is reachable from a workstation browser without opening inbound ports,
+and — on a GPU queue — actually sees its allocated GPU(s) from a notebook
+kernel.
+
+> **Portability note:** this procedure is written against a generic Slurm
+> cluster and is not tied to the PCS reference templates. Prerequisites are
+> stated explicitly below so the test can be relocated to another test set
+> (e.g. a repo-level `test_cases` collection) and run on any Slurm cluster
+> that meets them.
+
+---
+
+## Prerequisites
+
+- A Slurm cluster with:
+  - a login node the tester can reach (SSH, or SSM if on AWS),
+  - a CPU partition and a GPU partition (any CUDA GPU; verified on
+    `g6.12xlarge`, 4× NVIDIA L4),
+  - a **shared `$HOME`** visible from login and compute nodes (NFS or
+    equivalent) — the venv, the sbatch script, and the token file live there,
+  - GPU partitions configured with `gres/gpu` (check
+    `scontrol show node <gpu-node> | grep Gres`).
+- On the workstation (only for the browser-access step): AWS CLI + Session
+  Manager plugin if using SSM port forwarding, or plain SSH `-L` if the login
+  node accepts SSH.
+- Internet egress from login and compute nodes (pip installs, first run).
+
+Time: ~15 min on a warm cluster; add node scale-up time (2–3 min per queue,
+more if the node runs first-boot provisioning) on a scale-to-zero cluster.
+
+---
+
+## Step 1 — environment setup (once, on the login node)
+
+```bash
+python3 -m venv $HOME/jupyter-env
+$HOME/jupyter-env/bin/pip install --upgrade pip jupyterlab
+$HOME/jupyter-env/bin/pip install torch        # GPU test only
+$HOME/jupyter-env/bin/jupyter lab --version
+```
+
+**Expected:** a version number prints (verified with 4.6.1). Because `$HOME`
+is shared, every compute node sees the same venv.
+
+---
+
+## Step 2 — CPU: Jupyter server as a Slurm job
+
+Save as `$HOME/jupyter.sbatch` (this is the same script as the user-facing
+guide; adjust `--partition` to your CPU queue):
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=jupyter
+#SBATCH --partition=cpu1
+#SBATCH --nodes=1
+#SBATCH --time=8:00:00
+#SBATCH --output=%u-jupyter-%j.log
+
+umask 077
+
+PORT=$((8000 + SLURM_JOB_ID % 1000))
+NODE_IP=$(hostname -I | awk '{print $1}')
+
+TOKEN_FILE=$HOME/.jupyter-token-$SLURM_JOB_ID
+openssl rand -hex 24 > "$TOKEN_FILE"
+
+echo "Jupyter on $(hostname) ($NODE_IP) port $PORT; token in $TOKEN_FILE"
+
+source $HOME/jupyter-env/bin/activate
+exec jupyter lab --no-browser --ip="$NODE_IP" --port="$PORT" \
+  --ServerApp.token="$(cat "$TOKEN_FILE")" \
+  --notebook-dir="$HOME"
+```
+
+```bash
+cd $HOME && sbatch jupyter.sbatch
+squeue                                    # wait for state R
+head -30 $(ls -t $HOME/*-jupyter-*.log | head -1)
+ls -l $HOME/.jupyter-token-*
+```
+
+**Expected:**
+
+- Job reaches `R` (on scale-to-zero: `CF` for 2–3 min first).
+- The log shows the node IP and the job-derived port (e.g. job 10 → port 8010).
+- The token file exists with mode `-rw-------` (600) and is **not** echoed in
+  the job log.
+
+### 2a. HTTP reachability and token auth (from the login node)
+
+```bash
+NODE_IP=<ip from log>; PORT=<port from log>; JOBID=<jobid>
+curl -s -o /dev/null -w '%{http_code}\n' http://$NODE_IP:$PORT/api/status   # no token
+curl -s -H "Authorization: token $(cat $HOME/.jupyter-token-$JOBID)" \
+  http://$NODE_IP:$PORT/api/status
+```
+
+**Expected:** `403` without the token; with it, a JSON status body such as
+`{"connections": 0, "kernels": 0, "last_activity": "...", "started": "..."}`.
+
+### 2b. Browser path from the workstation
+
+Via SSM (AWS; `LOGIN_ID` = login-node instance ID) — run locally:
+
+```bash
+aws ssm start-session --target $LOGIN_ID \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters host=$NODE_IP,portNumber=$PORT,localPortNumber=8888
+# other terminal:
+curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8888/lab?token=$(TOKEN)"
+```
+
+(Or the SSH equivalent: `ssh -L 8888:$NODE_IP:$PORT <login-node>`.)
+
+**Expected:** `200` from `/lab?token=…`, and the same `/api/status` JSON as 2a
+through `localhost:8888`. Opening the URL in a browser shows JupyterLab.
+
+---
+
+## Step 3 — GPU: server on a GPU queue, GPU visible from the kernel
+
+Copy the script to `jupyter-gpu.sbatch` and change only the header:
+
+```bash
+#SBATCH --job-name=jupyter-gpu
+#SBATCH --partition=gpu-g6         # your GPU queue
+#SBATCH --gres=gpu:1
+```
+
+Submit and repeat the Step 2 checks (server up, 403/JSON, tunnel). Then verify
+GPU visibility **inside the job's allocation** — `--overlap` attaches to the
+running Jupyter job without consuming its resources:
+
+```bash
+srun --jobid=<gpu-jobid> --overlap nvidia-smi
+```
+
+**Expected:** the full GPU table for the node (all physical GPUs listed —
+e.g. 4× NVIDIA L4 on g6.12xlarge; allocation limits are enforced per-process
+via `CUDA_VISIBLE_DEVICES`, not in `nvidia-smi`).
+
+### 3a. Framework-level GPU check (the actual pass/fail gate)
+
+Save as `$HOME/gpu_check.py`:
+
+```python
+import json, os, subprocess
+import torch
+res = {
+    "hostname": subprocess.run(["hostname"], capture_output=True, text=True).stdout.strip(),
+    "CUDA_VISIBLE_DEVICES": os.environ.get("CUDA_VISIBLE_DEVICES", "<unset>"),
+    "SLURM_JOB_ID": os.environ.get("SLURM_JOB_ID", "<unset>"),
+    "torch_version": torch.__version__,
+    "cuda_available": torch.cuda.is_available(),
+    "device_count": torch.cuda.device_count(),
+}
+if res["cuda_available"]:
+    res["device_name"] = torch.cuda.get_device_name(0)
+    x = torch.rand(1000, 1000, device="cuda")
+    res["matmul_sum_positive"] = bool((x @ x).sum().item() > 0)
+print(json.dumps(res, indent=2))
+```
+
+Run it two ways — directly in the allocation, and through an actual notebook
+executed by the Jupyter machinery (`jupyter execute` uses the same kernel the
+browser would):
+
+```bash
+# direct
+srun --jobid=<gpu-jobid> --overlap $HOME/jupyter-env/bin/python $HOME/gpu_check.py
+
+# as a notebook: one code cell containing  exec(open('/home/.../gpu_check.py').read())
+srun --jobid=<gpu-jobid> --overlap $HOME/jupyter-env/bin/jupyter execute \
+  --output=gpu_check_out.ipynb $HOME/gpu_check.ipynb
+```
+
+**Expected (both ways, pass criteria in bold):**
+
+```json
+{
+  "CUDA_VISIBLE_DEVICES": "0",
+  "cuda_available": true,          ← must be true
+  "device_count": 1,               ← must equal the --gres count
+  "device_name": "NVIDIA L4",
+  "matmul_sum_positive": true      ← must be true (a real CUDA op ran)
+}
+```
+
+`CUDA_VISIBLE_DEVICES` matching the `--gres` count (here `0` for `gpu:1` on a
+4-GPU node) confirms Slurm's gres enforcement reaches the kernel process; the
+matmul confirms compute actually executes on the device, not just enumeration.
+
+---
+
+## Step 4 — cleanup
+
+```bash
+scancel <cpu-jobid> <gpu-jobid>
+rm $HOME/.jupyter-token-*
+```
+
+**Expected:** `squeue` empties; on scale-to-zero clusters the nodes terminate
+after the idle timeout.
+
+---
+
+## Verified configuration (2026-07-07)
+
+| Item | Value |
+|---|---|
+| Cluster | AWS PCS (Slurm 25.11), scale-to-zero queues |
+| CPU test | `cpu1` queue, c-family node — server up, 403/token-JSON, tunnel `200` |
+| GPU test | `gpu-g6` queue, g6.12xlarge (4× L4), `--gres=gpu:1` |
+| GPU result | `cuda_available=true`, `device_count=1`, `CUDA_VISIBLE_DEVICES=0`, CUDA matmul OK — identical from direct `srun` and from `jupyter execute` notebook run |
+| Access path | SSM port-forward via login node (`AWS-StartPortForwardingSessionToRemoteHost`), no inbound ports |
+| Software | JupyterLab 4.6.1, torch 2.12.1+cu130, driver 595.71.05 / CUDA 13.2 |

--- a/architectures/aws-pcs/tests/jupyter-notebook-test.md
+++ b/architectures/aws-pcs/tests/jupyter-notebook-test.md
@@ -49,8 +49,9 @@ is shared, every compute node sees the same venv.
 
 ## Step 2 — CPU: Jupyter server as a Slurm job
 
-Save as `$HOME/jupyter.sbatch` (this is the same script as the user-facing
-guide; adjust `--partition` to your CPU queue):
+Save as `$HOME/jupyter.sbatch` (a trimmed variant of the script in
+[JUPYTER.md](../docs/JUPYTER.md) — the server-launch logic is the same; **keep
+the two in sync** when changing it. Adjust `--partition` to your CPU queue):
 
 ```bash
 #!/bin/bash
@@ -62,6 +63,8 @@ guide; adjust `--partition` to your CPU queue):
 
 umask 077
 
+# Port range 8000-8999; collisions possible only if two servers share a node
+# with job IDs differing by a multiple of 1000
 PORT=$((8000 + SLURM_JOB_ID % 1000))
 NODE_IP=$(hostname -I | awk '{print $1}')
 
@@ -110,8 +113,8 @@ Via SSM (AWS; `LOGIN_ID` = login-node instance ID) — run locally:
 aws ssm start-session --target $LOGIN_ID \
   --document-name AWS-StartPortForwardingSessionToRemoteHost \
   --parameters host=$NODE_IP,portNumber=$PORT,localPortNumber=8888
-# other terminal:
-curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8888/lab?token=$(TOKEN)"
+# other terminal — TOKEN=<value from `cat ~/.jupyter-token-<jobid>` on the login node>:
+curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8888/lab?token=$TOKEN"
 ```
 
 (Or the SSH equivalent: `ssh -L 8888:$NODE_IP:$PORT <login-node>`.)
@@ -165,7 +168,23 @@ if res["cuda_available"]:
 print(json.dumps(res, indent=2))
 ```
 
-Run it two ways — directly in the allocation, and through an actual notebook
+Create a one-cell notebook that runs the same script (the cell path must
+match where `gpu_check.py` was saved):
+
+```bash
+cat > $HOME/gpu_check.ipynb <<EOF
+{
+ "cells": [
+  {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [],
+   "source": ["exec(open('$HOME/gpu_check.py').read())"]}
+ ],
+ "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+ "nbformat": 4, "nbformat_minor": 5
+}
+EOF
+```
+
+Run the check two ways — directly in the allocation, and through the notebook
 executed by the Jupyter machinery (`jupyter execute` uses the same kernel the
 browser would):
 
@@ -173,9 +192,12 @@ browser would):
 # direct
 srun --jobid=<gpu-jobid> --overlap $HOME/jupyter-env/bin/python $HOME/gpu_check.py
 
-# as a notebook: one code cell containing  exec(open('/home/.../gpu_check.py').read())
+# as a notebook (prints nothing on success; output lands in gpu_check_out.ipynb)
 srun --jobid=<gpu-jobid> --overlap $HOME/jupyter-env/bin/jupyter execute \
   --output=gpu_check_out.ipynb $HOME/gpu_check.ipynb
+
+# print the executed cell's output
+python3 -c "import json; nb=json.load(open('$HOME/gpu_check_out.ipynb')); [print(''.join(o.get('text',[]))) for c in nb['cells'] for o in c.get('outputs',[]) if 'text' in o]"
 ```
 
 **Expected (both ways, pass criteria in bold):**
@@ -193,6 +215,9 @@ srun --jobid=<gpu-jobid> --overlap $HOME/jupyter-env/bin/jupyter execute \
 `CUDA_VISIBLE_DEVICES` matching the `--gres` count (here `0` for `gpu:1` on a
 4-GPU node) confirms Slurm's gres enforcement reaches the kernel process; the
 matmul confirms compute actually executes on the device, not just enumeration.
+(Note: `device_count == --gres count` assumes the cluster constrains devices
+per job — `ConstrainDevices=yes` in `cgroup.conf`, the PCS default. On a
+cluster without device cgroups the kernel sees every GPU on the node.)
 
 ---
 
@@ -225,3 +250,4 @@ seeing exactly the `--gres` allocation from both direct `srun` and a
 | 2026-07-08 | **fresh `deploy-all`** (E2E gate also passed: 6 monitoring containers, Pyxis container job) | `cpu1` c6i.4xlarge, scale-from-zero | — |
 | 2026-07-08 | same fresh cluster | `gpu-g6` g6.12xlarge, first-boot node | identical to 07-07 GPU run |
 | 2026-07-08 | **fresh `deploy-all` + P5 CNG on a Capacity Block** (GPU E2E also passed: Pyxis CUDA container `nvidia-smi`, DCGM exporter scraping all 8 GPUs) | `gpu-p5` p5.48xlarge (8× H100, 32 NICs), `--gres=gpu:8` | `device_count=8`, `CUDA_VISIBLE_DEVICES=0,…,7`, matmul OK; multi-NIC first-IP binding worked unchanged |
+| 2026-07-09 | fresh `deploy-all` cluster — **clean-room pass**: every command block in this file and JUPYTER.md executed verbatim in its documented role (login node / workstation), including the `Name=*login` login-node discovery, the workstation `$TOKEN` curl, and the notebook-creation heredoc | `cpu1` + `gpu-g6` g6.12xlarge, `--gres=gpu:1` | identical results; notebook run output extracted with the documented print command |

--- a/architectures/aws-pcs/tests/jupyter-notebook-test.md
+++ b/architectures/aws-pcs/tests/jupyter-notebook-test.md
@@ -107,17 +107,35 @@ curl -s -H "Authorization: token $(cat $HOME/.jupyter-token-$JOBID)" \
 
 ### 2b. Browser path from the workstation
 
-Via SSM (AWS; `LOGIN_ID` = login-node instance ID) — run locally:
+Run from your local workstation. Prerequisites: AWS CLI +
+[Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+installed, and IAM permissions from `cluster-user-iam.yaml` (see
+[JUPYTER.md §Required IAM permissions](../docs/JUPYTER.md#required-iam-permissions)).
 
 ```bash
-aws ssm start-session --target $LOGIN_ID \
+# Discover the login-node instance ID
+LOGIN_ID=$(aws ec2 describe-instances \
+  --region <region> \
+  --filters "Name=tag:Name,Values=*login" \
+            "Name=instance-state-name,Values=running" \
+  --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+# Open the SSM port-forward tunnel (stays in foreground; Ctrl-C to close)
+aws ssm start-session \
+  --region <region> \
+  --target "$LOGIN_ID" \
   --document-name AWS-StartPortForwardingSessionToRemoteHost \
-  --parameters host=$NODE_IP,portNumber=$PORT,localPortNumber=8888
-# other terminal — TOKEN=<value from `cat ~/.jupyter-token-<jobid>` on the login node>:
+  --parameters "host=$NODE_IP,portNumber=$PORT,localPortNumber=8888"
+```
+
+In a second terminal on the workstation (TOKEN = value of
+`cat ~/.jupyter-token-<jobid>` on the login node):
+
+```bash
 curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8888/lab?token=$TOKEN"
 ```
 
-(Or the SSH equivalent: `ssh -L 8888:$NODE_IP:$PORT <login-node>`.)
+(SSH alternative when `SSHAccessCidr` is set: `ssh -L 8888:$NODE_IP:$PORT <login-node>`.)
 
 **Expected:** `200` from `/lab?token=…`, and the same `/api/status` JSON as 2a
 through `localhost:8888`. Opening the URL in a browser shows JupyterLab.

--- a/architectures/aws-pcs/tests/jupyter-notebook-test.md
+++ b/architectures/aws-pcs/tests/jupyter-notebook-test.md
@@ -208,13 +208,13 @@ after the idle timeout.
 
 ---
 
-## Verified configuration (2026-07-07)
+## Verified configurations
 
-| Item | Value |
-|---|---|
-| Cluster | AWS PCS (Slurm 25.11), scale-to-zero queues |
-| CPU test | `cpu1` queue, c-family node — server up, 403/token-JSON, tunnel `200` |
-| GPU test | `gpu-g6` queue, g6.12xlarge (4× L4), `--gres=gpu:1` |
-| GPU result | `cuda_available=true`, `device_count=1`, `CUDA_VISIBLE_DEVICES=0`, CUDA matmul OK — identical from direct `srun` and from `jupyter execute` notebook run |
-| Access path | SSM port-forward via login node (`AWS-StartPortForwardingSessionToRemoteHost`), no inbound ports |
-| Software | JupyterLab 4.6.1, torch 2.12.1+cu130, driver 595.71.05 / CUDA 13.2 |
+| Item | 2026-07-07 (existing cluster) | 2026-07-08 (fresh deploy-all) |
+|---|---|---|
+| Cluster | AWS PCS (Slurm 25.11), scale-to-zero queues | Fresh `pcs-ml-cluster-deploy-all.yaml` deploy (us-east-2), Slurm 25.11 — E2E gate also passed (6 monitoring containers, Pyxis `ubuntu:22.04` container job) |
+| CPU test | `cpu1` queue, c-family node — server up, 403/token-JSON, tunnel `200` | `cpu1` queue, c6i.4xlarge, scale-from-zero — same results |
+| GPU test | `gpu-g6` queue, g6.12xlarge (4× L4), `--gres=gpu:1` | same, first-boot node (Enroot/Pyxis install then job start) |
+| GPU result | `cuda_available=true`, `device_count=1`, `CUDA_VISIBLE_DEVICES=0`, CUDA matmul OK — identical from direct `srun` and from `jupyter execute` notebook run | identical |
+| Access path | SSM port-forward via login node (`AWS-StartPortForwardingSessionToRemoteHost`), no inbound ports | identical (`/lab` = `200` through the tunnel for both queues) |
+| Software | JupyterLab 4.6.1, torch 2.12.1+cu130, driver 595.71.05 / CUDA 13.2 | identical |

--- a/architectures/aws-pcs/tests/jupyter-notebook-test.md
+++ b/architectures/aws-pcs/tests/jupyter-notebook-test.md
@@ -210,11 +210,18 @@ after the idle timeout.
 
 ## Verified configurations
 
-| Item | 2026-07-07 (existing cluster) | 2026-07-08 (fresh deploy-all) |
-|---|---|---|
-| Cluster | AWS PCS (Slurm 25.11), scale-to-zero queues | Fresh `pcs-ml-cluster-deploy-all.yaml` deploy (us-east-2), Slurm 25.11 — E2E gate also passed (6 monitoring containers, Pyxis `ubuntu:22.04` container job) |
-| CPU test | `cpu1` queue, c-family node — server up, 403/token-JSON, tunnel `200` | `cpu1` queue, c6i.4xlarge, scale-from-zero — same results |
-| GPU test | `gpu-g6` queue, g6.12xlarge (4× L4), `--gres=gpu:1` | same, first-boot node (Enroot/Pyxis install then job start) |
-| GPU result | `cuda_available=true`, `device_count=1`, `CUDA_VISIBLE_DEVICES=0`, CUDA matmul OK — identical from direct `srun` and from `jupyter execute` notebook run | identical |
-| Access path | SSM port-forward via login node (`AWS-StartPortForwardingSessionToRemoteHost`), no inbound ports | identical (`/lab` = `200` through the tunnel for both queues) |
-| Software | JupyterLab 4.6.1, torch 2.12.1+cu130, driver 595.71.05 / CUDA 13.2 | identical |
+All runs: AWS PCS, Slurm 25.11, us-east-2, scale-to-zero queues; JupyterLab
+4.6.1, torch 2.12.1+cu130, driver 595.71.05 / CUDA 13.2. Access via SSM
+port-forward through the login node (no inbound ports). Every run passed the
+same gates — server up as a Slurm job, token file mode 600, `403` without /
+JSON with token, `/lab` = `200` through the tunnel, and (GPU) the kernel
+seeing exactly the `--gres` allocation from both direct `srun` and a
+`jupyter execute` notebook run.
+
+| Date | Cluster | Queue / instance | GPU check |
+|---|---|---|---|
+| 2026-07-07 | existing dev cluster | `cpu1` (c-family) | — |
+| 2026-07-07 | existing dev cluster | `gpu-g6` g6.12xlarge (4× L4), `--gres=gpu:1` | `device_count=1`, `CUDA_VISIBLE_DEVICES=0`, matmul OK |
+| 2026-07-08 | **fresh `deploy-all`** (E2E gate also passed: 6 monitoring containers, Pyxis container job) | `cpu1` c6i.4xlarge, scale-from-zero | — |
+| 2026-07-08 | same fresh cluster | `gpu-g6` g6.12xlarge, first-boot node | identical to 07-07 GPU run |
+| 2026-07-08 | **fresh `deploy-all` + P5 CNG on a Capacity Block** (GPU E2E also passed: Pyxis CUDA container `nvidia-smi`, DCGM exporter scraping all 8 GPUs) | `gpu-p5` p5.48xlarge (8× H100, 32 NICs), `--gres=gpu:8` | `device_count=8`, `CUDA_VISIBLE_DEVICES=0,…,7`, matmul OK; multi-NIC first-IP binding worked unchanged |


### PR DESCRIPTION
## What

Docs-only PR adding a way to run Jupyter Lab on PCS compute nodes:

- `docs/JUPYTER.md` — user guide. Jupyter runs **as a Slurm batch job**
  (scale-from-zero, `--gres`, `--time` auto-termination), reached from a
  workstation browser via **SSM port forwarding through the login node** — no
  inbound ports, covered by the stock `cluster-user-iam.yaml` policy. Per-job
  token + job-ID-derived port make it multi-user-safe.
- `tests/jupyter-notebook-test.md` — verification procedure (Test 15), with a
  framework-level GPU gate: the notebook kernel must see exactly the `--gres`
  allocation and run a CUDA op.
- `tests/README.md` matrix row + README docs link.

## Placement (#1169)

Per #1169, this starts under `architectures/aws-pcs/` (where it was verified);
the files are written Slurm-generic so they can move to `3.test_cases/` later
without rework.

## Verification (real hardware, fresh `deploy-all` clusters, us-east-2, Slurm 25.11)

| Queue / instance | Result |
|---|---|
| `cpu1` c6i.4xlarge, scale-from-zero | server up as a job, token auth (`403` without / JSON with), `/lab` = `200` through the SSM tunnel |
| `gpu-g6` g6.12xlarge, `--gres=gpu:1` | same gates; kernel sees 1× L4 (`device_count=1`), CUDA matmul OK — from both direct `srun` and a `jupyter execute` notebook run |
| `gpu-p5` p5.48xlarge on a Capacity Block, `--gres=gpu:8` | same gates; kernel sees 8× H100 (`CUDA_VISIBLE_DEVICES=0,…,7`); 32-NIC first-IP binding works unchanged |

Standard E2E gates (monitoring containers, Pyxis container job, DCGM on GPU
nodes) passed on the same clusters. `tests/lint-docs.sh` passes.


**Note:** this PR also updates the `tests/README.md` region-coverage matrix (Ohio row: *GPU verified* → `✅ P5`, date → 2026-07-08) — a byproduct of the p5.48xlarge verification run above, called out here for traceability.