### PR TITLE
Align Kimi example with shared HF-cache pre-staging; harden qwen intra-PD liveness

### DIFF
--- a/examples/inference/sglang/README.md
+++ b/examples/inference/sglang/README.md
@@ -46,7 +46,7 @@ weights are staged in **HF cache layout** under `<nvme>/huggingface` — the dir
 engines loading by repo id, so the staged snapshot is found as a cache hit:
 
 ```bash
-./download-model.sh moonshotai/Kimi-K2.5        ml.p5en.48xlarge
+./download-model.sh moonshotai/Kimi-K2.6        ml.p5en.48xlarge
 ./download-model.sh deepseek-ai/DeepSeek-V4-Pro ml.p6-b300.48xlarge
 # watch: kubectl logs -f -l app=model-downloader   (each node prints "Download complete!")
 # then:  kubectl delete daemonset model-downloader

--- a/examples/inference/sglang/download-model-daemonset.yaml
+++ b/examples/inference/sglang/download-model-daemonset.yaml
@@ -16,7 +16,7 @@
 # DaemonSet lands on the GPU nodes of BOTH a plain EKS managed nodegroup and a
 # HyperPod instance group. To apply by hand instead:
 #   export INSTANCE_TYPE=ml.p5en.48xlarge INSTANCE_TYPE_ALT=p5en.48xlarge \
-#          HF_REPO_ID=moonshotai/Kimi-K2.5
+#          HF_REPO_ID=moonshotai/Kimi-K2.6
 #   envsubst '${INSTANCE_TYPE} ${INSTANCE_TYPE_ALT} ${HF_REPO_ID}' \
 #     < download-model-daemonset.yaml | kubectl apply -f -
 #   # wait until each pod logs "Download complete!", then deploy the engine

--- a/examples/inference/sglang/download-model.sh
+++ b/examples/inference/sglang/download-model.sh
@@ -10,7 +10,7 @@
 #
 # Examples:
 #   ./download-model.sh deepseek-ai/DeepSeek-V4-Pro ml.p6-b300.48xlarge
-#   ./download-model.sh moonshotai/Kimi-K2.5 ml.p5en.48xlarge
+#   ./download-model.sh moonshotai/Kimi-K2.6 ml.p5en.48xlarge
 #
 # The weights are staged in HF cache layout under
 # /opt/dlami/nvme/huggingface — the dir every serving manifest mounts at

--- a/examples/inference/sglang/dsv4flash-b300-intra-3p1d/dsv4flash-pd-deploy.yaml
+++ b/examples/inference/sglang/dsv4flash-b300-intra-3p1d/dsv4flash-pd-deploy.yaml
@@ -288,13 +288,14 @@ spec:
       # The node's local NVMe is mounted at different paths on the two AMIs:
       #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
       #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
-      # Picking the WRONG path is not a hard error: type=DirectoryOrCreate will
-      # silently create an empty dir on the small root disk, and the 500GB+
-      # weights then download there and can fill it up.
+      # Pre-staging with ../download-model.sh (required, see README) creates
+      # this dir. type=Directory makes a wrong path (or a skipped pre-stage)
+      # fail loudly with FailedMount instead of silently creating an empty dir
+      # on the small root disk and downloading the 500GB+ weights there.
       - name: nvme-hf
         hostPath:
           path: /opt/dlami/nvme/huggingface  # For EKS: /mnt/k8s-disks/0/huggingface
-          type: DirectoryOrCreate
+          type: Directory
       - name: nvme-tmp
         hostPath:
           path: /opt/dlami/nvme/tmp          # For EKS: /mnt/k8s-disks/0/tmp

--- a/examples/inference/sglang/glm5.2-b300-tp2-dp4/README.md
+++ b/examples/inference/sglang/glm5.2-b300-tp2-dp4/README.md
@@ -19,7 +19,7 @@ The NVFP4 checkpoint fits in 2 GPUs, so instead of one big engine the node runs 
 
 1. **Provision the B300 node** — on self-managed (eksctl) EKS, create the nodegroup first: see [`../dsv4pro-b300-single-node/NODEGROUP-EKS.md`](../dsv4pro-b300-single-node/NODEGROUP-EKS.md).
    On HyperPod-on-EKS, nodes are already provisioned.
-2. **Pre-stage the weights** (recommended) — the downloader is a DaemonSet, so every matching B300 node gets the weights staged into its NVMe HF cache
+2. **Pre-stage the weights** (required) — the downloader is a DaemonSet, so every matching B300 node gets the weights staged into its NVMe HF cache
    (the same dir the engine pods mount at `/root/.cache/huggingface`); replicas landing on that node then load from local disk instead of downloading:
 
    ```bash

--- a/examples/inference/sglang/glm5.2-b300-tp2-dp4/manifests/glm52-deploy.yaml
+++ b/examples/inference/sglang/glm5.2-b300-tp2-dp4/manifests/glm52-deploy.yaml
@@ -281,19 +281,20 @@ spec:
       # ⚠️  SET THIS PER CLUSTER — the one thing scheduling can't auto-detect.
       # The node's local NVMe is mounted at different paths on the two AMIs.
       # Default below is HyperPod's DLAMI mount; for self-managed EKS swap both
-      # paths to the instance-store RAID0 (commented). Picking the WRONG path is
-      # not a hard error: type=DirectoryOrCreate will silently create an empty
-      # dir on the small root disk and the weights will fill it up.
+      # paths to the instance-store RAID0 (commented).
       #
       #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
       #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
       #
-      # The HF cache is shared by all four replicas on the node — the weights
-      # are downloaded (or pre-staged) once and read by every engine.
+      # The HF cache is shared by all four replicas on the node — pre-staged
+      # once by ../download-model.sh (required, see README), which creates this
+      # dir. type=Directory makes a wrong path (or a skipped pre-stage) fail
+      # loudly with FailedMount instead of silently creating an empty dir on
+      # the small root disk and downloading the weights there.
       - name: nvme-hf
         hostPath:
           path: /opt/dlami/nvme/huggingface  #For EKS: /mnt/k8s-disks/0/huggingface
-          type: DirectoryOrCreate
+          type: Directory
       - name: nvme-tmp
         hostPath:
           path: /opt/dlami/nvme/tmp         #For EKS: /mnt/k8s-disks/0/tmp

--- a/examples/inference/sglang/kimi2.6-h200-1p1d/README.md
+++ b/examples/inference/sglang/kimi2.6-h200-1p1d/README.md
@@ -33,7 +33,7 @@ Workload: TBD (`sglang.bench_serving`).
   one for decode
 - NVIDIA device plugin and EFA device plugin installed
 - Local NVMe under `/opt/dlami/nvme` on each node for the model cache
-  (~555 GB of Kimi-K2.5 weights are pre-staged there)
+  (~555 GB of Kimi-K2.6 weights are pre-staged there)
 
 ### Software
 
@@ -74,9 +74,9 @@ Workload: TBD (`sglang.bench_serving`).
 cd examples/inference/sglang
 ./build-image.sh
 
-# 2. pre-stage the weights to every matching node's NVMe (wait for
+# 2. pre-stage the weights into every matching node's NVMe HF cache (wait for
 #    "Download complete!" in each downloader pod's logs)
-./download-model.sh moonshotai/Kimi-K2.5 ml.p5en.48xlarge
+./download-model.sh moonshotai/Kimi-K2.6 ml.p5en.48xlarge
 
 cd kimi2.6-h200-1p1d
 
@@ -94,7 +94,7 @@ capture for the 1T MoE). The router exposes an OpenAI-compatible endpoint on
 kubectl port-forward svc/sglang-router 30000:30000
 curl http://localhost:30000/v1/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model": "/nvme/moonshotai-Kimi-K2.5", "prompt": "The capital of France is", "max_tokens": 32}'
+  -d '{"model": "moonshotai/Kimi-K2.6", "prompt": "The capital of France is", "max_tokens": 32}'
 ```
 
 ## Files

--- a/examples/inference/sglang/kimi2.6-h200-1p1d/manifests/kimi-pd-deploy.yaml
+++ b/examples/inference/sglang/kimi2.6-h200-1p1d/manifests/kimi-pd-deploy.yaml
@@ -205,14 +205,14 @@ spec:
       #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
       #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
       # This is the node's HF cache (mounted at /root/.cache/huggingface; the
-      # engine loads by repo id) — pre-stage it with ../download-model.sh.
-      # Picking the WRONG path is not a hard error: type=DirectoryOrCreate will
-      # silently create an empty dir on the small root disk, and the 1TB+
-      # weights then download there and can fill it up.
+      # engine loads by repo id) — pre-stage it with ../download-model.sh,
+      # which creates this dir. type=Directory makes a wrong path (or a skipped
+      # pre-stage) fail loudly with FailedMount instead of silently creating an
+      # empty dir on the small root disk and downloading the 1TB+ weights there.
       - name: nvme-hf
         hostPath:
           path: /opt/dlami/nvme/huggingface  # For EKS: /mnt/k8s-disks/0/huggingface
-          type: DirectoryOrCreate
+          type: Directory
       - name: gdrdrv
         hostPath:
           path: /dev/gdrdrv
@@ -367,14 +367,14 @@ spec:
       #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
       #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
       # This is the node's HF cache (mounted at /root/.cache/huggingface; the
-      # engine loads by repo id) — pre-stage it with ../download-model.sh.
-      # Picking the WRONG path is not a hard error: type=DirectoryOrCreate will
-      # silently create an empty dir on the small root disk, and the 1TB+
-      # weights then download there and can fill it up.
+      # engine loads by repo id) — pre-stage it with ../download-model.sh,
+      # which creates this dir. type=Directory makes a wrong path (or a skipped
+      # pre-stage) fail loudly with FailedMount instead of silently creating an
+      # empty dir on the small root disk and downloading the 1TB+ weights there.
       - name: nvme-hf
         hostPath:
           path: /opt/dlami/nvme/huggingface  # For EKS: /mnt/k8s-disks/0/huggingface
-          type: DirectoryOrCreate
+          type: Directory
       - name: gdrdrv
         hostPath:
           path: /dev/gdrdrv

--- a/examples/inference/sglang/kimi2.6-h200-1p1d/manifests/kimi-pd-deploy.yaml
+++ b/examples/inference/sglang/kimi2.6-h200-1p1d/manifests/kimi-pd-deploy.yaml
@@ -143,7 +143,7 @@ spec:
         - -c
         - |
           python3 -m sglang.launch_server \
-            --model-path /nvme/moonshotai-Kimi-K2.5 \
+            --model-path moonshotai/Kimi-K2.6 \
             --host 0.0.0.0 \
             --port 30000 \
             --tp-size 8 \
@@ -166,8 +166,8 @@ spec:
         volumeMounts:
         - name: shm
           mountPath: /dev/shm
-        - name: nvme-storage
-          mountPath: /nvme
+        - name: nvme-hf
+          mountPath: /root/.cache/huggingface
         - name: gdrdrv
           mountPath: /dev/gdrdrv
         resources:
@@ -202,15 +202,17 @@ spec:
           sizeLimit: 64Gi
       # ⚠️  SET THIS PER CLUSTER — the one thing scheduling can't auto-detect.
       # The node's local NVMe is mounted at different paths on the two AMIs:
-      #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme
-      #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0   (setup-local-disks raid0)
-      # type=Directory means the path must already exist (it holds the pre-staged
-      # model at <path>/moonshotai-Kimi-K2.5); a wrong path keeps the pod Pending
-      # with a FailedMount error rather than starting.
-      - name: nvme-storage
+      #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
+      #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
+      # This is the node's HF cache (mounted at /root/.cache/huggingface; the
+      # engine loads by repo id) — pre-stage it with ../download-model.sh.
+      # Picking the WRONG path is not a hard error: type=DirectoryOrCreate will
+      # silently create an empty dir on the small root disk, and the 1TB+
+      # weights then download there and can fill it up.
+      - name: nvme-hf
         hostPath:
-          path: /opt/dlami/nvme  #For EKS: /mnt/k8s-disks/0
-          type: Directory
+          path: /opt/dlami/nvme/huggingface  # For EKS: /mnt/k8s-disks/0/huggingface
+          type: DirectoryOrCreate
       - name: gdrdrv
         hostPath:
           path: /dev/gdrdrv
@@ -304,7 +306,7 @@ spec:
         - -c
         - |
           python3 -m sglang.launch_server \
-            --model-path /nvme/moonshotai-Kimi-K2.5 \
+            --model-path moonshotai/Kimi-K2.6 \
             --host 0.0.0.0 \
             --port 30000 \
             --tp-size 8 \
@@ -326,8 +328,8 @@ spec:
         volumeMounts:
         - name: shm
           mountPath: /dev/shm
-        - name: nvme-storage
-          mountPath: /nvme
+        - name: nvme-hf
+          mountPath: /root/.cache/huggingface
         - name: gdrdrv
           mountPath: /dev/gdrdrv
         resources:
@@ -362,15 +364,17 @@ spec:
           sizeLimit: 64Gi
       # ⚠️  SET THIS PER CLUSTER — the one thing scheduling can't auto-detect.
       # The node's local NVMe is mounted at different paths on the two AMIs:
-      #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme
-      #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0   (setup-local-disks raid0)
-      # type=Directory means the path must already exist (it holds the pre-staged
-      # model at <path>/moonshotai-Kimi-K2.5); a wrong path keeps the pod Pending
-      # with a FailedMount error rather than starting.
-      - name: nvme-storage
+      #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
+      #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
+      # This is the node's HF cache (mounted at /root/.cache/huggingface; the
+      # engine loads by repo id) — pre-stage it with ../download-model.sh.
+      # Picking the WRONG path is not a hard error: type=DirectoryOrCreate will
+      # silently create an empty dir on the small root disk, and the 1TB+
+      # weights then download there and can fill it up.
+      - name: nvme-hf
         hostPath:
-          path: /opt/dlami/nvme  #For EKS: /mnt/k8s-disks/0
-          type: Directory
+          path: /opt/dlami/nvme/huggingface  # For EKS: /mnt/k8s-disks/0/huggingface
+          type: DirectoryOrCreate
       - name: gdrdrv
         hostPath:
           path: /dev/gdrdrv

--- a/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/README.md
+++ b/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/README.md
@@ -14,6 +14,14 @@ engine on `127.0.0.1`.
 
 ## Deploy
 
+**Pre-stage the weights first (required)** — this pod runs **eight** engine processes that all load the same model from the node's HF cache; without pre-staging, the cold start begins with a full download:
+
+```bash
+../download-model.sh Qwen/Qwen3.5-27B ml.p6-b300.48xlarge
+# wait for "Download complete!" in the downloader pod's logs, then:
+kubectl delete daemonset model-downloader
+```
+
 ```bash
 kubectl apply -f qwen-pd-deploy.yaml
 kubectl rollout status deploy/qwen35-intra-pd
@@ -46,9 +54,9 @@ Tear down with `kubectl delete -f qwen-pd-deploy.yaml`.
   pod-per-role PD shape needs RDMA and is shown in
   [`../kimi2.6-h200-1p1d`](../kimi2.6-h200-1p1d).
 - Weights are read from the node's NVMe at `/opt/dlami/nvme/huggingface`
-  (mounted into the container as `~/.cache/huggingface`). Optionally pre-stage
-  them with the shared [`../download-model.sh`](..):
-  `../download-model.sh Qwen/Qwen3.5-27B ml.p6-b300.48xlarge`.
+  (mounted into the container as `~/.cache/huggingface`) — pre-staged by the
+  shared [`../download-model.sh`](../download-model.sh) in the Deploy step
+  above.
 - Stock image `lmsysorg/sglang:v0.5.12.post1-cu130` — no custom build needed;
   intra-node NIXL transfer doesn't cross EFA.
 - Per-engine ports: prefill `30000-30005`, decode `30010-30011`, bootstrap

--- a/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/qwen-pd-deploy.yaml
+++ b/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/qwen-pd-deploy.yaml
@@ -122,17 +122,34 @@ spec:
         resources:
           limits:
             nvidia.com/gpu: 8
-        # Probe the foreground prefill (30005) — it keeps the container alive, so
-        # if it wedges the pod should restart. The 1800s initial delay clears the
-        # long cold start (8 engines load + CUDA-graph capture, gated behind the
-        # decode-ready wait loop) so liveness never fires during warmup.
+        # Liveness ANDs all eight engines: httpGet can only hit one port, and a
+        # dead engine is otherwise never recovered — the router health-checks
+        # around a dead prefill (pod stays Ready at reduced capacity), and both
+        # decodes dead leaves nothing to route to at all. Any engine down for
+        # 5x60s restarts the whole container, i.e. the whole PD group (long
+        # cold start — the price of self-healing back to full capacity). The
+        # 1800s initial delay clears that cold start (8 engines load +
+        # CUDA-graph capture, gated behind the decode-ready wait loop) so
+        # liveness never fires during warmup.
         livenessProbe:
-          httpGet:
-            path: /health
-            port: 30005
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              # -m 3 keeps the worst case (8 ports x 3s) under timeoutSeconds
+              for p in 30000 30001 30002 30003 30004 30005 30010 30011; do
+                curl -sf -m 3 http://127.0.0.1:${p}/health || exit 1
+              done
           initialDelaySeconds: 1800
           periodSeconds: 60
+          timeoutSeconds: 30
           failureThreshold: 5
+        # Readiness deliberately does NOT AND the engines: it watches only the
+        # foreground prefill. If it also required every engine, one dead
+        # background engine would instantly flip the pod NotReady and stop ALL
+        # traffic (replicas: 1) during the up-to-5-min window before liveness
+        # restarts it — worse than serving degraded until the restart lands.
         readinessProbe:
           httpGet:
             path: /health

--- a/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/qwen-pd-deploy.yaml
+++ b/examples/inference/sglang/qwen3.5-27b-b300-intra-pd/qwen-pd-deploy.yaml
@@ -320,10 +320,11 @@ spec:
       # The node's local NVMe is mounted at different paths on the two AMIs:
       #   HyperPod-on-EKS (DLAMI):           /opt/dlami/nvme/...
       #   self-managed EKS (RAID0 instance): /mnt/k8s-disks/0/...   (setup-local-disks raid0)
-      # Picking the WRONG path is not a hard error: type=DirectoryOrCreate will
-      # silently create an empty dir on the small root disk, and weights then
-      # download there and can fill it up.
+      # Pre-staging with ../download-model.sh (required, see README) creates
+      # this dir. type=Directory makes a wrong path (or a skipped pre-stage)
+      # fail loudly with FailedMount instead of silently creating an empty dir
+      # on the small root disk and downloading the weights there.
       - name: nvme-storage
         hostPath:
           path: /opt/dlami/nvme/huggingface  # For EKS: /mnt/k8s-disks/0/huggingface
-          type: DirectoryOrCreate
+          type: Directory


### PR DESCRIPTION
## Purpose

Align Kimi and qwen examples, to be consistent with previous PR

## Changes

- kimi2.6-h200-1p1d: load by repo id (moonshotai/Kimi-K2.6) from the node's HF cache mounted at /root/.cache/huggingface, matching the layout the shared download-model.sh stages — the old /nvme/moonshotai-Kimi-K2.5 path never matched what the downloader produced. hostPath now points at <nvme>/huggingface with DirectoryOrCreate, consistent with the sibling B300 examples; README curl and pre-stage steps updated to match.
- Rename remaining Kimi-K2.5 references to Kimi-K2.6 across the shared downloader docs, finally matching the kimi2.6-* directory name.
- qwen3.5-27b-b300-intra-pd: liveness now ANDs /health of all eight engines via exec probe (same shape as dsv4flash) — a dead background engine previously left the pod Ready at reduced capacity forever; readiness deliberately stays on the foreground engine only. curl -m 3 keeps the worst case (8x3s) under timeoutSeconds. Pre-staging promoted to a required Deploy step (eight engines share the node cache).
- glm5.2: pre-staging is required, not recommended.

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:
- Instance type:
- Number of nodes:

**Test commands:**
```bash

```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
