### PR TITLE
fix(aws-pcs): correct EC2 tag filter for locating the login node in docs

### DIFF
--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -287,13 +287,13 @@ want direct SSH, set `SSHAccessCidr` to a trusted CIDR at deploy time to open SS
 on the login node to that CIDR.
 
 **Console:** [EC2 Console](https://console.aws.amazon.com/ec2/home#Instances:) → filter
-by `aws:pcs:compute-node-group-name = login` → **Connect** → **Session Manager**.
+by `Name = PCS-login` → **Connect** → **Session Manager**.
 
 **CLI** (AWS CloudShell has the required permissions):
 
 ```bash
 INSTANCE_ID=$(aws ec2 describe-instances \
-  --filters "Name=tag:aws:pcs:compute-node-group-name,Values=login" \
+  --filters "Name=tag:Name,Values=PCS-login" \
             "Name=instance-state-name,Values=running" \
   --query 'Reservations[0].Instances[0].InstanceId' --output text)
 aws ssm start-session --target $INSTANCE_ID
@@ -451,7 +451,7 @@ No public access required; works even when the login node has no inbound rules.
 ```bash
 # Login node instance ID
 INSTANCE_ID=$(aws ec2 describe-instances \
-  --filters "Name=tag:aws:pcs:compute-node-group-name,Values=login" \
+  --filters "Name=tag:Name,Values=PCS-login" \
             "Name=instance-state-name,Values=running" \
   --query 'Reservations[0].Instances[0].InstanceId' --output text)
 
@@ -478,7 +478,7 @@ Get the login node's public IP from the EC2 console, or:
 
 ```bash
 aws ec2 describe-instances \
-  --filters "Name=tag:aws:pcs:compute-node-group-name,Values=login" \
+  --filters "Name=tag:Name,Values=PCS-login" \
             "Name=instance-state-name,Values=running" \
   --query 'Reservations[0].Instances[0].PublicIpAddress' --output text
 ```

--- a/architectures/aws-pcs/tests/lint-docs.sh
+++ b/architectures/aws-pcs/tests/lint-docs.sh
@@ -37,6 +37,11 @@ BANNED=(
   $'DeployMonitoring=true\tMonitoringStack|internally|nested\tDeployMonitoring (bool) was replaced by MonitoringStack at the deploy-all layer'
   $'S3 (public )?hosting is not allowed\tNEVERMATCH\tPostInstallScriptUrl now accepts s3:// URLs'
   $'architectures/aws-pcs/iam/\tNEVERMATCH\tthe iam/ directory was removed; use docs/IAM.md + assets/cluster-*-iam.yaml'
+  # PCS emits aws:pcs:compute-node-group-*id* (the internal pcs_xxx handle), NOT
+  # aws:pcs:compute-node-group-name — a copy-paste filter with the -name key
+  # returns nothing (silently), so the docs example fails at first use.
+  # The stable, human-readable filter is Name=tag:Name,Values=PCS-login.
+  $'tag:aws:pcs:compute-node-group-name\tNEVERMATCH\ttag key aws:pcs:compute-node-group-name does not exist — use Name=tag:Name,Values=PCS-login'
 )
 for entry in "${BANNED[@]}"; do
   IFS=$'\t' read -r pat allow msg <<<"$entry"

--- a/architectures/aws-pcs/tests/lint-docs.sh
+++ b/architectures/aws-pcs/tests/lint-docs.sh
@@ -40,8 +40,11 @@ BANNED=(
   # PCS emits aws:pcs:compute-node-group-*id* (the internal pcs_xxx handle), NOT
   # aws:pcs:compute-node-group-name — a copy-paste filter with the -name key
   # returns nothing (silently), so the docs example fails at first use.
-  # The stable, human-readable filter is Name=tag:Name,Values=PCS-login.
-  $'tag:aws:pcs:compute-node-group-name\tNEVERMATCH\ttag key aws:pcs:compute-node-group-name does not exist — use Name=tag:Name,Values=PCS-login'
+  # Match the bare key (no `tag:` prefix) so both forms of the typo — the CLI
+  # `Name=tag:aws:pcs:compute-node-group-name,...` filter AND the plain
+  # console-hint `by aws:pcs:compute-node-group-name = login` — are caught.
+  # The real tag ends in `-id`, so `-name` never appears legitimately.
+  $'aws:pcs:compute-node-group-name\tNEVERMATCH\ttag key aws:pcs:compute-node-group-name does not exist — use Name=tag:Name,Values=PCS-login'
 )
 for entry in "${BANNED[@]}"; do
   IFS=$'\t' read -r pat allow msg <<<"$entry"


### PR DESCRIPTION
## What

README §6 (Accessing the Cluster) and §8.2 (Monitoring — Option A/B) tell
users to locate the login node by filtering on

```
Name=tag:aws:pcs:compute-node-group-name,Values=login
```

but **PCS does not emit that tag**. What PCS emits is
`aws:pcs:compute-node-group-id` (value is the internal `pcs_xxx` handle,
not the human-readable CngName). The documented filter matches nothing,
so `describe-instances ... --query 'Reservations[0].Instances[0].InstanceId'`
returns `None` and every follow-up (`aws ssm start-session --target None`,
port-forward, public-IP lookup) fails at the very first copy-paste step.

Fix: switch the three filters (and the console hint) to
`Name=tag:Name,Values=PCS-login`, which uses the stable `Name` tag PCS puts
on the login CNG. Verified on a live cluster:

```
LOGIN=$(aws ec2 describe-instances \
  --filters "Name=tag:Name,Values=PCS-login" "Name=instance-state-name,Values=running" \
  --query 'Reservations[0].Instances[0].InstanceId' --output text)
# → i-0a35438c5c04e8b14 (correct)
```

Also adds a `tests/lint-docs.sh` banned-pattern entry so this tag-key typo
can't reappear silently. The pattern matches the bare key (no `tag:`
prefix), so **both** forms of the typo — the CLI filter
`Name=tag:aws:pcs:compute-node-group-name,...` and the plain console hint
`by aws:pcs:compute-node-group-name = login` — are caught.

## Testing

- Lint passes on the fix.
- Negative tests, both re-injecting the broken **CLI filter** form and the
  bare **console-hint** form, make the lint FAIL with the affected README
  locations.
- Filter resolves the login instance on a running cluster (us-east-2).
- `JUPYTER.md` already used the correct form, no change needed.