### PR TITLE
fix(aws-pcs): work around AWS CLI cross-region S3 redirect failure on multi-NIC instances

### DIFF
--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -418,7 +418,27 @@ Resources:
               if [ -n "${PostInstallScriptUrl}" ]; then
                 echo "Downloading post-install script from ${PostInstallScriptUrl}..." | tee /var/log/pcs-post-install.log
                 case "${PostInstallScriptUrl}" in
-                  s3://*) aws s3 cp "${PostInstallScriptUrl}" /tmp/pcs-post-install.sh >> /var/log/pcs-post-install.log 2>&1 ;;
+                  s3://*)
+                    # Resolve the bucket's real region via HTTPS HEAD and pass it as
+                    # --region. Without this, `aws s3 cp` uses the instance's IMDS
+                    # region for signing; if that differs from the bucket's region,
+                    # the HeadObject probe gets 301 Moved Permanently and the CLI's
+                    # CRT S3 client fails to recover (aws-c-s3 AWS_ERROR_S3_INVALID_
+                    # RESPONSE_STATUS 14343). Symptom: post-install exit 127 on GPU
+                    # CNGs when the templates bucket sits in a different region
+                    # than the cluster.
+                    S3_URL="${PostInstallScriptUrl}"
+                    S3_BUCKET_FOR_HEAD=$(printf '%s' "$S3_URL" | sed -E 's#^s3://([^/]+).*#\1#')
+                    S3_BUCKET_REGION=$(curl -sI "https://$S3_BUCKET_FOR_HEAD.s3.amazonaws.com/" \
+                      | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+                    if [ -n "$S3_BUCKET_REGION" ]; then
+                      echo "Resolved bucket region: $S3_BUCKET_REGION" | tee -a /var/log/pcs-post-install.log
+                      aws s3 cp "$S3_URL" /tmp/pcs-post-install.sh --region "$S3_BUCKET_REGION" >> /var/log/pcs-post-install.log 2>&1
+                    else
+                      echo "Bucket region lookup failed; falling back to CLI default" | tee -a /var/log/pcs-post-install.log
+                      aws s3 cp "$S3_URL" /tmp/pcs-post-install.sh >> /var/log/pcs-post-install.log 2>&1
+                    fi
+                    ;;
                   *)      curl -fsSL "${PostInstallScriptUrl}" -o /tmp/pcs-post-install.sh ;;
                 esac
                 chmod +x /tmp/pcs-post-install.sh
@@ -472,7 +492,15 @@ Resources:
                 # ldap-add-user.sh helper onto /usr/local/bin from the same bucket.
                 export S3_BUCKET="${S3BucketName}"
                 export S3_KEY_PREFIX="${S3KeyPrefix}"
-                aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh
+                # Resolve the bucket's region (see post-install block above for why —
+                # cross-region cp gets 301 on multi-NIC instances).
+                S3_BUCKET_REGION=$(curl -sI "https://${S3BucketName}.s3.amazonaws.com/" \
+                  | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+                if [ -n "$S3_BUCKET_REGION" ]; then
+                  aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh --region "$S3_BUCKET_REGION"
+                else
+                  aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh
+                fi
                 chmod +x /tmp/setup-directory.sh
                 bash /tmp/setup-directory.sh "${DirectoryRole}" 2>&1 | tee /var/log/directory-setup.log
               fi

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -405,7 +405,27 @@ Resources:
               if [ -n "${PostInstallScriptUrl}" ]; then
                 echo "Downloading post-install script from ${PostInstallScriptUrl}..." | tee /var/log/pcs-post-install.log
                 case "${PostInstallScriptUrl}" in
-                  s3://*) aws s3 cp "${PostInstallScriptUrl}" /tmp/pcs-post-install.sh >> /var/log/pcs-post-install.log 2>&1 ;;
+                  s3://*)
+                    # Resolve the bucket's real region via HTTPS HEAD and pass it as
+                    # --region. Without this, `aws s3 cp` uses the instance's IMDS
+                    # region for signing; if that differs from the bucket's region,
+                    # the HeadObject probe gets 301 Moved Permanently and the CLI's
+                    # CRT S3 client fails to recover (aws-c-s3 AWS_ERROR_S3_INVALID_
+                    # RESPONSE_STATUS 14343). Symptom: post-install exit 127 on GPU
+                    # CNGs when the templates bucket sits in a different region
+                    # than the cluster.
+                    S3_URL="${PostInstallScriptUrl}"
+                    S3_BUCKET_FOR_HEAD=$(printf '%s' "$S3_URL" | sed -E 's#^s3://([^/]+).*#\1#')
+                    S3_BUCKET_REGION=$(curl -sI "https://$S3_BUCKET_FOR_HEAD.s3.amazonaws.com/" \
+                      | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+                    if [ -n "$S3_BUCKET_REGION" ]; then
+                      echo "Resolved bucket region: $S3_BUCKET_REGION" | tee -a /var/log/pcs-post-install.log
+                      aws s3 cp "$S3_URL" /tmp/pcs-post-install.sh --region "$S3_BUCKET_REGION" >> /var/log/pcs-post-install.log 2>&1
+                    else
+                      echo "Bucket region lookup failed; falling back to CLI default" | tee -a /var/log/pcs-post-install.log
+                      aws s3 cp "$S3_URL" /tmp/pcs-post-install.sh >> /var/log/pcs-post-install.log 2>&1
+                    fi
+                    ;;
                   *)      curl -fsSL "${PostInstallScriptUrl}" -o /tmp/pcs-post-install.sh ;;
                 esac
                 chmod +x /tmp/pcs-post-install.sh
@@ -473,7 +493,15 @@ Resources:
                 # ldap-add-user.sh helper onto /usr/local/bin from the same bucket.
                 export S3_BUCKET="${S3BucketName}"
                 export S3_KEY_PREFIX="${S3KeyPrefix}"
-                aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh
+                # Resolve the bucket's region (see post-install block above for why —
+                # cross-region cp gets 301 on multi-NIC instances).
+                S3_BUCKET_REGION=$(curl -sI "https://${S3BucketName}.s3.amazonaws.com/" \
+                  | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+                if [ -n "$S3_BUCKET_REGION" ]; then
+                  aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh --region "$S3_BUCKET_REGION"
+                else
+                  aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh
+                fi
                 chmod +x /tmp/setup-directory.sh
                 bash /tmp/setup-directory.sh "${DirectoryRole}" 2>&1 | tee /var/log/directory-setup.log
               fi

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -408,7 +408,27 @@ Resources:
               if [ -n "${PostInstallScriptUrl}" ]; then
                 echo "Downloading post-install script from ${PostInstallScriptUrl}..." | tee /var/log/pcs-post-install.log
                 case "${PostInstallScriptUrl}" in
-                  s3://*) aws s3 cp "${PostInstallScriptUrl}" /tmp/pcs-post-install.sh >> /var/log/pcs-post-install.log 2>&1 ;;
+                  s3://*)
+                    # Resolve the bucket's real region via HTTPS HEAD and pass it as
+                    # --region. Without this, `aws s3 cp` uses the instance's IMDS
+                    # region for signing; if that differs from the bucket's region,
+                    # the HeadObject probe gets 301 Moved Permanently and the CLI's
+                    # CRT S3 client fails to recover (aws-c-s3 AWS_ERROR_S3_INVALID_
+                    # RESPONSE_STATUS 14343). Symptom: post-install exit 127 on GPU
+                    # CNGs when the templates bucket sits in a different region
+                    # than the cluster.
+                    S3_URL="${PostInstallScriptUrl}"
+                    S3_BUCKET_FOR_HEAD=$(printf '%s' "$S3_URL" | sed -E 's#^s3://([^/]+).*#\1#')
+                    S3_BUCKET_REGION=$(curl -sI "https://$S3_BUCKET_FOR_HEAD.s3.amazonaws.com/" \
+                      | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+                    if [ -n "$S3_BUCKET_REGION" ]; then
+                      echo "Resolved bucket region: $S3_BUCKET_REGION" | tee -a /var/log/pcs-post-install.log
+                      aws s3 cp "$S3_URL" /tmp/pcs-post-install.sh --region "$S3_BUCKET_REGION" >> /var/log/pcs-post-install.log 2>&1
+                    else
+                      echo "Bucket region lookup failed; falling back to CLI default" | tee -a /var/log/pcs-post-install.log
+                      aws s3 cp "$S3_URL" /tmp/pcs-post-install.sh >> /var/log/pcs-post-install.log 2>&1
+                    fi
+                    ;;
                   *)      curl -fsSL "${PostInstallScriptUrl}" -o /tmp/pcs-post-install.sh ;;
                 esac
                 chmod +x /tmp/pcs-post-install.sh
@@ -476,7 +496,15 @@ Resources:
                 # ldap-add-user.sh helper onto /usr/local/bin from the same bucket.
                 export S3_BUCKET="${S3BucketName}"
                 export S3_KEY_PREFIX="${S3KeyPrefix}"
-                aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh
+                # Resolve the bucket's region (see post-install block above for why —
+                # cross-region cp gets 301 on multi-NIC instances).
+                S3_BUCKET_REGION=$(curl -sI "https://${S3BucketName}.s3.amazonaws.com/" \
+                  | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+                if [ -n "$S3_BUCKET_REGION" ]; then
+                  aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh --region "$S3_BUCKET_REGION"
+                else
+                  aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh
+                fi
                 chmod +x /tmp/setup-directory.sh
                 bash /tmp/setup-directory.sh "${DirectoryRole}" 2>&1 | tee /var/log/directory-setup.log
               fi

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -481,7 +481,27 @@ Resources:
               if [ -n "${PostInstallScriptUrl}" ]; then
                 echo "Downloading post-install script from ${PostInstallScriptUrl}..." | tee /var/log/pcs-post-install.log
                 case "${PostInstallScriptUrl}" in
-                  s3://*) aws s3 cp "${PostInstallScriptUrl}" /tmp/pcs-post-install.sh >> /var/log/pcs-post-install.log 2>&1 ;;
+                  s3://*)
+                    # Resolve the bucket's real region via HTTPS HEAD and pass it as
+                    # --region. Without this, `aws s3 cp` uses the instance's IMDS
+                    # region for signing; if that differs from the bucket's region,
+                    # the HeadObject probe gets 301 Moved Permanently and the CLI's
+                    # CRT S3 client fails to recover (aws-c-s3 AWS_ERROR_S3_INVALID_
+                    # RESPONSE_STATUS 14343). Symptom: post-install exit 127 on GPU
+                    # CNGs when the templates bucket sits in a different region
+                    # than the cluster.
+                    S3_URL="${PostInstallScriptUrl}"
+                    S3_BUCKET_FOR_HEAD=$(printf '%s' "$S3_URL" | sed -E 's#^s3://([^/]+).*#\1#')
+                    S3_BUCKET_REGION=$(curl -sI "https://$S3_BUCKET_FOR_HEAD.s3.amazonaws.com/" \
+                      | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+                    if [ -n "$S3_BUCKET_REGION" ]; then
+                      echo "Resolved bucket region: $S3_BUCKET_REGION" | tee -a /var/log/pcs-post-install.log
+                      aws s3 cp "$S3_URL" /tmp/pcs-post-install.sh --region "$S3_BUCKET_REGION" >> /var/log/pcs-post-install.log 2>&1
+                    else
+                      echo "Bucket region lookup failed; falling back to CLI default" | tee -a /var/log/pcs-post-install.log
+                      aws s3 cp "$S3_URL" /tmp/pcs-post-install.sh >> /var/log/pcs-post-install.log 2>&1
+                    fi
+                    ;;
                   *)      curl -fsSL "${PostInstallScriptUrl}" -o /tmp/pcs-post-install.sh ;;
                 esac
                 chmod +x /tmp/pcs-post-install.sh
@@ -549,7 +569,15 @@ Resources:
                 # ldap-add-user.sh helper onto /usr/local/bin from the same bucket.
                 export S3_BUCKET="${S3BucketName}"
                 export S3_KEY_PREFIX="${S3KeyPrefix}"
-                aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh
+                # Resolve the bucket's region (see post-install block above for why —
+                # cross-region cp gets 301 on multi-NIC instances).
+                S3_BUCKET_REGION=$(curl -sI "https://${S3BucketName}.s3.amazonaws.com/" \
+                  | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+                if [ -n "$S3_BUCKET_REGION" ]; then
+                  aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh --region "$S3_BUCKET_REGION"
+                else
+                  aws s3 cp s3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh /tmp/setup-directory.sh
+                fi
                 chmod +x /tmp/setup-directory.sh
                 # Capture the script's REAL exit code so a failed LDAP client
                 # setup is VISIBLE in the log instead of being masked. The old

--- a/architectures/aws-pcs/assets/scripts/setup-directory.sh
+++ b/architectures/aws-pcs/assets/scripts/setup-directory.sh
@@ -210,8 +210,17 @@ EOF
     # location this script came from (S3_BUCKET/S3_KEY_PREFIX passed by UserData);
     # falls back to a no-op with a hint if those are unset.
     if [ -n "${S3_BUCKET:-}" ]; then
+        # Resolve the bucket's region via HTTPS HEAD and pass it to --region.
+        # Without this, cross-region `aws s3 cp` gets a 301 on the HeadObject
+        # probe that CRT S3 client cannot recover from — most visibly on
+        # multi-NIC instances (P5/P6). Silent fallback keeps single-region
+        # deployments working exactly as before.
+        BUCKET_REGION=$(curl -sI "https://${S3_BUCKET}.s3.amazonaws.com/" 2>/dev/null \
+          | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print tolower($2)}')
+        REGION_ARG=""
+        [ -n "${BUCKET_REGION}" ] && REGION_ARG="--region ${BUCKET_REGION}"
         if aws s3 cp "s3://${S3_BUCKET}/${S3_KEY_PREFIX:-templates/aws-pcs/}scripts/ldap-add-user.sh" \
-             /usr/local/bin/ldap-add-user.sh 2>/dev/null; then
+             /usr/local/bin/ldap-add-user.sh ${REGION_ARG} 2>/dev/null; then
             chmod 755 /usr/local/bin/ldap-add-user.sh
             echo "[directory-server] Installed helper: /usr/local/bin/ldap-add-user.sh"
         else


### PR DESCRIPTION
## What

The UserData snippets that fetch `install-enroot-pyxis.sh` (post-install)
and `setup-directory.sh` (multi-user) call `aws s3 cp` without an explicit
`--region`, expecting the CLI's normal behaviour: when the bucket is in
a different region than the caller, the S3 HeadObject probe returns 301
with an `x-amz-bucket-region` hint, the CLI follows it, and the copy
succeeds. This works as intended on login nodes and on ordinary compute.

On **multi-NIC EFA instances (P5 / P5e / P5en / P6-B200 / P6-B300 —
8–32 default routes)** the CLI does not recover from that 301: the CRT
S3 client aborts with `AWS_ERROR_S3_INVALID_RESPONSE_STATUS` (error 14343)
before the redirect is applied.

```
[S3MetaRequest] error 14343 (aws-c-s3 AWS_ERROR_S3_INVALID_RESPONSE_STATUS)
[S3MetaRequest] Meta request cannot recover from error 14343
download failed: … An error occurred (301) when calling the HeadObject operation
bash: /tmp/pcs-post-install.sh: No such file or directory
Post-install script completed (exit 127)
```

The compute node ends up with no Pyxis, and every `srun --container-image=…`
fails — the failure is compute-only and easy to miss until the first
container job. The common trigger is the stock public bucket
(`awsome-distributed-ai`, us-east-1) consumed from a non-us-east-1
cluster; anyone deploying P5/P6 from Tokyo hits it immediately.

The upstream CLI bug is being tracked separately; this PR is a defensive
workaround at the deploy layer so PCS clusters don't have to wait for
that fix.

## Fix

Resolve the bucket's real region via an anonymous HTTPS HEAD
(`x-amz-bucket-region` response header — no IAM/credentials needed) and
pass it explicitly as `--region` to `aws s3 cp`. If the HEAD probe
returns nothing (private / non-standard endpoint), fall back to the
original `aws s3 cp` invocation so **same-region deployments behave
exactly as before** and no working setup regresses.

Applied in lock-step to the four hand-maintained CNG UserData copies
(`add-cng.yaml` + `add-cng-p5.yaml` + `add-cng-p6-b200.yaml` +
`add-cng-p6-b300.yaml`), on both the post-install fetch and the
setup-directory fetch, and to `scripts/setup-directory.sh`'s
`ldap-add-user.sh` fetch on the login node.

## Testing

- **Symptom reproduced** on a fresh Tokyo cluster with
  `DirectoryService=OpenLDAP-LoginNode` and `p5.48xlarge` on a Capacity
  Block: the P5 compute produced the 301 / exit 127 above; login was fine.
- **Fix verified live** on a new Tokyo cluster with the same P5 CB using
  the fixed templates. Both login and P5 compute now log:

  ```
  Downloading post-install script from s3://…/install-enroot-pyxis.sh...
  Resolved bucket region: us-east-1
  Completed 12.7 KiB/12.7 KiB … download: … to tmp/pcs-post-install.sh
  Executing post-install script...
  ```

  Post-install runs to `exit 0`; `spank_pyxis.so` installed; monitoring
  stack up (6 containers) on login.
- The region-resolve block runs POSIX-clean under `dash` (cloud-init
  `runcmd` shell): real public bucket → `us-east-1` resolved; nonexistent
  bucket → empty, falls through to the original call.
- `aws cloudformation validate-template` passes on all four CNG templates;
  `tests/lint-docs.sh` passes.