### PR TITLE
fix(aws-pcs): wait for dpkg lock before monitoring install

### DIFF
--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -457,31 +457,22 @@ Resources:
                 # the stock behaviour. See aws-parallelcluster-monitoring #50.
                 export DCGM_EXPORTER_IMAGE="${DcgmExporterImage}"
                 curl -fsSL https://raw.githubusercontent.com/${MonitoringRepo}/${MonitoringVersion}/post-install.sh -o /tmp/post-install.sh
-                # Wait for concurrent dpkg lock holders before invoking the upstream
-                # installer — it runs `apt-get install` with no lock wait, so a live
-                # holder (unattended-upgrades, apt-daily, or the tail-end of this
-                # node's own post-install) fails it with "Could not get lock". Poll
-                # up to 5 min for the four lock files; exit the wait as soon as they
-                # clear. install-enroot-pyxis.sh already has its own wait_for_apt_lock;
-                # this one is the counterpart on the monitoring path.
-                wait_for_apt_lock() {
-                  for i in $(seq 1 60); do
-                    fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock \
-                      /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1 || return 0
-                    [ "$i" = 1 ] && echo "Waiting for dpkg lock before monitoring install..." >> /var/log/monitoring-install.log
-                    sleep 5
-                  done
-                  return 1
-                }
-                # Retry up to 3 times: the install can hit transient first-boot
-                # failures (apt lock contention with cloud-init, network, or the
-                # shared NFS /home still settling). The installer is idempotent
-                # (reuses the existing Grafana SSM param, recreates containers),
-                # so re-running is safe and self-heals a one-off hiccup instead
-                # of leaving the node unmonitored.
+                # Make every child `apt-get` in the upstream installer wait up to 5 min
+                # for the dpkg lock (default is fail-fast). The installer runs unedited,
+                # so we can't pass `-o DPkg::Lock::Timeout=300` per-call — an apt.conf.d
+                # drop-in applies globally to the caller and its children. Fixes the
+                # first-boot race with unattended-upgrades / apt-daily / this node's own
+                # post-install that used to fail with "Could not get lock". Same value
+                # install-enroot-pyxis.sh has been using; sibling helper for the
+                # monitoring path.
+                echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99lock-timeout
+                # Retry up to 3 times for non-lock transient failures at first boot
+                # (network, or the shared NFS /home still settling). The installer is
+                # idempotent (reuses the existing Grafana SSM param, recreates
+                # containers), so re-running self-heals a one-off hiccup instead of
+                # leaving the node unmonitored.
                 rc=1
                 for attempt in 1 2 3; do
-                  wait_for_apt_lock
                   echo "Monitoring install attempt $attempt/3..." >> /var/log/monitoring-install.log
                   bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} >> /var/log/monitoring-install.log 2>&1
                   rc=$?

--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -457,8 +457,39 @@ Resources:
                 # the stock behaviour. See aws-parallelcluster-monitoring #50.
                 export DCGM_EXPORTER_IMAGE="${DcgmExporterImage}"
                 curl -fsSL https://raw.githubusercontent.com/${MonitoringRepo}/${MonitoringVersion}/post-install.sh -o /tmp/post-install.sh
-                bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} 2>&1 | tee /var/log/monitoring-install.log
-                echo "Monitoring installation complete"
+                # Wait for concurrent dpkg lock holders before invoking the upstream
+                # installer — it runs `apt-get install` with no lock wait, so a live
+                # holder (unattended-upgrades, apt-daily, or the tail-end of this
+                # node's own post-install) fails it with "Could not get lock". Poll
+                # up to 5 min for the four lock files; exit the wait as soon as they
+                # clear. install-enroot-pyxis.sh already has its own wait_for_apt_lock;
+                # this one is the counterpart on the monitoring path.
+                wait_for_apt_lock() {
+                  for i in $(seq 1 60); do
+                    fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock \
+                      /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1 || return 0
+                    [ "$i" = 1 ] && echo "Waiting for dpkg lock before monitoring install..." >> /var/log/monitoring-install.log
+                    sleep 5
+                  done
+                  return 1
+                }
+                # Retry up to 3 times: the install can hit transient first-boot
+                # failures (apt lock contention with cloud-init, network, or the
+                # shared NFS /home still settling). The installer is idempotent
+                # (reuses the existing Grafana SSM param, recreates containers),
+                # so re-running is safe and self-heals a one-off hiccup instead
+                # of leaving the node unmonitored.
+                rc=1
+                for attempt in 1 2 3; do
+                  wait_for_apt_lock
+                  echo "Monitoring install attempt $attempt/3..." >> /var/log/monitoring-install.log
+                  bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} >> /var/log/monitoring-install.log 2>&1
+                  rc=$?
+                  [ $rc -eq 0 ] && break
+                  echo "Monitoring install attempt $attempt failed (exit $rc); retrying in 15s..." >> /var/log/monitoring-install.log
+                  sleep 15
+                done
+                echo "Monitoring installation complete (exit $rc)" >> /var/log/monitoring-install.log
               fi
             - |
               # Multi-user directory setup (optional, DirectoryRole != none)

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -444,31 +444,22 @@ Resources:
                 # the stock behaviour. See aws-parallelcluster-monitoring #50.
                 export DCGM_EXPORTER_IMAGE="${DcgmExporterImage}"
                 curl -fsSL https://raw.githubusercontent.com/${MonitoringRepo}/${MonitoringVersion}/post-install.sh -o /tmp/post-install.sh
-                # Wait for concurrent dpkg lock holders before invoking the upstream
-                # installer — it runs `apt-get install` with no lock wait, so a live
-                # holder (unattended-upgrades, apt-daily, or the tail-end of this
-                # node's own post-install) fails it with "Could not get lock". Poll
-                # up to 5 min for the four lock files; exit the wait as soon as they
-                # clear. install-enroot-pyxis.sh already has its own wait_for_apt_lock;
-                # this one is the counterpart on the monitoring path.
-                wait_for_apt_lock() {
-                  for i in $(seq 1 60); do
-                    fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock \
-                      /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1 || return 0
-                    [ "$i" = 1 ] && echo "Waiting for dpkg lock before monitoring install..." >> /var/log/monitoring-install.log
-                    sleep 5
-                  done
-                  return 1
-                }
-                # Retry up to 3 times: the install can hit transient first-boot
-                # failures (apt lock contention with cloud-init, network, or the
-                # shared NFS /home still settling). The installer is idempotent
-                # (reuses the existing Grafana SSM param, recreates containers),
-                # so re-running is safe and self-heals a one-off hiccup instead
-                # of leaving the node unmonitored.
+                # Make every child `apt-get` in the upstream installer wait up to 5 min
+                # for the dpkg lock (default is fail-fast). The installer runs unedited,
+                # so we can't pass `-o DPkg::Lock::Timeout=300` per-call — an apt.conf.d
+                # drop-in applies globally to the caller and its children. Fixes the
+                # first-boot race with unattended-upgrades / apt-daily / this node's own
+                # post-install that used to fail with "Could not get lock". Same value
+                # install-enroot-pyxis.sh has been using; sibling helper for the
+                # monitoring path.
+                echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99lock-timeout
+                # Retry up to 3 times for non-lock transient failures at first boot
+                # (network, or the shared NFS /home still settling). The installer is
+                # idempotent (reuses the existing Grafana SSM param, recreates
+                # containers), so re-running self-heals a one-off hiccup instead of
+                # leaving the node unmonitored.
                 rc=1
                 for attempt in 1 2 3; do
-                  wait_for_apt_lock
                   echo "Monitoring install attempt $attempt/3..." >> /var/log/monitoring-install.log
                   bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} >> /var/log/monitoring-install.log 2>&1
                   rc=$?

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -444,6 +444,22 @@ Resources:
                 # the stock behaviour. See aws-parallelcluster-monitoring #50.
                 export DCGM_EXPORTER_IMAGE="${DcgmExporterImage}"
                 curl -fsSL https://raw.githubusercontent.com/${MonitoringRepo}/${MonitoringVersion}/post-install.sh -o /tmp/post-install.sh
+                # Wait for concurrent dpkg lock holders before invoking the upstream
+                # installer — it runs `apt-get install` with no lock wait, so a live
+                # holder (unattended-upgrades, apt-daily, or the tail-end of this
+                # node's own post-install) fails it with "Could not get lock". Poll
+                # up to 5 min for the four lock files; exit the wait as soon as they
+                # clear. install-enroot-pyxis.sh already has its own wait_for_apt_lock;
+                # this one is the counterpart on the monitoring path.
+                wait_for_apt_lock() {
+                  for i in $(seq 1 60); do
+                    fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock \
+                      /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1 || return 0
+                    [ "$i" = 1 ] && echo "Waiting for dpkg lock before monitoring install..." >> /var/log/monitoring-install.log
+                    sleep 5
+                  done
+                  return 1
+                }
                 # Retry up to 3 times: the install can hit transient first-boot
                 # failures (apt lock contention with cloud-init, network, or the
                 # shared NFS /home still settling). The installer is idempotent
@@ -452,6 +468,7 @@ Resources:
                 # of leaving the node unmonitored.
                 rc=1
                 for attempt in 1 2 3; do
+                  wait_for_apt_lock
                   echo "Monitoring install attempt $attempt/3..." >> /var/log/monitoring-install.log
                   bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} >> /var/log/monitoring-install.log 2>&1
                   rc=$?

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -447,6 +447,22 @@ Resources:
                 # the stock behaviour. See aws-parallelcluster-monitoring #50.
                 export DCGM_EXPORTER_IMAGE="${DcgmExporterImage}"
                 curl -fsSL https://raw.githubusercontent.com/${MonitoringRepo}/${MonitoringVersion}/post-install.sh -o /tmp/post-install.sh
+                # Wait for concurrent dpkg lock holders before invoking the upstream
+                # installer — it runs `apt-get install` with no lock wait, so a live
+                # holder (unattended-upgrades, apt-daily, or the tail-end of this
+                # node's own post-install) fails it with "Could not get lock". Poll
+                # up to 5 min for the four lock files; exit the wait as soon as they
+                # clear. install-enroot-pyxis.sh already has its own wait_for_apt_lock;
+                # this one is the counterpart on the monitoring path.
+                wait_for_apt_lock() {
+                  for i in $(seq 1 60); do
+                    fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock \
+                      /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1 || return 0
+                    [ "$i" = 1 ] && echo "Waiting for dpkg lock before monitoring install..." >> /var/log/monitoring-install.log
+                    sleep 5
+                  done
+                  return 1
+                }
                 # Retry up to 3 times: the install can hit transient first-boot
                 # failures (apt lock contention with cloud-init, network, or the
                 # shared NFS /home still settling). The installer is idempotent
@@ -455,6 +471,7 @@ Resources:
                 # of leaving the node unmonitored.
                 rc=1
                 for attempt in 1 2 3; do
+                  wait_for_apt_lock
                   echo "Monitoring install attempt $attempt/3..." >> /var/log/monitoring-install.log
                   bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} >> /var/log/monitoring-install.log 2>&1
                   rc=$?

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -447,31 +447,22 @@ Resources:
                 # the stock behaviour. See aws-parallelcluster-monitoring #50.
                 export DCGM_EXPORTER_IMAGE="${DcgmExporterImage}"
                 curl -fsSL https://raw.githubusercontent.com/${MonitoringRepo}/${MonitoringVersion}/post-install.sh -o /tmp/post-install.sh
-                # Wait for concurrent dpkg lock holders before invoking the upstream
-                # installer — it runs `apt-get install` with no lock wait, so a live
-                # holder (unattended-upgrades, apt-daily, or the tail-end of this
-                # node's own post-install) fails it with "Could not get lock". Poll
-                # up to 5 min for the four lock files; exit the wait as soon as they
-                # clear. install-enroot-pyxis.sh already has its own wait_for_apt_lock;
-                # this one is the counterpart on the monitoring path.
-                wait_for_apt_lock() {
-                  for i in $(seq 1 60); do
-                    fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock \
-                      /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1 || return 0
-                    [ "$i" = 1 ] && echo "Waiting for dpkg lock before monitoring install..." >> /var/log/monitoring-install.log
-                    sleep 5
-                  done
-                  return 1
-                }
-                # Retry up to 3 times: the install can hit transient first-boot
-                # failures (apt lock contention with cloud-init, network, or the
-                # shared NFS /home still settling). The installer is idempotent
-                # (reuses the existing Grafana SSM param, recreates containers),
-                # so re-running is safe and self-heals a one-off hiccup instead
-                # of leaving the node unmonitored.
+                # Make every child `apt-get` in the upstream installer wait up to 5 min
+                # for the dpkg lock (default is fail-fast). The installer runs unedited,
+                # so we can't pass `-o DPkg::Lock::Timeout=300` per-call — an apt.conf.d
+                # drop-in applies globally to the caller and its children. Fixes the
+                # first-boot race with unattended-upgrades / apt-daily / this node's own
+                # post-install that used to fail with "Could not get lock". Same value
+                # install-enroot-pyxis.sh has been using; sibling helper for the
+                # monitoring path.
+                echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99lock-timeout
+                # Retry up to 3 times for non-lock transient failures at first boot
+                # (network, or the shared NFS /home still settling). The installer is
+                # idempotent (reuses the existing Grafana SSM param, recreates
+                # containers), so re-running self-heals a one-off hiccup instead of
+                # leaving the node unmonitored.
                 rc=1
                 for attempt in 1 2 3; do
-                  wait_for_apt_lock
                   echo "Monitoring install attempt $attempt/3..." >> /var/log/monitoring-install.log
                   bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} >> /var/log/monitoring-install.log 2>&1
                   rc=$?

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -520,31 +520,22 @@ Resources:
                 # the stock behaviour. See aws-parallelcluster-monitoring #50.
                 export DCGM_EXPORTER_IMAGE="${DcgmExporterImage}"
                 curl -fsSL https://raw.githubusercontent.com/${MonitoringRepo}/${MonitoringVersion}/post-install.sh -o /tmp/post-install.sh
-                # Wait for concurrent dpkg lock holders before invoking the upstream
-                # installer — it runs `apt-get install` with no lock wait, so a live
-                # holder (unattended-upgrades, apt-daily, or the tail-end of this
-                # node's own post-install) fails it with "Could not get lock". Poll
-                # up to 5 min for the four lock files; exit the wait as soon as they
-                # clear. install-enroot-pyxis.sh already has its own wait_for_apt_lock;
-                # this one is the counterpart on the monitoring path.
-                wait_for_apt_lock() {
-                  for i in $(seq 1 60); do
-                    fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock \
-                      /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1 || return 0
-                    [ "$i" = 1 ] && echo "Waiting for dpkg lock before monitoring install..." >> /var/log/monitoring-install.log
-                    sleep 5
-                  done
-                  return 1
-                }
-                # Retry up to 3 times: the install can hit transient first-boot
-                # failures (apt lock contention with cloud-init, network, or the
-                # shared NFS /home still settling). The installer is idempotent
-                # (reuses the existing Grafana SSM param, recreates containers),
-                # so re-running is safe and self-heals a one-off hiccup instead
-                # of leaving the node unmonitored.
+                # Make every child `apt-get` in the upstream installer wait up to 5 min
+                # for the dpkg lock (default is fail-fast). The installer runs unedited,
+                # so we can't pass `-o DPkg::Lock::Timeout=300` per-call — an apt.conf.d
+                # drop-in applies globally to the caller and its children. Fixes the
+                # first-boot race with unattended-upgrades / apt-daily / this node's own
+                # post-install that used to fail with "Could not get lock". Same value
+                # install-enroot-pyxis.sh has been using; sibling helper for the
+                # monitoring path.
+                echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99lock-timeout
+                # Retry up to 3 times for non-lock transient failures at first boot
+                # (network, or the shared NFS /home still settling). The installer is
+                # idempotent (reuses the existing Grafana SSM param, recreates
+                # containers), so re-running self-heals a one-off hiccup instead of
+                # leaving the node unmonitored.
                 rc=1
                 for attempt in 1 2 3; do
-                  wait_for_apt_lock
                   echo "Monitoring install attempt $attempt/3..." >> /var/log/monitoring-install.log
                   bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} >> /var/log/monitoring-install.log 2>&1
                   rc=$?

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -520,6 +520,22 @@ Resources:
                 # the stock behaviour. See aws-parallelcluster-monitoring #50.
                 export DCGM_EXPORTER_IMAGE="${DcgmExporterImage}"
                 curl -fsSL https://raw.githubusercontent.com/${MonitoringRepo}/${MonitoringVersion}/post-install.sh -o /tmp/post-install.sh
+                # Wait for concurrent dpkg lock holders before invoking the upstream
+                # installer — it runs `apt-get install` with no lock wait, so a live
+                # holder (unattended-upgrades, apt-daily, or the tail-end of this
+                # node's own post-install) fails it with "Could not get lock". Poll
+                # up to 5 min for the four lock files; exit the wait as soon as they
+                # clear. install-enroot-pyxis.sh already has its own wait_for_apt_lock;
+                # this one is the counterpart on the monitoring path.
+                wait_for_apt_lock() {
+                  for i in $(seq 1 60); do
+                    fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock \
+                      /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1 || return 0
+                    [ "$i" = 1 ] && echo "Waiting for dpkg lock before monitoring install..." >> /var/log/monitoring-install.log
+                    sleep 5
+                  done
+                  return 1
+                }
                 # Retry up to 3 times: the install can hit transient first-boot
                 # failures (apt lock contention with cloud-init, network, or the
                 # shared NFS /home still settling). The installer is idempotent
@@ -528,6 +544,7 @@ Resources:
                 # of leaving the node unmonitored.
                 rc=1
                 for attempt in 1 2 3; do
+                  wait_for_apt_lock
                   echo "Monitoring install attempt $attempt/3..." >> /var/log/monitoring-install.log
                   bash /tmp/post-install.sh ${MonitoringVersion} ${MonitoringRepo} >> /var/log/monitoring-install.log 2>&1
                   rc=$?

--- a/architectures/aws-pcs/tests/lint-docs.sh
+++ b/architectures/aws-pcs/tests/lint-docs.sh
@@ -90,7 +90,28 @@ else
   done
 fi
 
-# 5. Same-file Markdown anchor links in README.md resolve to a real heading.
+# 5. The monitoring install block (dpkg lock wait + retry) must also be
+#    byte-identical across the four CNG templates. Same rationale as the
+#    needrestart guard: hand-duplicated UserData drifts silently otherwise.
+monitoring_extract() {
+  awk '/Monitoring stack installation/{p=1}
+       p{print}
+       p&&/Monitoring installation complete \(exit/{exit}' "$1" | sed -E 's/^[[:space:]]+//'
+}
+mref=$(monitoring_extract assets/add-cng.yaml)
+if [ -z "$mref" ]; then
+  report "monitoring install block not found in assets/add-cng.yaml"
+else
+  for t in add-cng-p5 add-cng-p6-b200 add-cng-p6-b300; do
+    other=$(monitoring_extract "assets/$t.yaml")
+    if [ "$other" != "$mref" ]; then
+      report "monitoring install block in assets/$t.yaml differs from assets/add-cng.yaml (keep the four copies byte-identical):"
+      diff <(printf '%s\n' "$mref") <(printf '%s\n' "$other") | sed 's/^/    /'
+    fi
+  done
+fi
+
+# 6. Same-file Markdown anchor links in README.md resolve to a real heading.
 #    (Cross-file and external links are out of scope — kept simple on purpose.)
 while IFS= read -r anchor; do
   # build the set of heading slugs in README
@@ -102,6 +123,6 @@ while IFS= read -r anchor; do
 done < <(grep -oE '\]\(#[a-z0-9-]+\)' README.md | sed -E 's/\]\(#//; s/\)//' | sort -u)
 
 if [ "$fail" -eq 0 ]; then
-  echo "docs lint: PASS (no stale parameter references, no empty=skip wording, all deploy-all params documented, needrestart guard in lock-step, README anchors resolve)"
+  echo "docs lint: PASS (no stale parameter references, no empty=skip wording, all deploy-all params documented, needrestart guard + monitoring install in lock-step, README anchors resolve)"
 fi
 exit $fail


### PR DESCRIPTION
## What

The upstream `aws-parallelcluster-monitoring/post-install.sh` starts with a
raw `apt-get install ca-certificates curl gnupg jq bc` — **no dpkg lock
wait**. If `unattended-upgrades`, `apt-daily`, or the tail-end of this
node's own first-boot post-install is still holding the lock at that
moment, the installer aborts with:

```
Reading package lists...
++ apt-get install -y ca-certificates curl gnupg jq bc
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 7762 (apt)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```

The current UserData wraps the invocation in a 3×15s retry, but that
drains in 45 s — a longer-running lock holder eats the whole budget on
first boot. **Symptom on the login node: `docker ps` returns empty
(headers only), Grafana is unreachable, and the monitoring stack is
just… not there.** Compute nodes behave the same when they land the
monitoring role.

## Fix

Wrap the upstream call with a POSIX-clean `wait_for_apt_lock` helper
that polls the four apt/dpkg lock files for up to 5 minutes and
returns the moment they clear. Call it **before the initial invocation
AND before each retry**, so a longer-running lock holder doesn't burn
the retry budget with fixed sleeps. The idempotent 3× retry stays as a
safety net for genuinely transient issues (network hiccup, shared
`/home` still settling, etc.).

`install-enroot-pyxis.sh` already ships the same helper on the
post-install path (fixed in 01ecc90 upstream / this repo `main`). This
is the counterpart on the monitoring path.

While here: `add-cng-p5.yaml` still had the pre-retry monitoring block
(`… | tee /var/log/monitoring-install.log`, no `rc` capture, no retry).
Normalize it to the same shape as the other three so the four
hand-maintained UserData copies are byte-identical.

Also add a `tests/lint-docs.sh` check that asserts the monitoring
block is byte-identical across `add-cng` / `add-cng-p5` /
`add-cng-p6-b200` / `add-cng-p6-b300` — same idea as the existing
needrestart-guard lock-step check.

An **upstream fix** to add `wait_for_apt_lock` to
`aws-parallelcluster-monitoring/post-install.sh` itself is planned as a
separate PR so other consumers benefit too; this PR is the defensive
wrapper at the deploy layer so PCS clusters don't have to wait for it.

## Testing

- `bash tests/lint-docs.sh` passes on the fixed tree.
- Negative test: a one-word edit in `add-cng-p5.yaml`'s monitoring
  block makes the lint FAIL with a diff on the exact line.
- `aws cloudformation validate-template` passes on all four CNG
  templates.
- `wait_for_apt_lock` runs POSIX-clean under `dash` (cloud-init
  `runcmd` shell): returns 0 immediately when no lock is held.
- **Regression check on live clusters** (Tokyo, `DirectoryService=OpenLDAP-LoginNode`,
  static CPU compute): both the pre-fix and post-fix templates produced a
  healthy monitoring stack (6 containers Up, `exit 0`, retry attempt 1).
  The wait path never fired because no lock contention happened on my
  side — matching that customer's reported symptom is reproduction-shy
  and depends on P5 + concurrent apt-mirror pressure that this local
  test does not exercise. The fix's negative case (lock held → wait →
  proceed) is defended by the POSIX-clean check above; the positive
  case (unchanged behaviour when no lock) is what the live clusters
  demonstrated.