### PR TITLE
Fix unquoted OS_VERSION in FSDP create_venv.sh

### DIFF
--- a/3.test_cases/pytorch/FSDP/slurm/create_venv.sh
+++ b/3.test_cases/pytorch/FSDP/slurm/create_venv.sh
@@ -8,7 +8,7 @@ PYTHON_V=python3
 OS_VERSION=$(cat /etc/os-release | grep VERSION_ID | awk -F '=' '{print $2}')
 OS_VERSION=${OS_VERSION//\"/}
 
-if [ $OS_VERSION = "20.04" ]; then
+if [ "$OS_VERSION" = "20.04" ]; then
 
    PYTHON_VERSION=$(python3.9 --version | awk '{print $2}' | awk -F'.' '{print $1"."$2}')
    PYTHON_V=python3.9


### PR DESCRIPTION
## Purpose

Relates to a shell-robustness issue in the FSDP Slurm setup script. The
`create_venv.sh` script does an unquoted string comparison on `$OS_VERSION`,
which breaks when the variable is empty.

## Changes

- Quote `$OS_VERSION` in the `[ ]` string test in
  `3.test_cases/pytorch/FSDP/slurm/create_venv.sh`.

`OS_VERSION` is parsed from `/etc/os-release`. If that file is missing or the
`awk` parse yields an empty string, `if [ $OS_VERSION = "20.04" ]` expands to
`if [ = "20.04" ]`, which is a syntax error (`unary operator expected` /
`too many arguments`). Because the script runs under `set -ex`, this aborts
venv creation. Quoting the variable (`[ "$OS_VERSION" = "20.04" ]`) makes the
comparison evaluate to a well-defined false instead of erroring out.
Addresses ShellCheck SC2086.

## Test Plan

**Environment:**
- AWS Service: N/A (shell syntax fix, filesystem-independent)
- Instance type: N/A
- Number of nodes: N/A

**Test commands:**
```bash
# Syntax check
bash -n 3.test_cases/pytorch/FSDP/slurm/create_venv.sh

# Behavior with an empty OS_VERSION (reproduces the original failure)
OS_VERSION=""
[ $OS_VERSION = "20.04" ]   && echo ok   # before: syntax error
[ "$OS_VERSION" = "20.04" ] && echo ok || echo "false, no error"  # after
```

## Test Results

- `bash -n` passes with no syntax errors.
- With `OS_VERSION=""`, the unquoted form raises
  `bash: [: =: unary operator expected`; the quoted form cleanly evaluates to
  false and the script proceeds to the `else` branch.

## Directory Structure

N/A — one-line fix to an existing script, no test case added or restructured.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`). — N/A, no dependency changes
- [x] A README is included or updated with prerequisites, instructions, and known issues. — N/A, no behavior/usage change
- [x] New test cases follow the [expected directory structure](#directory-structure). — N/A, no new test case