### PR TITLE
Use is None instead of == None in conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,7 +23,7 @@ def docker_build(change_test_dir, request):
         return img_name
 
     yield _build
-    if request.config.option.keep_artifacts == None:
+    if request.config.option.keep_artifacts is None:
         for img in img_list:
             subprocess.check_call(['docker', 'image', 'rm', img])
 


### PR DESCRIPTION
## Purpose

Small code-quality fix in the repo-root `conftest.py`: a comparison to `None`
uses the equality operator instead of the identity operator.

## Changes

- In `conftest.py`, change `if request.config.option.keep_artifacts == None:`
  to `if request.config.option.keep_artifacts is None:`.

PEP 8 (Programming Recommendations) states that comparisons to singletons like
`None` should always be done with `is`/`is not`, never the equality operators.
This is a style/correctness fix with no behavior change — `keep_artifacts` is
either `None` or a string, so `==` and `is` yield the same result here, but
`is` is the correct idiom and avoids relying on `__eq__`.

## Test Plan

**Environment:**
- AWS Service: N/A (test-harness fixture, no infrastructure involved)
- Instance type: N/A
- Number of nodes: N/A

**Test commands:**
```bash
# Byte-compile check
python3 -m py_compile conftest.py

# Confirm the docker_build fixture still collects without error
python3 -m pytest --collect-only -q
```

## Test Results

- `py_compile` succeeds.
- Fixture collection is unchanged; the `docker_build` teardown still removes
  built images when `--keep-artifacts` is not passed. No behavior change.

## Directory Structure

N/A — one-line change to an existing file, no test case added or restructured.

## Checklist

- [x] I have read the [[contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md)](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`). — N/A, no dependency changes
- [x] A README is included or updated with prerequisites, instructions, and known issues. — N/A, no behavior/usage change
- [x] New test cases follow the [[expected directory structure](vscode-webview://0dl7l6gdftg206q4ja8po4jl1orvcnuh9tmtj9qnqagpq6oth0dr/index.html?id=9ba2ae8a-a7eb-42a3-bc3d-bc6b7c027516&parentId=21&origin=0646607a-ab85-4425-a3fd-b13675c96112&swVersion=4&extensionId=kiro.kiroAgent&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&remoteAuthority=ssh-remote%2Bdev&purpose=webviewView#directory-structure)](#directory-structure). — N/A, no new test case
