### PR TITLE
Fix bare except to catch ImportError in test cases

### DIFF
--- a/3.test_cases/pytorch/mosaicml-composer/stable-diffusion/single-node/calculate_number_of_parameters.py
+++ b/3.test_cases/pytorch/mosaicml-composer/stable-diffusion/single-node/calculate_number_of_parameters.py
@@ -12,7 +12,7 @@ from transformers import CLIPTextModel
 try:
     import xformers
     is_xformers_installed = True
-except:
+except ImportError:
     is_xformers_installed = False
 
 class StableDiffusion(composer.models.ComposerModel):

--- a/3.test_cases/pytorch/picotron/train.py
+++ b/3.test_cases/pytorch/picotron/train.py
@@ -28,7 +28,7 @@ import wandb
 
 try:
     import torch.cuda.nvtx as nvtx
-except:
+except ImportError:
     print("NVIDIA NSight tools not available")
     class nvtx:
         @staticmethod


### PR DESCRIPTION
## Purpose

Code-quality fix across two test cases: bare `except:` clauses used to guard
optional-dependency imports also swallow `KeyboardInterrupt` and `SystemExit`,
which can make the scripts hard to interrupt and mask unrelated failures.

## Changes

- `3.test_cases/pytorch/picotron/train.py`: narrow the `try`/`except` around
  the optional `torch.cuda.nvtx` import from bare `except:` to
  `except ImportError:`.
- `3.test_cases/pytorch/mosaicml-composer/stable-diffusion/single-node/calculate_number_of_parameters.py`:
  narrow the `try`/`except` around the optional `xformers` import from bare
  `except:` to `except ImportError:`.

Both sites are guarding an optional dependency, so `ImportError` is the exact
exception to catch. A bare `except:` additionally catches `KeyboardInterrupt`,
`SystemExit`, and any unrelated error raised at import time, hiding real
problems. This matches the explicit `except Exception:` / `except ImportError:`
style already used elsewhere in the repo. No behavior change on the intended
path (dependency present or absent).

## Test Plan

**Environment:**
- AWS Service: N/A (Python import-guard fix, no infrastructure involved)
- Instance type: N/A
- Number of nodes: N/A

**Test commands:**
```bash
# Byte-compile both files
python3 -m py_compile \
  3.test_cases/pytorch/picotron/train.py \
  "3.test_cases/pytorch/mosaicml-composer/stable-diffusion/single-node/calculate_number_of_parameters.py"

# Confirm the optional-import fallback still works when the dep is absent
python3 -c "
try:
    import definitely_not_installed as _
except ImportError:
    print('fallback path taken')
"
```

## Test Results

- `py_compile` succeeds for both files.
- The `except ImportError:` fallback triggers when the optional dependency is
  missing (nvtx / xformers), exactly as before; the difference is that
  `Ctrl-C` and `SystemExit` are no longer swallowed at these import sites.

## Directory Structure

N/A — one-line change in each of two existing files, no test case added or
restructured.

## Checklist

- [x] I have read the [[contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md)](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`). — N/A, no dependency changes
- [x] A README is included or updated with prerequisites, instructions, and known issues. — N/A, no behavior/usage change
- [x] New test cases follow the [[expected directory structure](vscode-webview://0dl7l6gdftg206q4ja8po4jl1orvcnuh9tmtj9qnqagpq6oth0dr/index.html?id=9ba2ae8a-a7eb-42a3-bc3d-bc6b7c027516&parentId=21&origin=0646607a-ab85-4425-a3fd-b13675c96112&swVersion=4&extensionId=kiro.kiroAgent&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&remoteAuthority=ssh-remote%2Bdev&purpose=webviewView#directory-structure)](#directory-structure). — N/A, no new test case