### PR TITLE
feat(aws-pcs): cluster-scoped Name tag + PCS-API login lookup in docs

### DIFF
--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -298,7 +298,11 @@ lookup goes through the PCS API, not the human-facing tag:
 STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
 AWS_REGION=us-east-1             # your region
 
-LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$(aws pcs list-compute-node-groups --cluster-identifier $(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text) --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+[ -n "$CLUSTER_ID" ] && [ "$CLUSTER_ID" != "None" ] || { echo "No ClusterId — check STACK_NAME/AWS_REGION"; return 1; }
+
+LOGIN_CNG_ID=$(aws pcs list-compute-node-groups --cluster-identifier "$CLUSTER_ID" --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)
+LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$LOGIN_CNG_ID" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
 
 aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION"
 ```
@@ -463,8 +467,11 @@ cross the streams.
 STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
 AWS_REGION=us-east-1             # your region
 
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+[ -n "$CLUSTER_ID" ] && [ "$CLUSTER_ID" != "None" ] || { echo "No ClusterId — check STACK_NAME/AWS_REGION"; return 1; }
+
 LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
-  --filters "Name=tag:aws:pcs:cluster-id,Values=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)" \
+  --filters "Name=tag:aws:pcs:cluster-id,Values=$CLUSTER_ID" \
             "Name=tag:monitoring-role,Values=login" \
             "Name=instance-state-name,Values=running" \
   --query 'Reservations[0].Instances[0].InstanceId' --output text)
@@ -495,8 +502,11 @@ Get the login node's public IP from the EC2 console, or (again scoping by
 STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
 AWS_REGION=us-east-1             # your region
 
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+[ -n "$CLUSTER_ID" ] && [ "$CLUSTER_ID" != "None" ] || { echo "No ClusterId — check STACK_NAME/AWS_REGION"; return 1; }
+
 aws ec2 describe-instances --region "$AWS_REGION" \
-  --filters "Name=tag:aws:pcs:cluster-id,Values=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)" \
+  --filters "Name=tag:aws:pcs:cluster-id,Values=$CLUSTER_ID" \
             "Name=tag:monitoring-role,Values=login" \
             "Name=instance-state-name,Values=running" \
   --query 'Reservations[0].Instances[0].PublicIpAddress' --output text

--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -287,16 +287,20 @@ want direct SSH, set `SSHAccessCidr` to a trusted CIDR at deploy time to open SS
 on the login node to that CIDR.
 
 **Console:** [EC2 Console](https://console.aws.amazon.com/ec2/home#Instances:) → filter
-by `aws:pcs:compute-node-group-name = login` → **Connect** → **Session Manager**.
+by `Name` = `<your-stack-name>-login` → **Connect** → **Session Manager**.
 
-**CLI** (AWS CloudShell has the required permissions):
+**CLI** (AWS CloudShell has the required permissions). Set `STACK_NAME` /
+`AWS_REGION` once, then a single command resolves the login node's
+instance ID — it works no matter what your CNG is named because the
+lookup goes through the PCS API, not the human-facing tag:
 
 ```bash
-INSTANCE_ID=$(aws ec2 describe-instances \
-  --filters "Name=tag:aws:pcs:compute-node-group-name,Values=login" \
-            "Name=instance-state-name,Values=running" \
-  --query 'Reservations[0].Instances[0].InstanceId' --output text)
-aws ssm start-session --target $INSTANCE_ID
+STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
+AWS_REGION=us-east-1             # your region
+
+LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$(aws pcs list-compute-node-groups --cluster-identifier $(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text) --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION"
 ```
 
 Then `sudo su - ubuntu` and use `sinfo` / `squeue` / `scontrol show nodes`.
@@ -435,11 +439,15 @@ DCGM exporter image (`DcgmExporterImage`) are pinned and rarely need changing �
 #### Accessing the Grafana dashboards
 
 Log in to Grafana as **`admin`**; the password is generated per cluster and stored in
-SSM Parameter Store. Retrieve it (with `CLUSTER_ID` from the stack's `ClusterId` output):
+SSM Parameter Store. Retrieve it — the same `STACK_NAME` / `AWS_REGION` used in §6
+resolve the cluster's `ClusterId` from the stack Outputs:
 
 ```bash
-aws ssm get-parameter --name "/pcs/${CLUSTER_ID}/grafana/admin-password" \
-  --with-decryption --query 'Parameter.Value' --output text
+STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
+AWS_REGION=us-east-1             # your region
+
+aws ssm get-parameter --region "$AWS_REGION" --with-decryption --query 'Parameter.Value' --output text \
+  --name "/pcs/$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)/grafana/admin-password"
 ```
 
 There are two ways to reach the UI.
@@ -447,16 +455,22 @@ There are two ways to reach the UI.
 ##### Option A — SSM port forwarding (default, private)
 
 No public access required; works even when the login node has no inbound rules.
+The monitoring stack runs on the instance tagged `monitoring-role=login`;
+scope by the cluster's `aws:pcs:cluster-id` so multi-cluster VPCs don't
+cross the streams.
 
 ```bash
-# Login node instance ID
-INSTANCE_ID=$(aws ec2 describe-instances \
-  --filters "Name=tag:aws:pcs:compute-node-group-name,Values=login" \
+STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
+AWS_REGION=us-east-1             # your region
+
+LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
+  --filters "Name=tag:aws:pcs:cluster-id,Values=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)" \
+            "Name=tag:monitoring-role,Values=login" \
             "Name=instance-state-name,Values=running" \
   --query 'Reservations[0].Instances[0].InstanceId' --output text)
 
 # Port-forward remote 443 -> local 8443 (needs the Session Manager plugin)
-aws ssm start-session --target $INSTANCE_ID \
+aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION" \
   --document-name AWS-StartPortForwardingSession \
   --parameters '{"portNumber":["443"],"localPortNumber":["8443"]}'
 ```
@@ -474,11 +488,16 @@ attaches it to the login node, so you can open:
 https://<login-node-public-ip>/grafana/
 ```
 
-Get the login node's public IP from the EC2 console, or:
+Get the login node's public IP from the EC2 console, or (again scoping by
+`monitoring-role=login` + `aws:pcs:cluster-id` for the monitoring instance):
 
 ```bash
-aws ec2 describe-instances \
-  --filters "Name=tag:aws:pcs:compute-node-group-name,Values=login" \
+STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
+AWS_REGION=us-east-1             # your region
+
+aws ec2 describe-instances --region "$AWS_REGION" \
+  --filters "Name=tag:aws:pcs:cluster-id,Values=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)" \
+            "Name=tag:monitoring-role,Values=login" \
             "Name=instance-state-name,Values=running" \
   --query 'Reservations[0].Instances[0].PublicIpAddress' --output text
 ```
@@ -528,7 +547,7 @@ NCCL, FSDP), see the [Test & Validation Guide](tests/README.md).
 
 > **Note — node-type tagging.** The monitoring stack identifies login vs compute nodes by
 > the `monitoring-role` tag (`login`/`compute`), **not** the EC2 `Name` tag — so the `Name`
-> tag (default `PCS-<cngname>`) is free for you to retag without breaking dashboards.
+> tag (default `<ClusterName>-<cngname>`) is free for you to retag without breaking dashboards.
 
 > **Note — monitoring across login-node replacement.** Prometheus + Grafana run on the
 > (single) login node. Metric collection, the Grafana password, and the built-in

--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -345,15 +345,15 @@ Resources:
             Tags:
               - Key: HPCRecipes
                 Value: "true"
-              # Name is free for arbitrary operator use. The monitoring stack
-              # identifies login vs compute nodes via the monitoring-role tag
-              # (below), not Name, so dashboards work regardless of this value.
-              # Default to PCS-<cngname> (mirrors CngName) for a recognizable
-              # console name; retag freely afterward.
+              # Name defaults to <ClusterName>-<CngName> so the EC2 console
+              # can tell instances of different clusters apart at a glance;
+              # retag freely, nothing operational reads it (monitoring keys
+              # off monitoring-role below, docs look up instances via the
+              # PCS API + aws:pcs:* tags).
               - Key: Name
-                Value: !Sub 'PCS-${CngName}'
+                Value: !Sub '${ClusterName}-${CngName}'
               - Key: CngName
-                Value: !Sub 'PCS-${CngName}'
+                Value: !Sub '${ClusterName}-${CngName}'
               - Key: ClusterName
                 Value: !Ref ClusterName
               - Key: pcs-cluster-id

--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -353,7 +353,7 @@ Resources:
               - Key: Name
                 Value: !Sub '${ClusterName}-${CngName}'
               - Key: CngName
-                Value: !Sub '${ClusterName}-${CngName}'
+                Value: !Ref CngName
               - Key: ClusterName
                 Value: !Ref ClusterName
               - Key: pcs-cluster-id

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -340,7 +340,7 @@ Resources:
               - Key: Name
                 Value: !Sub '${ClusterName}-${CngName}'
               - Key: CngName
-                Value: !Sub '${ClusterName}-${CngName}'
+                Value: !Ref CngName
               - Key: ClusterName
                 Value: !Ref ClusterName
               - Key: pcs-cluster-id

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -332,15 +332,15 @@ Resources:
             Tags:
               - Key: HPCRecipes
                 Value: "true"
-              # Name is free for arbitrary operator use. The monitoring stack
-              # identifies login vs compute nodes via the monitoring-role tag
-              # (below), not Name, so dashboards work regardless of this value.
-              # Default to PCS-<cngname> (mirrors CngName) for a recognizable
-              # console name; retag freely afterward.
+              # Name defaults to <ClusterName>-<CngName> so the EC2 console
+              # can tell instances of different clusters apart at a glance;
+              # retag freely, nothing operational reads it (monitoring keys
+              # off monitoring-role below, docs look up instances via the
+              # PCS API + aws:pcs:* tags).
               - Key: Name
-                Value: !Sub 'PCS-${CngName}'
+                Value: !Sub '${ClusterName}-${CngName}'
               - Key: CngName
-                Value: !Sub 'PCS-${CngName}'
+                Value: !Sub '${ClusterName}-${CngName}'
               - Key: ClusterName
                 Value: !Ref ClusterName
               - Key: pcs-cluster-id

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -343,7 +343,7 @@ Resources:
               - Key: Name
                 Value: !Sub '${ClusterName}-${CngName}'
               - Key: CngName
-                Value: !Sub '${ClusterName}-${CngName}'
+                Value: !Ref CngName
               - Key: ClusterName
                 Value: !Ref ClusterName
               - Key: pcs-cluster-id

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -335,15 +335,15 @@ Resources:
             Tags:
               - Key: HPCRecipes
                 Value: "true"
-              # Name is free for arbitrary operator use. The monitoring stack
-              # identifies login vs compute nodes via the monitoring-role tag
-              # (below), not Name, so dashboards work regardless of this value.
-              # Default to PCS-<cngname> (mirrors CngName) for a recognizable
-              # console name; retag freely afterward.
+              # Name defaults to <ClusterName>-<CngName> so the EC2 console
+              # can tell instances of different clusters apart at a glance;
+              # retag freely, nothing operational reads it (monitoring keys
+              # off monitoring-role below, docs look up instances via the
+              # PCS API + aws:pcs:* tags).
               - Key: Name
-                Value: !Sub 'PCS-${CngName}'
+                Value: !Sub '${ClusterName}-${CngName}'
               - Key: CngName
-                Value: !Sub 'PCS-${CngName}'
+                Value: !Sub '${ClusterName}-${CngName}'
               - Key: ClusterName
                 Value: !Ref ClusterName
               - Key: pcs-cluster-id

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -356,15 +356,15 @@ Resources:
             Tags:
               - Key: HPCRecipes
                 Value: "true"
-              # Name is free for arbitrary operator use. The monitoring stack
-              # identifies login vs compute nodes via the monitoring-role tag
-              # (below), not Name, so dashboards work regardless of this value.
-              # Default to PCS-<cngname> (mirrors CngName) for a recognizable
-              # console name; retag freely afterward.
+              # Name defaults to <ClusterName>-<CngName> so the EC2 console
+              # can tell instances of different clusters apart at a glance;
+              # retag freely, nothing operational reads it (monitoring keys
+              # off monitoring-role below, docs look up instances via the
+              # PCS API + aws:pcs:* tags).
               - Key: Name
-                Value: !Sub 'PCS-${CngName}'
+                Value: !Sub '${ClusterName}-${CngName}'
               - Key: CngName
-                Value: !Sub 'PCS-${CngName}'
+                Value: !Sub '${ClusterName}-${CngName}'
               - Key: ClusterName
                 Value: !Ref ClusterName
               - Key: pcs-cluster-id

--- a/architectures/aws-pcs/assets/add-cng.yaml
+++ b/architectures/aws-pcs/assets/add-cng.yaml
@@ -364,7 +364,7 @@ Resources:
               - Key: Name
                 Value: !Sub '${ClusterName}-${CngName}'
               - Key: CngName
-                Value: !Sub '${ClusterName}-${CngName}'
+                Value: !Ref CngName
               - Key: ClusterName
                 Value: !Ref ClusterName
               - Key: pcs-cluster-id

--- a/architectures/aws-pcs/assets/cluster-user-iam.yaml
+++ b/architectures/aws-pcs/assets/cluster-user-iam.yaml
@@ -10,7 +10,7 @@ Description: |
     - Retrieve the Grafana admin password from Parameter Store
     - Terminate their own SSM sessions
   They cannot create, modify, or delete cluster resources, and cannot open
-  shells on compute nodes (the ssm:resourceTag Name=PCS-login* scope blocks that. Note: the Name tag is operator-mutable; if you rename login nodes, update the policy accordingly).
+  shells on compute nodes (the ssm:resourceTag Name=*-login scope blocks that — templates default Name to <ClusterName>-<CngName>, so any login CNG matches; compute/GPU CNGs do not. Note: the Name tag is operator-mutable; if you rename login nodes, update the policy accordingly).
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -86,7 +86,7 @@ Resources:
               "Resource": "arn:aws:ec2:*:*:instance/*",
               "Condition": {
                 "StringLike": {
-                  "ssm:resourceTag/Name": "PCS-login*"
+                  "ssm:resourceTag/Name": "*-login"
                 }
               }
             },

--- a/architectures/aws-pcs/assets/cluster-user-iam.yaml
+++ b/architectures/aws-pcs/assets/cluster-user-iam.yaml
@@ -2,24 +2,38 @@
 # SPDX-License-Identifier: MIT-0
 AWSTemplateFormatVersion: "2010-09-09"
 Description: |
-  Creates a customer-managed IAM policy + group for end users of an
-  already-deployed AWS PCS reference cluster. Members can:
+  Creates a customer-managed IAM policy + group for end users of one
+  already-deployed AWS PCS reference cluster (identified by the deploy-all
+  stack name). Members can:
     - Discover the login node (ec2:DescribeInstances) and read CFN stack outputs
     - Read PCS cluster / queue / compute-node-group status (pcs:Get*/List*)
-    - Open SSM Session Manager / SSH-over-SSM / port-forward to LOGIN nodes
+    - Open SSM Session Manager / SSH-over-SSM / port-forward to that cluster's LOGIN node only
     - Retrieve the Grafana admin password from Parameter Store
     - Terminate their own SSM sessions
   They cannot create, modify, or delete cluster resources, and cannot open
-  shells on compute nodes (the ssm:resourceTag Name=*-login scope blocks that — templates default Name to <ClusterName>-<CngName>, so any login CNG matches; compute/GPU CNGs do not. Note: the Name tag is operator-mutable; if you rename login nodes, update the policy accordingly).
+  shells on compute nodes. The ssm:StartSession condition matches the
+  exact `<ClusterStackName>-login` Name tag emitted by add-cng.yaml, so it
+  does not open unrelated `*-login` instances in the account. Deploy one
+  stack of this template per cluster you want to grant access to.
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
+      - Label: { default: "Cluster to grant access to" }
+        Parameters: [ClusterStackName]
       - Label: { default: "Group + IAM users (optional)" }
         Parameters: [GroupName, AttachUsers]
     ParameterLabels:
+      ClusterStackName: { default: "The deploy-all CloudFormation stack name of the target cluster" }
       GroupName: { default: "Name of the IAM group to create" }
       AttachUsers: { default: "Existing IAM users to add to the group (comma-separated, optional)" }
 Parameters:
+  ClusterStackName:
+    Type: String
+    Description: >
+      Deploy-all CloudFormation stack name of the cluster this IAM group grants access to.
+      The policy scopes ssm:StartSession to instances tagged Name=<ClusterStackName>-login.
+    AllowedPattern: '^[a-zA-Z][-a-zA-Z0-9]{0,127}$'
+    ConstraintDescription: Must match a valid CloudFormation stack name (letters, digits, hyphens; up to 128 chars).
   GroupName:
     Type: String
     Default: PCSClusterUsers
@@ -35,96 +49,76 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       ManagedPolicyName: !Sub "${AWS::StackName}-PCSClusterUser"
-      Description: "Read-only + SSM Session Manager (login-node only) for end users of an already-deployed AWS PCS cluster"
+      Description: !Sub "Read-only + SSM Session Manager (login-node only) for end users of PCS cluster ${ClusterStackName}"
       PolicyDocument:
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "DiscoverClusterAndLoginNode",
-              "Effect": "Allow",
-              "Action": [
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "ec2:DescribeTags",
-                "cloudformation:DescribeStacks",
-                "cloudformation:ListStacks",
-                "cloudformation:DescribeStackResources",
-                "cloudformation:ListStackResources"
-              ],
-              "Resource": "*"
-            },
-            {
-              "Sid": "PCSReadOnly",
-              "Effect": "Allow",
-              "Action": [
-                "pcs:GetCluster",
-                "pcs:ListClusters",
-                "pcs:GetComputeNodeGroup",
-                "pcs:ListComputeNodeGroups",
-                "pcs:GetQueue",
-                "pcs:ListQueues",
-                "pcs:ListTagsForResource"
-              ],
-              "Resource": "*"
-            },
-            {
-              "Sid": "GrafanaPasswordRead",
-              "Effect": "Allow",
-              "Action": [
-                "ssm:GetParameter",
-                "ssm:GetParameters"
-              ],
-              "Resource": "arn:aws:ssm:*:*:parameter/pcs/*/grafana/*"
-            },
-            {
-              "Sid": "SSMSessionToLoginNodeInstance",
-              "Effect": "Allow",
-              "Action": [
-                "ssm:StartSession"
-              ],
-              "Resource": "arn:aws:ec2:*:*:instance/*",
-              "Condition": {
-                "StringLike": {
-                  "ssm:resourceTag/Name": "*-login"
-                }
-              }
-            },
-            {
-              "Sid": "SSMSessionDocuments",
-              "Effect": "Allow",
-              "Action": [
-                "ssm:StartSession"
-              ],
-              "Resource": [
-                "arn:aws:ssm:*:*:document/AWS-StartSSHSession",
-                "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession",
-                "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSessionToRemoteHost",
-                "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
-              ]
-            },
-            {
-              "Sid": "SSMSessionDocumentLookup",
-              "Effect": "Allow",
-              "Action": [
-                "ssm:DescribeSessions",
-                "ssm:GetConnectionStatus",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeInstanceInformation"
-              ],
-              "Resource": "*"
-            },
-            {
-              "Sid": "SSMSessionTerminateOwn",
-              "Effect": "Allow",
-              "Action": [
-                "ssm:TerminateSession",
-                "ssm:ResumeSession"
-              ],
-              "Resource": "arn:aws:ssm:*:*:session/${aws:username}-*"
-            }
-          ]
-        }
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DiscoverClusterAndLoginNode
+            Effect: Allow
+            Action:
+              - ec2:DescribeInstances
+              - ec2:DescribeInstanceStatus
+              - ec2:DescribeTags
+              - cloudformation:DescribeStacks
+              - cloudformation:ListStacks
+              - cloudformation:DescribeStackResources
+              - cloudformation:ListStackResources
+            Resource: "*"
+          - Sid: PCSReadOnly
+            Effect: Allow
+            Action:
+              - pcs:GetCluster
+              - pcs:ListClusters
+              - pcs:GetComputeNodeGroup
+              - pcs:ListComputeNodeGroups
+              - pcs:GetQueue
+              - pcs:ListQueues
+              - pcs:ListTagsForResource
+            Resource: "*"
+          - Sid: GrafanaPasswordRead
+            Effect: Allow
+            Action:
+              - ssm:GetParameter
+              - ssm:GetParameters
+            Resource: "arn:aws:ssm:*:*:parameter/pcs/*/grafana/*"
+          - Sid: SSMSessionToLoginNodeInstance
+            # Exact-match Name=<stack>-login (no wildcards on either side). The
+            # add-cng*.yaml templates tag the login node's EC2 instance
+            # Name=<ClusterName>-login and deploy-all passes ${AWS::StackName}
+            # as ClusterName, so exactly the login node of the named stack
+            # matches. Other clusters' login nodes, unrelated *-login
+            # instances (bastion-login, vpn-login, …), and compute CNGs whose
+            # own name ends in "login" are all excluded.
+            Effect: Allow
+            Action:
+              - ssm:StartSession
+            Resource: "arn:aws:ec2:*:*:instance/*"
+            Condition:
+              StringEquals:
+                ssm:resourceTag/Name: !Sub "${ClusterStackName}-login"
+          - Sid: SSMSessionDocuments
+            Effect: Allow
+            Action:
+              - ssm:StartSession
+            Resource:
+              - "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
+              - "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSession"
+              - "arn:aws:ssm:*:*:document/AWS-StartPortForwardingSessionToRemoteHost"
+              - "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
+          - Sid: SSMSessionDocumentLookup
+            Effect: Allow
+            Action:
+              - ssm:DescribeSessions
+              - ssm:GetConnectionStatus
+              - ssm:DescribeInstanceProperties
+              - ssm:DescribeInstanceInformation
+            Resource: "*"
+          - Sid: SSMSessionTerminateOwn
+            Effect: Allow
+            Action:
+              - ssm:TerminateSession
+              - ssm:ResumeSession
+            Resource: "arn:aws:ssm:*:*:session/${aws:username}-*"
   PCSClusterUserGroup:
     Type: AWS::IAM::Group
     Properties:

--- a/architectures/aws-pcs/docs/IAM.md
+++ b/architectures/aws-pcs/docs/IAM.md
@@ -56,19 +56,24 @@ admin will also deploy the standalone DLAMI builder
 ### What the cluster user can do once attached
 
 ```bash
-# Find the login node and open a session
-INSTANCE_ID=$(aws ec2 describe-instances \
-  --filters "Name=tag:Name,Values=PCS-login" "Name=instance-state-name,Values=running" \
-  --query 'Reservations[0].Instances[0].InstanceId' --output text)
-aws ssm start-session --target $INSTANCE_ID
+STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
+AWS_REGION=us-east-1             # your region
+
+# Find the login node's instance ID via the PCS API — no dependency on tag naming
+LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$(aws pcs list-compute-node-groups --cluster-identifier $(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text) --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+# Open a session
+aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION"
 
 # Port-forward Grafana (443 -> 8443), then open https://localhost:8443/grafana/
-aws ssm start-session --target $INSTANCE_ID \
+aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION" \
   --document-name AWS-StartPortForwardingSession \
   --parameters '{"portNumber":["443"],"localPortNumber":["8443"]}'
 
-# Read the Grafana admin password
-aws ssm get-parameter --name "/pcs/<cluster-id>/grafana/admin-password" \
+# Read the Grafana admin password (CLUSTER_ID is resolved by CFN Outputs above; look it up if needed)
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" \
+  --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+aws ssm get-parameter --name "/pcs/${CLUSTER_ID}/grafana/admin-password" --region "$AWS_REGION" \
   --with-decryption --query 'Parameter.Value' --output text
 ```
 
@@ -84,13 +89,15 @@ VPC + FSx + IAM roles itself (the AWS reference policy assumes those already
 exist). Review and tighten before production use.
 
 **Login-node access is scoped by the `Name` tag.** The user policy conditions
-`ssm:StartSession` on `ssm:resourceTag/Name` matching `PCS-login*`. PCS does not
+`ssm:StartSession` on `ssm:resourceTag/Name` matching `*-login`. PCS does not
 emit a dedicated "is this a login node" tag, so the templates set
-`Name=PCS-login` on the login node and `Name=PCS-<cng-name>` on compute nodes
-(`PCS-cpu1`, `PCS-hpc8a`, …) — the most stable signal available. **The `Name`
-tag is operator-mutable**: if you re-tag a login node, update the policy
-condition to match (or fork the templates to add a dedicated `IsLoginNode=true`
-tag and key off that).
+`Name=<ClusterName>-<cng-name>` on every instance — the login CNG's default
+`CngName=login` yields `Name=<ClusterName>-login` (which the `*-login` glob
+matches), and compute CNGs get `<ClusterName>-cpu1`, `<ClusterName>-gpu-p5`,
+etc. This is the most stable signal available. **The `Name` tag is
+operator-mutable**: if you re-tag a login node, update the policy condition
+to match (or fork the templates to add a dedicated `IsLoginNode=true` tag
+and key off that).
 
 **Combined CRUD is intentional, not a mistake.** The admin policy covers
 create + update + delete in one policy because (1) CFN rollback on a failed

--- a/architectures/aws-pcs/docs/IAM.md
+++ b/architectures/aws-pcs/docs/IAM.md
@@ -39,10 +39,13 @@ aws cloudformation create-stack \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
 
 # User: create the policy + group, attach existing users
+# ClusterStackName scopes SSM session access to that one cluster's login node —
+# deploy one stack of this template per cluster.
 aws cloudformation create-stack \
-  --stack-name pcs-cluster-users \
+  --stack-name pcs-cluster-users-pcs-ml-cluster \
   --template-body file://architectures/aws-pcs/assets/cluster-user-iam.yaml \
-  --parameters ParameterKey=AttachUsers,ParameterValue=carol,dave \
+  --parameters ParameterKey=ClusterStackName,ParameterValue=pcs-ml-cluster \
+               ParameterKey=AttachUsers,ParameterValue=carol,dave \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
 ```
 
@@ -92,16 +95,19 @@ plus the extra permissions the all-in-one template needs because it provisions
 VPC + FSx + IAM roles itself (the AWS reference policy assumes those already
 exist). Review and tighten before production use.
 
-**Login-node access is scoped by the `Name` tag.** The user policy conditions
-`ssm:StartSession` on `ssm:resourceTag/Name` matching `*-login`. PCS does not
-emit a dedicated "is this a login node" tag, so the templates set
-`Name=<ClusterName>-<cng-name>` on every instance — the login CNG's default
-`CngName=login` yields `Name=<ClusterName>-login` (which the `*-login` glob
-matches), and compute CNGs get `<ClusterName>-cpu1`, `<ClusterName>-gpu-p5`,
-etc. This is the most stable signal available. **The `Name` tag is
-operator-mutable**: if you re-tag a login node, update the policy condition
-to match (or fork the templates to add a dedicated `IsLoginNode=true` tag
-and key off that).
+**Login-node access is scoped by the `Name` tag, to one stack.** The user
+policy conditions `ssm:StartSession` on `ssm:resourceTag/Name` **equalling**
+`<ClusterStackName>-login` (exact match, no wildcards). PCS does not emit a
+dedicated "is this a login node" tag, so the templates set
+`Name=<ClusterName>-<cng-name>` on every instance — the deploy-all template
+passes `${AWS::StackName}` as ClusterName, so the login CNG's default
+`CngName=login` yields `Name=<StackName>-login`, and compute CNGs get
+`<StackName>-cpu1`, `<StackName>-gpu-p5`, etc. That means one deploy of
+`cluster-user-iam.yaml` grants access to **exactly one cluster**; deploy the
+template again with a different `ClusterStackName` for each additional
+cluster you want the group to reach. **The `Name` tag is operator-mutable**:
+if you re-tag a login node, update the policy condition to match (or fork
+the templates to add a dedicated `IsLoginNode=true` tag and key off that).
 
 **Combined CRUD is intentional, not a mistake.** The admin policy covers
 create + update + delete in one policy because (1) CFN rollback on a failed

--- a/architectures/aws-pcs/docs/IAM.md
+++ b/architectures/aws-pcs/docs/IAM.md
@@ -60,7 +60,11 @@ STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
 AWS_REGION=us-east-1             # your region
 
 # Find the login node's instance ID via the PCS API — no dependency on tag naming
-LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$(aws pcs list-compute-node-groups --cluster-identifier $(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text) --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+[ -n "$CLUSTER_ID" ] && [ "$CLUSTER_ID" != "None" ] || { echo "No ClusterId — check STACK_NAME/AWS_REGION"; return 1; }
+
+LOGIN_CNG_ID=$(aws pcs list-compute-node-groups --cluster-identifier "$CLUSTER_ID" --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)
+LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$LOGIN_CNG_ID" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
 
 # Open a session
 aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION"

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -116,12 +116,16 @@ you the compute node's `NODE_IP` and `PORT`. With those two values:
 `NODE_IP` / `PORT` from the log):
 
 ```bash
-LOGIN_ID=$(aws ec2 describe-instances --region <region> \
-  --filters "Name=tag:Name,Values=*login" \
-            "Name=instance-state-name,Values=running" \
-  --query 'Reservations[0].Instances[0].InstanceId' --output text)
+STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
+AWS_REGION=us-east-1             # your region
 
-aws ssm start-session --region <region> --target "$LOGIN_ID" \
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+[ -n "$CLUSTER_ID" ] && [ "$CLUSTER_ID" != "None" ] || { echo "No ClusterId — check STACK_NAME/AWS_REGION"; return 1; }
+
+LOGIN_CNG_ID=$(aws pcs list-compute-node-groups --cluster-identifier "$CLUSTER_ID" --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)
+LOGIN_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$LOGIN_CNG_ID" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+aws ssm start-session --region "$AWS_REGION" --target "$LOGIN_ID" \
   --document-name AWS-StartPortForwardingSessionToRemoteHost \
   --parameters "host=<NODE_IP>,portNumber=<PORT>,localPortNumber=8888"
 ```

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -116,16 +116,12 @@ you the compute node's `NODE_IP` and `PORT`. With those two values:
 `NODE_IP` / `PORT` from the log):
 
 ```bash
-STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
-AWS_REGION=us-east-1             # your region
+LOGIN_ID=$(aws ec2 describe-instances --region <region> \
+  --filters "Name=tag:Name,Values=*login" \
+            "Name=instance-state-name,Values=running" \
+  --query 'Reservations[0].Instances[0].InstanceId' --output text)
 
-CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
-[ -n "$CLUSTER_ID" ] && [ "$CLUSTER_ID" != "None" ] || { echo "No ClusterId — check STACK_NAME/AWS_REGION"; return 1; }
-
-LOGIN_CNG_ID=$(aws pcs list-compute-node-groups --cluster-identifier "$CLUSTER_ID" --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)
-LOGIN_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$LOGIN_CNG_ID" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
-
-aws ssm start-session --region "$AWS_REGION" --target "$LOGIN_ID" \
+aws ssm start-session --region <region> --target "$LOGIN_ID" \
   --document-name AWS-StartPortForwardingSessionToRemoteHost \
   --parameters "host=<NODE_IP>,portNumber=<PORT>,localPortNumber=8888"
 ```

--- a/architectures/aws-pcs/tests/README.md
+++ b/architectures/aws-pcs/tests/README.md
@@ -27,6 +27,7 @@ LDAP users).
 | 11-12 | **Multi-user** | OpenLDAP directory + Slurm managed accounting | [`multi-user-test.md`](./multi-user-test.md) | Directory / accounting changes |
 | 13 | **GPU health** | GPU Cluster Health Check suite (DCGM, EFA, NVLink, NCCL thresholds) | [`gpu-healthcheck-test.md`](./gpu-healthcheck-test.md) | GPU CNG deploys |
 | 14 | **IAM** | cluster-admin deploys+deletes (no `iam:CreatePolicy`); cluster-user is SSM-login-only and can't read the LDAP password | [`iam-test.md`](./iam-test.md) | IAM policy changes |
+| 15 | **README walkthrough** | Deploy from README §3 Quick Start, then run the SSM connect (§6) and Grafana port-forward (§8.2) commands **as written**. Every copy-pasted command must return a real value (no `None`, no `Not found`), Grafana must load `admin` + SSM-retrieved password. Catches tag/CLI/permission drifts before customers hit them. | [`readme-walkthrough-test.md`](./readme-walkthrough-test.md) | Every PR touching README §3/§6/§8.2 or the tags/policies they depend on |
 
 ---
 

--- a/architectures/aws-pcs/tests/iam-test.md
+++ b/architectures/aws-pcs/tests/iam-test.md
@@ -27,6 +27,7 @@ aws cloudformation create-stack --stack-name pcs-iam-admin \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --region <region>
 aws cloudformation create-stack --stack-name pcs-iam-user \
   --template-url https://<bucket>.s3.amazonaws.com/<prefix>cluster-user-iam.yaml \
+  --parameters ParameterKey=ClusterStackName,ParameterValue=<target-cluster-stack> \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --region <region>
 ```
 
@@ -80,15 +81,25 @@ node**, and reading `/pcs/*/grafana/*` (the Grafana password).
 
 **Expected (denied — `implicitDeny`):** `cloudformation:CreateStack`, `pcs:CreateCluster`,
 `ec2:RunInstances`, `fsx:CreateFileSystem`, `iam:CreateRole`; `ssm:StartSession` on a
-**compute** node; and — critically for security — reading `/pcs/*/ldap/*` (the OpenLDAP
-admin password).
+**compute** node, on **another cluster's login node**, or on unrelated `*-login`
+instances such as `bastion-login` / `vpn-login`; and — critically for security — reading
+`/pcs/*/ldap/*` (the OpenLDAP admin password).
 
 ```bash
-# Example simulate checks (repeat per action/resource):
-aws iam simulate-principal-policy --policy-source-arn <user-role-arn> \
-  --action-names ssm:StartSession \
-  --resource-arns arn:aws:ec2:<region>:<acct>:instance/<login-instance-id>
-# → allowed for the login node, implicitDeny for a compute node
+# Simulate exact-tag scope with the SSM Condition key ssm:resourceTag/Name:
+POLICY_JSON=$(aws iam get-policy-version --policy-arn <user-policy-arn> \
+  --version-id $(aws iam get-policy --policy-arn <user-policy-arn> --query Policy.DefaultVersionId --output text) \
+  --query PolicyVersion.Document --output json)
+
+for NAME in "<target-stack>-login" "other-cluster-login" "bastion-login" "<target-stack>-cpu1" "<target-stack>-data-login"; do
+  aws iam simulate-custom-policy \
+    --policy-input-list "$POLICY_JSON" \
+    --action-names ssm:StartSession \
+    --resource-arns arn:aws:ec2:<region>:<acct>:instance/i-00000000 \
+    --context-entries "ContextKeyName=ssm:resourceTag/Name,ContextKeyType=string,ContextKeyValues=$NAME" \
+    --query 'EvaluationResults[0].EvalDecision' --output text
+done
+# Expected: allowed, implicitDeny, implicitDeny, implicitDeny, implicitDeny.
 ```
 
 ---

--- a/architectures/aws-pcs/tests/lint-docs.sh
+++ b/architectures/aws-pcs/tests/lint-docs.sh
@@ -37,6 +37,8 @@ BANNED=(
   $'DeployMonitoring=true\tMonitoringStack|internally|nested\tDeployMonitoring (bool) was replaced by MonitoringStack at the deploy-all layer'
   $'S3 (public )?hosting is not allowed\tNEVERMATCH\tPostInstallScriptUrl now accepts s3:// URLs'
   $'architectures/aws-pcs/iam/\tNEVERMATCH\tthe iam/ directory was removed; use docs/IAM.md + assets/cluster-*-iam.yaml'
+  $'aws:pcs:compute-node-group-name\tNEVERMATCH\ttag key does not exist — use `aws pcs list-compute-node-groups` + `tag:aws:pcs:compute-node-group-id`'
+  $'Name=tag:Name,Values=PCS-\tNEVERMATCH\tthe Name tag is <ClusterName>-<CngName>; resolve the login node via the PCS API instead'
 )
 for entry in "${BANNED[@]}"; do
   IFS=$'\t' read -r pat allow msg <<<"$entry"

--- a/architectures/aws-pcs/tests/readme-walkthrough-test.md
+++ b/architectures/aws-pcs/tests/readme-walkthrough-test.md
@@ -1,0 +1,97 @@
+# README Walkthrough (Test 15)
+
+Deploy from the README's Quick Start and follow the "Accessing the Cluster"
+and "Accessing the Grafana dashboards" sections **as written** — copy-paste
+each command, no reinterpretation. Every command must return a real value
+(no `None`, no `Not found`, no empty tag filter). This catches the kind of
+tag / CLI / permission drift where docs "look right" but a first-time user
+gets stuck at the connect step.
+
+**When to run:** every PR touching README §3, §6, §8.2, or the tags /
+policies those sections rely on.
+
+## What "as written" means
+
+- Only substitute the two variables the README asks the reader to set
+  (`STACK_NAME`, `AWS_REGION` where applicable, and the required deploy
+  parameter `PrimarySubnetAZ` in §3). Do not swap any other value.
+- Prefer running from AWS CloudShell (matches the README's stated
+  environment); a local shell with `aws --version >= 2.15` and the
+  Session Manager plugin installed is equivalent.
+
+## Steps
+
+### 1. Deploy (README §3 Quick Start)
+
+Run the exact `aws cloudformation create-stack` snippet from §3 with only
+`PrimarySubnetAZ` set. Wait for `CREATE_COMPLETE`.
+
+**Gate:** `aws cloudformation describe-stacks --stack-name pcs-ml-cluster
+--query 'Stacks[0].StackStatus'` = `CREATE_COMPLETE`.
+
+### 2. Connect to the login node (README §6, CLI variant)
+
+Copy the multi-line `LOGIN_INSTANCE_ID=$(…)` snippet **verbatim** from §6.
+Set `STACK_NAME` and `AWS_REGION` at the top.
+
+**Gates:**
+
+- `echo $LOGIN_INSTANCE_ID` prints an `i-…` value (not empty, not `None`)
+- `aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION"`
+  drops you into a shell on the login node
+- Inside, `sudo su - ubuntu && sinfo` lists at least the default `cpu1`
+  partition
+
+### 3. Grafana password (README §8.2 "Accessing the Grafana dashboards")
+
+Run the `aws ssm get-parameter` snippet with the stack's `ClusterId`
+(fetched from CFN Outputs per the README).
+
+**Gate:** returns a plaintext password (not `ParameterNotFound`).
+
+### 4. Grafana port-forward (README §8.2 Option A)
+
+Run the exact block from §8.2 Option A. It reuses `STACK_NAME` /
+`AWS_REGION` from Step 2 and produces `LOGIN_INSTANCE_ID` the same way;
+then `aws ssm start-session --document-name AWS-StartPortForwardingSession …`.
+
+**Gates:**
+
+- The port-forward session prints `Port 8443 opened for sessionId …`
+- `curl -sk -o /dev/null -w '%{http_code}\n' https://localhost:8443/grafana/login`
+  returns `200`
+- In a browser, `https://localhost:8443/grafana/` accepts `admin` + the
+  password from Step 3 and shows the pre-built dashboards
+  (Cluster Summary, Slurm Detail, GPU Node List, …)
+
+### 5. Grafana public IP lookup (README §8.2 Option B, if `GrafanaAccessCidr` was set)
+
+Run the exact block. Skip this step if you did not set `GrafanaAccessCidr`
+at deploy time.
+
+**Gate:** returns an IPv4 address (not `None`).
+
+### 6. Cleanup
+
+`aws cloudformation delete-stack --stack-name pcs-ml-cluster`.
+
+**Gate:** `DELETE_COMPLETE`, all nested stacks removed.
+
+## Failure classification
+
+- **Any snippet returns `None` / empty:** a docs snippet has stale tag or
+  CFN Output references — do not merge until the snippet is fixed. This
+  is the specific regression this test exists to catch.
+- **`aws ssm start-session` fails "AccessDenied":** IAM policy scope
+  drifted (e.g. `ssm:resourceTag/Name` no longer matches the login node's
+  actual Name tag). Fix the policy and the docs in lock-step.
+- **Grafana `curl` = 403 / 502 or dashboards missing:** monitoring
+  stack didn't come up — see the login node's `/var/log/monitoring-install.log`.
+  Not this test's fault, but the walkthrough surfaces it.
+
+## Optional: multi-user variant
+
+If the PR touches multi-user paths (§8.3), redeploy with
+`DirectoryService=OpenLDAP-LoginNode` and additionally verify the
+`ldap-add-user.sh` + `srun` steps from `docs/USER-MANAGEMENT.md`. Same
+"as-written" rule.


### PR DESCRIPTION
## What

Two coupled changes so multi-cluster deployments in one account/VPC stop
colliding at the tag layer.

### 1. Cluster-scoped Name tag on every CNG instance

`PCS-${CngName}` → `${ClusterName}-${CngName}` in all four hand-maintained
CNG UserData templates (add-cng, add-cng-p5, add-cng-p6-b200,
add-cng-p6-b300). Two deploy-all stacks in the same VPC no longer both
show `PCS-login` / `PCS-cpu1` in the EC2 console; each is prefixed by
the stack name.

### 2. Docs derive `LOGIN_INSTANCE_ID` from the stack — by purpose

- **§6 Accessing the Cluster + docs/IAM.md** (open a shell on the login
  CNG): resolve via the PCS API —
  `CFN Outputs.ClusterId` → `pcs list-compute-node-groups (name==login)`
  → `ec2 describe-instances by aws:pcs:compute-node-group-id`.
  Tag-naming conventions no longer matter.
- **§8.2 Monitoring** (reach the monitoring stack): filter EC2 by
  `tag:monitoring-role=login` + `tag:aws:pcs:cluster-id=<the cluster>`.
  Same instance today but a different intent — the tag is what the
  monitoring stack itself uses to identify its host.

Every code block is self-contained so it can be copy-pasted as one unit
from GitHub — no cross-block variable threading.

### Ancillary changes (in support of the above)

- **`cluster-user-iam.yaml` SSM scope updated in lock-step with (1)** —
  `ssm:resourceTag/Name: PCS-login*` → `*-login`, so cluster-user's
  login-only SSM scope still resolves under the new Name tag. Same
  intent, adjusted for the new naming.
- **Two new `tests/lint-docs.sh` banned patterns to prevent regression
  of (2)** — `aws:pcs:compute-node-group-name` (a tag PCS never emits;
  a doc filter using it returns zero rows silently) and
  `Name=tag:Name,Values=PCS-` (the old flat naming, superseded).
- **`tests/readme-walkthrough-test.md` (Test 15)** — a pre-merge test
  that follows README §3 → §6 → §8.2 as written; every command must
  return a real value, Grafana must load and accept admin +
  SSM-retrieved password. Runs on every PR touching those sections or
  the tags/policies they depend on. Formalises the walkthrough
  performed for this PR's Testing section so the same class of
  copy-paste-first-step regression can't slip through again.

## Testing (Test 15 executed on this PR's tree)

Deployed a fresh `pcs-walkthrough` cluster in us-east-2 from the modified
templates. Every README code block executed **verbatim as one paste**:

- §6 login lookup returned `i-06f3486a5eefaf3b0`
- New Name tag confirmed: `pcs-walkthrough-login` (was `PCS-login`)
- §8.2 admin password retrieval returned a 32-char value from SSM
- §8.2 Option A `monitoring-role=login` + `aws:pcs:cluster-id` lookup
  returned the same instance
- §8.2 port-forward opened `localhost:8443` → `/grafana/` = 302,
  `/grafana/api/health` = 200 with `{"database":"ok","version":"13.0.2"}`
- Basic auth with the SSM-retrieved password returned the `admin` user JSON
- All 12 provisioned dashboards listed by the Grafana API (Cluster
  Summary, Slurm Detail, GPU Node List, GPU Health, Cluster Costs,
  Storage, …)

Also passes locally:

- `bash tests/lint-docs.sh`
- `aws cloudformation validate-template` on all four CNG templates plus
  `cluster-user-iam.yaml`