### PR TITLE
docs(hyperpod-eks): replace deprecated workshop catalog URL with the new docs site

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/README.md
@@ -1,6 +1,6 @@
 # Amazon EKS support in Amazon SageMaker HyperPod
 
-> 🚨 We recommend following the official [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) to deploy clusters, which contains detailed instructions and latest best-practices.
+> 🚨 We recommend following the official [Amazon SageMaker HyperPod EKS documentation](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) to deploy clusters, which contains detailed instructions and latest best-practices.
 
 ## 1. Architecture
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/README.md
@@ -1,6 +1,6 @@
 # Amazon EKS support in Amazon SageMaker HyperPod
 
-> 🚨 We recommend following the official [Amazon SageMaker HyperPod EKS Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US) to deploy clusters, which contains detailed instructions and latest best-practices.
+> 🚨 We recommend following the official [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) to deploy clusters, which contains detailed instructions and latest best-practices.
 
 ## 1. Architecture
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/automate-eks-cluster-creation.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/automate-eks-cluster-creation.sh
@@ -607,7 +607,7 @@ configure_eks_cluster() {
         echo -e "${YELLOW}Converting assumed-role ARN to IAM role ARN: ${USER_ARN}${NC}"
     fi        
 
-    echo -e "${GREEN}Note: By default, Amazon EKS will automatically create an AccessEntry with the AmazonEKSClusterAdminPolicy for the IAM principal that you use to deploy the CloudFormation stack. To allow other users entry, check out https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US/10-tips/07-add-users${NC}"
+    echo -e "${GREEN}Note: By default, Amazon EKS will automatically create an AccessEntry with the AmazonEKSClusterAdminPolicy for the IAM principal that you use to deploy the CloudFormation stack. To allow other users entry, check out https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/eks-orchestration/tips/add-users${NC}"
 
     # Create access entry for current user
     echo -e "${YELLOW}Adding current $PRINCIPAL_TYPE $USER_NAME to $EKS_CLUSTER_NAME...${NC}"
@@ -1066,7 +1066,7 @@ display_important_prereqs() {
 
     echo -e "\n${GREEN}2. 🌐 VPC Stack:${NC}"
     echo "   Deploy the hyperpod-eks-full-stack using:"
-    echo "   https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US/00-setup/02-own-account"
+    echo "   https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/eks-orchestration/getting-started/initial-cluster-setup"
     echo -e "   Choose between ${BLUE}\"Full Deployment\"${NC}, ${BLUE}\"Integrative Deployment\"${NC}, and ${BLUE}\"Minimal Deployment\"${NC}, depending on what you'd like to provision. This script accounts for all of these deployment modes."
     echo -e "   ${YELLOW}Full Deployment: Creates all prerequisite resources$ (10 minutes),${NC}"
     echo -e "   ${YELLOW}Integrative Deployment: Uses existing VPC and EKS cluster, but creates new network resources(subnet, security group, CIDR block), S3 bucket, and IAM role for the HyperPod cluster. (3 minutes),${NC}"

--- a/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/hyperpod-eks-cluster-creation.sh
+++ b/1.architectures/7.sagemaker-hyperpod-eks/automate-smhp-eks/hyperpod-eks-cluster-creation.sh
@@ -489,7 +489,7 @@ configure_eks_cluster() {
     echo -e "ARN: ${YELLOW}$USER_ARN${NC}"
     echo -e "Principal Type: ${YELLOW}$PRINCIPAL_TYPE${NC}"
     echo -e "${YELLOW}Note: You are authenticated using an IAM $PRINCIPAL_TYPE $USER_NAME${NC}"    
-    echo -e "${GREEN}Note: By default, Amazon EKS will automatically create an AccessEntry with the AmazonEKSClusterAdminPolicy for the IAM principal that you use to create the EKS Cluster. To allow other users entry, check out https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US/10-tips/07-add-users${NC}"
+    echo -e "${GREEN}Note: By default, Amazon EKS will automatically create an AccessEntry with the AmazonEKSClusterAdminPolicy for the IAM principal that you use to create the EKS Cluster. To allow other users entry, check out https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/eks-orchestration/tips/add-users${NC}"
 
     # Skip access entry creation if the EKS Cluster Stack was deployed 
     # Using the current IAM entity (user or role) from this script 

--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/README.md
@@ -1,6 +1,6 @@
 
 # Deploy HyperPod Infrastructure using CloudFormation
-🚨 We recommend following the official [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) to deploy clusters, which contains detailed instructions and latest best-practices.
+🚨 We recommend following the official [Amazon SageMaker HyperPod EKS documentation](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) to deploy clusters, which contains detailed instructions and latest best-practices.
 
 As depicted below, the workshop infrastructure can be deployed using a series of nested CloudFormation stacks, each of which is responsible for deploying different aspects of a full HyperPod cluster environment.
 
@@ -365,7 +365,7 @@ Parameter Values Required if Disabled:
 ## How Nested CloudFormation Stacks Work:
 As you can see in the [main-stack.yaml](./nested-stacks/main-stack.yaml) file, the [`AWS::CloudFormation::Stack`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stack.html)resources have a `TemplateURL` property that specifies the [S3 URL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access) pointing to the target CloudFormation template. 
 
-The `TemplateURL` property is configured to reference a regional mapping of S3 buckets, which by default points to an AWS owned S3 bucket which is used to host the CloudFormation templates for the [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration). Again, we recommend following the instruction in the workshop, but we've made the templates available here for your to modify and reuse as necessary to meet your specific needs.
+The `TemplateURL` property is configured to reference a regional mapping of S3 buckets, which by default points to an AWS owned S3 bucket which is used to host the CloudFormation templates for the [Amazon SageMaker HyperPod EKS documentation](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration). Again, we recommend following the instructions in the documentation, but we've made the templates available here for your to modify and reuse as necessary to meet your specific needs.
 
 ## How to Host the Nested CloudFormation Stacks In Your Own S3 Bucket:  
 
@@ -389,5 +389,5 @@ When you deploy the [main-stack.yaml](./nested-stacks/main-stack.yaml) template,
     - `LayerS3Key` - Update this to specify the S3 key for the `layer.zip` file you uploaded to your S3 bucket. 
     - `FunctionS3Key` - Update this to specify the S3 key for the `function.zip` file you uploaded to your S3 bucket. 
 
-See the official [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) for a more detailed explanation of the other parameters used in the nested CloudFormation stacks.
+See the official [Amazon SageMaker HyperPod EKS documentation](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) for a more detailed explanation of the other parameters used in the nested CloudFormation stacks.
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/README.md
@@ -1,6 +1,6 @@
 
 # Deploy HyperPod Infrastructure using CloudFormation
-🚨 We recommend following the official [Amazon SageMaker HyperPod EKS Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US) to deploy clusters, which contains detailed instructions and latest best-practices.
+🚨 We recommend following the official [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) to deploy clusters, which contains detailed instructions and latest best-practices.
 
 As depicted below, the workshop infrastructure can be deployed using a series of nested CloudFormation stacks, each of which is responsible for deploying different aspects of a full HyperPod cluster environment.
 
@@ -365,7 +365,7 @@ Parameter Values Required if Disabled:
 ## How Nested CloudFormation Stacks Work:
 As you can see in the [main-stack.yaml](./nested-stacks/main-stack.yaml) file, the [`AWS::CloudFormation::Stack`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stack.html)resources have a `TemplateURL` property that specifies the [S3 URL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access) pointing to the target CloudFormation template. 
 
-The `TemplateURL` property is configured to reference a regional mapping of S3 buckets, which by default points to an AWS owned S3 bucket which is used to host the CloudFormation templates for the [Amazon SageMaker HyperPod EKS Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US). Again, we recommend following the instruction in the workshop, but we've made the templates available here for your to modify and reuse as necessary to meet your specific needs. 
+The `TemplateURL` property is configured to reference a regional mapping of S3 buckets, which by default points to an AWS owned S3 bucket which is used to host the CloudFormation templates for the [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration). Again, we recommend following the instruction in the workshop, but we've made the templates available here for your to modify and reuse as necessary to meet your specific needs.
 
 ## How to Host the Nested CloudFormation Stacks In Your Own S3 Bucket:  
 
@@ -389,5 +389,5 @@ When you deploy the [main-stack.yaml](./nested-stacks/main-stack.yaml) template,
     - `LayerS3Key` - Update this to specify the S3 key for the `layer.zip` file you uploaded to your S3 bucket. 
     - `FunctionS3Key` - Update this to specify the S3 key for the `function.zip` file you uploaded to your S3 bucket. 
 
-See the official [Amazon SageMaker HyperPod EKS Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US) for a more detailed explanation of the other parameters used in the nested CloudFormation stacks. 
+See the official [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) for a more detailed explanation of the other parameters used in the nested CloudFormation stacks.
 

--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/helm-chart-injector/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/helm-chart-injector/README.md
@@ -16,7 +16,7 @@ The Helm Chart Injector is an AWS Lambda function that can be used as an [`AWS::
     └── lambda_function.py            <-- lambda function code
     └── requirements.txt              <-- lambda function requirements
 ```
-The [Amazon SageMaker HyperPod EKS Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US) maintains a copy of the `layer.zip` and `function.zip` files used to instantiate the Helm Chart Injector in an AWS owned S3 bucket, as configured using the `CustomResourceS3Bucket`, `LayerS3Key`, and `FunctionS3Key` parameters in the [main-stack.yaml](./../nested-stacks/main-stack.yaml) template. However, you can follow the steps below to build your own copy of the dependency files and host them in your own S3 bucket. 
+The [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) maintains a copy of the `layer.zip` and `function.zip` files used to instantiate the Helm Chart Injector in an AWS owned S3 bucket, as configured using the `CustomResourceS3Bucket`, `LayerS3Key`, and `FunctionS3Key` parameters in the [main-stack.yaml](./../nested-stacks/main-stack.yaml) template. However, you can follow the steps below to build your own copy of the dependency files and host them in your own S3 bucket.
 
 ## How to Build the Helm Chart Injector to Host in Your Own S3 Bucket:
 ```bash 

--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/helm-chart-injector/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/helm-chart-injector/README.md
@@ -16,7 +16,7 @@ The Helm Chart Injector is an AWS Lambda function that can be used as an [`AWS::
     └── lambda_function.py            <-- lambda function code
     └── requirements.txt              <-- lambda function requirements
 ```
-The [Amazon SageMaker HyperPod EKS Workshop](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) maintains a copy of the `layer.zip` and `function.zip` files used to instantiate the Helm Chart Injector in an AWS owned S3 bucket, as configured using the `CustomResourceS3Bucket`, `LayerS3Key`, and `FunctionS3Key` parameters in the [main-stack.yaml](./../nested-stacks/main-stack.yaml) template. However, you can follow the steps below to build your own copy of the dependency files and host them in your own S3 bucket.
+The [Amazon SageMaker HyperPod EKS documentation](https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration) maintains a copy of the `layer.zip` and `function.zip` files used to instantiate the Helm Chart Injector in an AWS owned S3 bucket, as configured using the `CustomResourceS3Bucket`, `LayerS3Key`, and `FunctionS3Key` parameters in the [main-stack.yaml](./../nested-stacks/main-stack.yaml) template. However, you can follow the steps below to build your own copy of the dependency files and host them in your own S3 bucket.
 
 ## How to Build the Helm Chart Injector to Host in Your Own S3 Bucket:
 ```bash 


### PR DESCRIPTION
## Purpose

Relates to the deprecation of the Workshop Studio catalog entry for the SageMaker HyperPod
EKS workshop. The workshop content now lives on the hosted documentation site, so the docs
in this repo should point there instead of the stale catalog URL.

Old: `https://catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US`
New: `https://awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration`

## Changes

Updated 5 occurrences of the deprecated workshop "Workshop" reference link across 3 files
under `1.architectures/7.sagemaker-hyperpod-eks/`:

- `README.md` (1 occurrence)
- `cfn-templates/README.md` (3 occurrences)
- `cfn-templates/helm-chart-injector/README.md` (1 occurrence)

Only the human-facing documentation links are changed. The S3 asset keys and the 1-Click-Deploy
`templateURL` that embed the workshop asset ID (`2433d39e-...`) are intentionally left untouched,
because those are functional S3 object paths, not documentation links.

## Test Plan

Documentation-only change; no infrastructure was deployed.

**Environment:**
- AWS Service: N/A (docs-only change)
- Instance type: N/A
- Number of nodes: N/A

**Test commands:**
```bash
# Confirm the deprecated catalog URL no longer appears in the edited docs
grep -rn "catalog.us-east-1.prod.workshops.aws/workshops/2433d39e-ccfe-4c00-9d3d-9917b729258e/en-US" \
  1.architectures/7.sagemaker-hyperpod-eks/README.md \
  1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/README.md \
  1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/helm-chart-injector/README.md

# Confirm the new docs URL is present
grep -rn "awslabs.github.io/ai-on-sagemaker-hyperpod/docs/category/eks-orchestration" \
  1.architectures/7.sagemaker-hyperpod-eks/
```

## Test Results

The first grep returns no matches (deprecated URL fully removed from the three edited files);
the second grep returns the 5 updated links. New links render correctly in the Markdown preview.

## Directory Structure

N/A — this PR updates existing documentation only and does not add or modify a test case.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the expected directory structure. (N/A — docs-only change)