### PR TITLE
feat: kimi-k2 DeepEP v1 + NVSHMEM-over-EFA arm (32-node results) + ep-backend scale limits

### DIFF
--- a/3.test_cases/megatron/megatron-bridge/README.md
+++ b/3.test_cases/megatron/megatron-bridge/README.md
@@ -117,7 +117,7 @@ identical directory layout.
 
 | Model | Directory | Workloads |
 |-------|-----------|--------|
-| [Kimi K2](https://huggingface.co/moonshotai/Kimi-K2-Base) (1.04T MoE, 384 experts) | [`kimi-k2/`](kimi-k2/) | Full-parameter SFT + UCCL-EP vs NCCL dispatcher A/B (32× p6-b300) |
+| [Kimi K2](https://huggingface.co/moonshotai/Kimi-K2-Base) (1.04T MoE, 384 experts) | [`kimi-k2/`](kimi-k2/) | Full-parameter SFT + 3-way dispatcher comparison: NCCL vs DeepEP+UCCL (same-campaign A/B) vs DeepEP+NVSHMEM (32× p6-b300) |
 | [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3) (671B MoE, 256 experts) | [`dsv3/`](dsv3/) | Full-parameter SFT + UCCL-EP vs NCCL dispatcher A/B (32× p6-b300) |
 | [Qwen3-235B-A22B](https://huggingface.co/Qwen/Qwen3-235B-A22B) (235B MoE, 128 experts) | [`qwen3-235b/`](qwen3-235b/) | **3-way** dispatcher comparison: NCCL vs DeepEP+UCCL vs DeepEP+NVSHMEM, EP16/EP32 (8× p6-b300 / B300) |
 | [Qwen3-30B-A3B](https://huggingface.co/Qwen/Qwen3-30B-A3B) (30B MoE, 128 experts) | [`qwen3-30b/`](qwen3-30b/) | Same **3-way** comparison on **8× p5.48xlarge / H100** (the size that fits H100-80GB), EP16/EP32 |
@@ -189,12 +189,14 @@ secondarily on the instance/fabric:
   the host-proxy penalty. Measured: **UCCL −36%** on DSV3 256× B300, and **−34% at 32 nodes /
   −21% at 16 nodes** on Kimi-K2 ([`kimi-k2/benchmarks/RESULTS.md`](kimi-k2/benchmarks/RESULTS.md))
   — the win itself scales with node count.
-- **DeepEP+NVSHMEM is the promising backend to watch.** It is the best DeepEP backend at most
-  8-node points here (both H100 EPs and B300 EP16, where it beats NCCL; UCCL edges it only at
-  B300 EP32 mb=4), and standalone EP micro-benchmarks suggest it is competitive-to-better than
-  UCCL in throughput mode — so it is a strong candidate for the large-scale regime. **Not yet
-  validated at 16–32 nodes** (UCCL is the proven large-scale choice today; NVSHMEM at K2 scale is
-  the top follow-up).
+- **DeepEP+NVSHMEM is validated at K2 scale (32 nodes) and competitive with UCCL.** It is the
+  best DeepEP backend at most 8-node points here (both H100 EPs and B300 EP16, where it beats
+  NCCL; UCCL edges it only at B300 EP32 mb=4), and the 2026-07-14 32-node run on literal Kimi-K2
+  (256× B300, TP8/PP8/EP32) confirmed it at scale: **3.74 s/iter at mb=4+overlap — −35% vs the
+  June NCCL baseline and slightly ahead of the June UCCL number** (cross-campaign comparison;
+  [`kimi-k2/benchmarks/RESULTS.md`](kimi-k2/benchmarks/RESULTS.md)). Both DeepEP transports are
+  now proven large-scale choices on EFA; note the NVSHMEM arm may need `GDRCOPY_DEV=on`
+  (see [`kimi-k2/README.md`](kimi-k2/README.md)).
 - **Fabric is second-order.** DeepEP looked worst on H100 (p5.48xlarge, lower EFA bandwidth
   exposes the host-proxy cost) and better on B300; p5en/newer should help. But it still lost at
   B300 8-node/EP32 — so treat this as **scale-primary, fabric-secondary**.

--- a/3.test_cases/megatron/megatron-bridge/README.md
+++ b/3.test_cases/megatron/megatron-bridge/README.md
@@ -193,10 +193,11 @@ secondarily on the instance/fabric:
   best DeepEP backend at most 8-node points here (both H100 EPs and B300 EP16, where it beats
   NCCL; UCCL edges it only at B300 EP32 mb=4), and the 2026-07-14 32-node run on literal Kimi-K2
   (256× B300, TP8/PP8/EP32) confirmed it at scale: **3.74 s/iter at mb=4+overlap — −35% vs the
-  June NCCL baseline and slightly ahead of the June UCCL number** (cross-campaign comparison;
-  [`kimi-k2/benchmarks/RESULTS.md`](kimi-k2/benchmarks/RESULTS.md)). Both DeepEP transports are
-  now proven large-scale choices on EFA; note the NVSHMEM arm may need `GDRCOPY_DEV=on`
-  (see [`kimi-k2/README.md`](kimi-k2/README.md)).
+  June NCCL baseline and on par with the June UCCL number** (within cross-campaign noise; at
+  mb=4 overlap=off it trails UCCL by ~10% — read the two DeepEP transports as competitive, not
+  ranked; [`kimi-k2/benchmarks/RESULTS.md`](kimi-k2/benchmarks/RESULTS.md)). Both DeepEP
+  transports are now proven large-scale choices on EFA; note the NVSHMEM arm may need
+  `GDRCOPY_DEV=on` (see [`kimi-k2/README.md`](kimi-k2/README.md)).
 - **Fabric is second-order.** DeepEP looked worst on H100 (p5.48xlarge, lower EFA bandwidth
   exposes the host-proxy cost) and better on B300; p5en/newer should help. But it still lost at
   B300 8-node/EP32 — so treat this as **scale-primary, fabric-secondary**.

--- a/3.test_cases/megatron/megatron-bridge/kimi-k2/README.md
+++ b/3.test_cases/megatron/megatron-bridge/kimi-k2/README.md
@@ -1,7 +1,7 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <!-- SPDX-License-Identifier: MIT-0 -->
 
-# Kimi K2 Full-Parameter SFT with Megatron-Bridge + UCCL-EP over EFA
+# Kimi K2 Full-Parameter SFT with Megatron-Bridge + DeepEP-over-EFA dispatchers (UCCL / NVSHMEM)
 
 This test case provides a reproducible recipe for **full-parameter supervised fine-tuning
 (SFT)** of [Kimi K2](https://huggingface.co/moonshotai/Kimi-K2-Base) (Moonshot AI's
@@ -30,6 +30,22 @@ patching Megatron-Core**:
   `import deep_ep` resolves to UCCL's EFA RDMA implementation instead of NVIDIA DeepEP.
 - The result: Megatron-Core's MoE dispatcher calls the same `deep_ep` API symbols it always
   does, but the bytes go over EFA via UCCL + GDRCopy instead of over IB verbs via NVSHMEM.
+
+Since 2026-07 this case also measures a **third arm** on literal Kimi-K2, mirroring the
+[`../qwen3-235b/`](../qwen3-235b/) three-way: **NVIDIA DeepEP v1 over NVSHMEM-libfabric/EFA**
+(the [`deepep-benchmark`](../../../../micro-benchmarks/expert-parallelism/deepep-benchmark)
+build, vendored at [`../deepep/`](../deepep/)). As in the qwen3 case, the arm is selected
+purely by **image** — the Megatron-Core code path is identical:
+
+| Arm | `MOE_DISPATCHER` | Image | all-to-all transport |
+|-----|------------------|-------|----------------------|
+| **NCCL all-to-all** (baseline) | `alltoall` | UCCL image | NCCL all-to-all over EFA |
+| **DeepEP + UCCL** | `deepep` | UCCL image | UCCL EFA-native `deep_ep` |
+| **DeepEP + NVSHMEM** | `deepep` | **NVSHMEM image** | NVIDIA DeepEP v1 over NVSHMEM-libfabric/EFA |
+
+Run instructions for the NVSHMEM arm are in
+[Running the DeepEP+NVSHMEM arm](#running-the-deepepnvshmem-arm-32-node-benchmark); measured
+numbers are in [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).
 
 > **This is a research/validation recipe, not a production-blessed path.** UCCL's `deep_ep`
 > drop-in was originally exercised primarily for vLLM **inference**. The training dispatch +
@@ -182,6 +198,71 @@ KAI gang scheduling (a `PodGroup` with `minMember: 32`, so all 32 nodes start to
 **OPTIONAL** and shipped commented out in the manifest; enable it by uncommenting the relevant
 blocks as documented in `kubernetes/README.md`.
 
+## Running the DeepEP+NVSHMEM arm (32-node benchmark)
+
+The NVSHMEM arm reuses the shared raw-pod launcher [`../run-ab-rawpods.sh`](../run-ab-rawpods.sh)
+with the **NVSHMEM image** (`EP_BACKEND=nvshmem` build of `../Dockerfile`) and
+`ARM_LABEL=deepep-nvshmem` to keep its run dirs distinct from the UCCL arm:
+
+```bash
+cd 3.test_cases/megatron/megatron-bridge
+export CTX=<kubectl-context> NS=kimi-k2-bench
+export IMG=<account>.dkr.ecr.<region>.amazonaws.com/megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13
+export MODEL=kimi-k2 ARM_LABEL=deepep-nvshmem EP_BACKEND=nvshmem
+export TENSOR_PARALLEL=8 PIPELINE_PARALLEL=8 EXPERT_PARALLEL=32   # DP=4 at 256 GPUs
+export GLOBAL_BATCH=256 TRAIN_ITERS=24 SEQ_LEN=4096 MOE_FORCE_BALANCE=on
+export CAMPAIGN_ID=<utc-stamp>-k2-nvshmem-pp8-32n
+
+MICRO_BATCH=4 MOE_A2A_OVERLAP=on  bash run-ab-rawpods.sh deepep 32
+MICRO_BATCH=4 MOE_A2A_OVERLAP=off bash run-ab-rawpods.sh deepep 32
+MICRO_BATCH=1 MOE_A2A_OVERLAP=off bash run-ab-rawpods.sh deepep 32
+```
+
+Validation is the same as the UCCL arm (`../bench/parse-runs.py`: `efa_ok` on every rank,
+`n_steady`, iteration-1 loss matches the other arms) **plus** `nvshmem_ok` — the log must show
+NVSHMEM-over-libfabric init, proving the transport is not silently UCCL or NCCL. The NVSHMEM
+arm writes `STATUS` and then **exits 1 at NVSHMEM finalize** after training completes; that
+exit code is benign — judge the run by `parse-runs.py` gates, not by pod exit status.
+
+### GDRCopy device (`GDRCOPY_DEV=on`)
+
+Kimi-K2's dispatch buffers outgrow NVSHMEM's initial 1 GiB symmetric-heap chunk, so NVSHMEM
+grows the heap dynamically (CUDA-VMM) and must register each new chunk with the
+libfabric/EFA transport — a path that requires **GDRCopy inside the container**. On clusters
+whose nvidia container toolkit does not inject `/dev/gdrdrv` (the `NVIDIA_GDRCOPY=enabled`
+env is silently ignored), every rank dies at init with
+`mem_heap.cpp:1361 ... register_mem_handle failed for remote` after a
+`GDRCopy support not enabled` warning. Fix: launch with `GDRCOPY_DEV=on`, which hostPath-mounts
+the node's `/dev/gdrdrv` into the pods (privileged). The host module must be loaded (a
+`gdrcopy-loader` DaemonSet or the DLAMI does this). No-op for the UCCL/alltoall arms.
+
+### Running without FSx (`STORAGE=hostpath`)
+
+On clusters without FSx Lustre (e.g. local-zone capacity blocks), set `STORAGE=hostpath`
+(optionally `HOSTPATH_ROOT`, default `/mnt/k8s-disks/0/bench-fsx`) and the launcher backs
+`/fsx` with node-local NVMe instead of the `fsx-kimi-k2` PVC. Two consequences:
+
+1. **Per-node staging.** `${STAGE}` (default `/fsx/kimi-k2`) must exist on **every** node
+   *before* launch: the bench entrypoint (`benchmarks/bench_kimi_k2_pretrain.py` →
+   `/fsx/kimi-k2/`), the Kimi-K2 HF config+tokenizer (→ `/fsx/kimi-k2/hf/`; no safetensors
+   needed — the bench uses `load_weights=False` + mock data), **and** a hub-layout cache of
+   `deepseek-ai/DeepSeek-V3` config+tokenizer (→ `/fsx/kimi-k2/hf-cache/hub/models--deepseek-ai--DeepSeek-V3/`)
+   because the DSV3 recipe scaffolding fetches it at config build; export `HF_HUB_OFFLINE=1`
+   (the launcher threads `HF_HOME`/`HF_HUB_OFFLINE` into the pods). A no-resource utility
+   DaemonSet mounting the same hostPath is the practical stager (`kubectl cp`/`exec` loop) and
+   doubles as the log harvester.
+2. **Per-node logs — harvest after every cell.** Each node holds only its own rank's
+   `logs/rank-<r>.log` (rank-0's node also holds `env.txt` + `STATUS`). Before launching the
+   next cell, merge the run tree locally (files are disjoint, so untar-merge is safe):
+
+   ```bash
+   for p in $(kubectl -n $NS get pods -l app=bench-util -o name); do
+     kubectl -n $NS exec ${p#pod/} -- bash -c \
+       "cd /fsx/megatron-bridge-bench && tar cf - ${CAMPAIGN_ID}" | tar xf - -C ./harvest/
+   done
+   python3 ../bench/parse-runs.py ./harvest/${CAMPAIGN_ID} --warmup 4
+   ```
+
 ## Parallelism and memory budget
 
 Starting point for 256 GPUs, adapted from Megatron-Bridge's DeepSeek-V3 32-node recipe
@@ -265,7 +346,7 @@ Model-specific files in **this** directory:
 | `conf/kimi_k2_sft.py` | Megatron-Bridge SFT `ConfigContainer` (mounted at `/workspace/conf` via ConfigMap, launched by `torchrun`) |
 | `kubernetes/` | etcd `Service`/`Deployment` + PyTorchJob template (+ optional KAI `PodGroup`); create the conf ConfigMap, then `envsubst ... \| kubectl apply` to deploy (see `kubernetes/README.md`) |
 | `benchmarks/bench_kimi_k2_pretrain.py` | Literal-K2 (384-expert) dispatcher A/B entrypoint (AutoBridge provider + mock data; launched via `../run-ab-rawpods.sh` with `MODEL=kimi-k2`) |
-| `benchmarks/RESULTS.md` | Measured UCCL-EP vs NCCL A/B on literal K2 (32-node PP8 + 16-node PP4 appendix, loss-equivalence) |
+| `benchmarks/RESULTS.md` | Measured dispatcher results on literal K2: UCCL-EP vs NCCL A/B (2026-06-04, 32-node PP8 + 16-node PP4 appendix, loss-equivalence) + DeepEP+NVSHMEM arm (2026-07-14, 32-node PP8, cross-campaign) |
 
 The MoE dispatcher A/B (NCCL all-to-all vs UCCL DeepEP-over-EFA) that first validated
 this UCCL-over-EFA path is an independent sibling case — see
@@ -279,5 +360,8 @@ this UCCL-over-EFA path is an independent sibling case — see
 - [DeepSeek-V3 recipe](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/deepseek/deepseek_v3.py)
 - [UCCL project](https://github.com/uccl-project/uccl)
 - [Kimi K2 (Moonshot AI)](https://huggingface.co/moonshotai/Kimi-K2-Base)
+- [NVIDIA DeepEP](https://github.com/deepseek-ai/DeepEP) — the v1 NVSHMEM backend used by the third arm
+- DeepEP v1 + NVSHMEM-over-EFA build: [`micro-benchmarks/expert-parallelism/deepep-benchmark`](../../../../micro-benchmarks/expert-parallelism/deepep-benchmark) (vendored at [`../deepep/`](../deepep/))
+- Sibling 3-way cases: [`../qwen3-235b/`](../qwen3-235b/) (B300) and [`../qwen3-30b/`](../qwen3-30b/) (P5/H100) — the NCCL/UCCL/NVSHMEM comparison pattern this arm follows
 - Sibling model case: [`../dsv3/`](../dsv3/) — DeepSeek-V3 256-expert dispatcher A/B (UCCL-EP vs NCCL all-to-all) that validated this environment
 - Sibling case: [`../../megatron-lm`](../../megatron-lm) (EFA/GDRCopy Dockerfile + PyTorchJob template)

--- a/3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md
@@ -55,9 +55,10 @@ every run. Two measurement campaigns feed this table:
 
 - **At mb≥4 — the throughput-efficient operating point — both DeepEP transports win
   decisively on literal K2**: UCCL −34/−35% iteration time in both overlap regimes
-  (same-campaign), NVSHMEM ~−35/−29% (cross-campaign). At the tuned point
-  (mb=4+overlap) NVSHMEM edges the June UCCL number by ~2.4% — within cross-campaign
-  noise; read the two DeepEP transports as **competitive**, not ranked.
+  (same-campaign), NVSHMEM ~−35/−29% (cross-campaign). Between the two DeepEP
+  transports there is **no ranking to read here**: at mb=4+overlap NVSHMEM lands ~2.4%
+  under the June UCCL number (within cross-campaign noise), while at mb=4 no-overlap
+  it trails UCCL by ~10% — call them **competitive**.
 - At **mb=1 no-overlap**, NCCL all-to-all stays fastest — the same unamortized
   per-dispatch-overhead regime seen on DSV3 (~12.6%) and on the K2 16-node run (~12%).
   A tuned run operates at mb≥4, where the DeepEP arms win.

--- a/3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md
@@ -15,42 +15,63 @@ NVSHMEM — is fixed by the image; see the arm table in [`../README.md`](../READ
 everything else (model, mock data, seq 4096, GBS 256, bf16, seed, EFA env,
 `MOE_A2A_OVERLAP` flags) is held fixed within a cell. 24 iterations per run,
 `log_interval=1`; the first 4 iterations (incl. the ~300 s compile) are dropped from
-perf stats. The June campaign measured UCCL vs NCCL same-campaign; the
-[DeepEP+NVSHMEM section](#deepepnvshmem-arm--32-node-pp8-2026-07-14-20260714t0515z-k2-nvshmem-pp8-32n-ue1)
-adds the third arm from a 2026-07-14 campaign (cross-campaign caveat noted there).
+perf stats. The headline table merges two campaigns — NCCL+UCCL (same-campaign A/B,
+2026-06-04) and DeepEP+NVSHMEM (2026-07-14) — with per-column provenance marked there.
 
-- Image: `megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb` (Bridge 0.4.2, Core 0.17.1)
+- UCCL/NCCL image: `megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb` (Bridge 0.4.2, Core 0.17.1)
 - Raw logs (no overwrite, all ranks): `/fsx/megatron-bridge-bench/<campaign>/kimi-k2/<arm>-mb<m>-ovl<on|off>/`
 - Per-run gate: `NET/OFI Selected provider is efa, fabric is efa-direct` on **all** nodes;
   deepep arms additionally show the UCCL-EP proxy registration (high-throughput mode).
 
 ---
 
-## Headline — 32-node PP8 (256× B300), campaign `20260604T083049Z-uccl-ab-pp8-32n-v2`
+## Headline — 32-node PP8 (256× B300), all three arms
 
 Parallelism **TP8 / PP8 / EP32 / DP4** (the canonical layout, same as the published
 DSV3 numbers). Steady-state mean over iters 5–24, zero stalls, EFA active 32/32 in
-every run.
+every run. Two measurement campaigns feed this table:
 
-| cell | UCCL deepep | NCCL alltoall | UCCL delta (iter time) |
-|---|---|---|---|
-| **mb=4, overlap=on** | **3.834 s/iter · 219.1 TF/GPU · 273.5k tok/s** | 5.793 s/iter · 144.8 TF/GPU · 181.0k tok/s | **−33.8%** |
-| **mb=4, overlap=off** | **6.041 s/iter · 138.8 TF/GPU** | 9.303 s/iter · 90.1 TF/GPU | **−35.1%** |
-| **mb=1, overlap=off** | 14.98 s/iter · 56.0 TF/GPU | **12.88 s/iter · 65.1 TF/GPU** | +16.3% (NCCL faster) |
-| mb=1, overlap=on | *not measured* (see coverage note) | *not measured* | — |
+- **¹ NCCL + UCCL**: same-campaign A/B, `20260604T083049Z-uccl-ab-pp8-32n-v2`
+  (2026-06-04, EKS us-west-2, FSx). The UCCL Δ is a rigorous same-campaign delta.
+- **² DeepEP+NVSHMEM**: `20260714T0515Z-k2-nvshmem-pp8-32n-ue1` (2026-07-14, EKS
+  `ml-clusters-shared-us-east-1`, 32× p6-b300 **us-east-1-atl-2a local-zone Capacity
+  Block**, node-local NVMe via `STORAGE=hostpath`, `GDRCOPY_DEV=on` — see
+  [`../README.md`](../README.md)). Image `megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13`
+  (NVSHMEM v3.7.0-0, DeepEP `567632d`, the
+  [`deepep-benchmark`](../../../../../micro-benchmarks/expert-parallelism/deepep-benchmark)
+  NVSHMEM-over-libfabric/EFA build). Same bench entrypoint, layout, GBS, seq, mock
+  data, iters, warmup. **The NVSHMEM Δ is cross-campaign** (different cluster/date/
+  storage) and carries noise the UCCL Δ does not — read it as indicative, not exact.
+
+| cell | NCCL alltoall¹ | DeepEP+UCCL¹ | DeepEP+NVSHMEM² | UCCL Δ¹ | NVSHMEM Δ² |
+|---|---|---|---|---|---|
+| **mb=4, overlap=on** | 5.793 s/iter · 144.8 TF/GPU · 181.0k tok/s | 3.834 s/iter · 219.1 TF/GPU · 273.5k tok/s | **3.742 s/iter · 224.6 TF/GPU · 280.2k tok/s** | **−33.8%** | ~−35.4% |
+| **mb=4, overlap=off** | 9.303 s/iter · 90.1 TF/GPU | **6.041 s/iter · 138.8 TF/GPU** | 6.632 s/iter · 126.4 TF/GPU · 158.1k tok/s | **−35.1%** | ~−28.7% |
+| **mb=1, overlap=off** | **12.88 s/iter · 65.1 TF/GPU** | 14.98 s/iter · 56.0 TF/GPU | 13.538 s/iter · 61.9 TF/GPU · 77.5k tok/s | +16.3% (NCCL faster) | ~+5.1% (NCCL faster) |
+| mb=1, overlap=on | *not measured* (see coverage note) | *not measured* | *not measured* | — | — |
 
 **Takeaways**
 
-- **At mb≥4 — the throughput-efficient operating point for both dispatchers — UCCL-EP
-  wins decisively on literal K2: −34/−35% iteration time in both overlap regimes.**
-  Overlap does not close the gap (it helps both arms; the relative win is unchanged).
-- At **mb=1 no-overlap**, NCCL all-to-all is ~16% faster — the same unamortized
+- **At mb≥4 — the throughput-efficient operating point — both DeepEP transports win
+  decisively on literal K2**: UCCL −34/−35% iteration time in both overlap regimes
+  (same-campaign), NVSHMEM ~−35/−29% (cross-campaign). At the tuned point
+  (mb=4+overlap) NVSHMEM edges the June UCCL number by ~2.4% — within cross-campaign
+  noise; read the two DeepEP transports as **competitive**, not ranked.
+- At **mb=1 no-overlap**, NCCL all-to-all stays fastest — the same unamortized
   per-dispatch-overhead regime seen on DSV3 (~12.6%) and on the K2 16-node run (~12%).
-  A tuned run operates at mb≥4, where UCCL wins.
+  A tuned run operates at mb≥4, where the DeepEP arms win.
 - The mb4+overlap UCCL advantage is **larger at 32-node/PP8 (−34%) than at
   16-node/PP4 (−21%)** (table below). EP width is **identical in both (EP32)** —
   the difference tracks the doubled node count (wider inter-node all-to-all span)
   and deeper pipeline, not expert-parallel width.
+
+**NVSHMEM-arm validity** — every cell: `efa_ok` on all 32 nodes, 0 stalls, `n_steady`
+20/20, `parse-runs.py` transport = **nvshmem** (NVSHMEM-over-libfabric init banner on
+the 8 EP-group leader nodes; no UCCL proxy lines). Iteration-1 `lm loss` 13.43885 /
+13.43207 / 13.43359 (mb4-ovlon / mb4-ovloff / mb1-ovloff); mb4-ovlon matches the June
+arms' 13.438850/13.438960 to 5 significant figures — same numerical work, bf16
+round-off apart. As designed, every NVSHMEM run wrote `STATUS` then exited 1 at
+NVSHMEM finalize (benign; see `../run-ab-rawpods.sh`).
 
 ### Numerical (work) equivalence — confirmed
 
@@ -80,45 +101,6 @@ The 32-node Capacity Block ended at 2026-06-04 ~10:51Z (EC2 reclaims instances
 - The planned same-campaign **DSV3 re-run never started** — DSV3 reference numbers
   remain the separate 2026-06-01 campaign in [`../../dsv3/benchmarks/RESULTS.md`](../../dsv3/benchmarks/RESULTS.md)
   (same image/layout, but not same-campaign apples-to-apples).
-
-## DeepEP+NVSHMEM arm — 32-node PP8 (2026-07-14, `20260714T0515Z-k2-nvshmem-pp8-32n-ue1`)
-
-The third dispatcher arm (see the arm table in [`../README.md`](../README.md)): **NVIDIA
-DeepEP v1 over NVSHMEM-libfabric/EFA** — the
-[`deepep-benchmark`](../../../../../micro-benchmarks/expert-parallelism/deepep-benchmark) build,
-image `megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13` (NVSHMEM v3.7.0-0,
-DeepEP `567632d`). Same bench entrypoint, layout (TP8/PP8/EP32/DP4, 256× B300), GBS 256,
-seq 4096, mock data, 24 iters, warmup 4 as the June campaign.
-
-> **Cross-campaign comparison, not a same-campaign A/B.** The NVSHMEM cells ran on a
-> *different cluster and date* than the June UCCL/NCCL numbers: EKS
-> `ml-clusters-shared-us-east-1`, 32× p6-b300 **us-east-1-atl-2a local-zone Capacity
-> Block**, node-local NVMe (`STORAGE=hostpath`) instead of FSx, `GDRCOPY_DEV=on`
-> (see [`../README.md`](../README.md)). Same image lineage, config, and EFA env, but
-> deltas below carry cross-cluster noise the June UCCL-vs-NCCL deltas do not.
-
-| cell | DeepEP+NVSHMEM (2026-07-14) | UCCL deepep (2026-06-04) | NCCL alltoall (2026-06-04) |
-|---|---|---|---|
-| **mb=4, overlap=on** | **3.742 s/iter · 224.6 TF/GPU · 280.2k tok/s** | 3.834 s/iter · 219.1 TF/GPU · 273.5k tok/s | 5.793 s/iter · 144.8 TF/GPU · 181.0k tok/s |
-| **mb=4, overlap=off** | 6.632 s/iter · 126.4 TF/GPU · 158.1k tok/s | **6.041 s/iter · 138.8 TF/GPU** | 9.303 s/iter · 90.1 TF/GPU |
-| **mb=1, overlap=off** | 13.538 s/iter · 61.9 TF/GPU · 77.5k tok/s | 14.98 s/iter · 56.0 TF/GPU | **12.88 s/iter · 65.1 TF/GPU** |
-
-**What the numbers say** (with the cross-campaign caveat above):
-
-- **NVSHMEM DeepEP is competitive with UCCL on literal K2 at the tuned operating point**:
-  at mb=4+overlap it edges the June UCCL number (−2.4% iter time) and lands −35.4% vs the
-  June NCCL baseline — the same "DeepEP-class dispatchers win decisively at mb≥4" picture.
-- At mb=4 no-overlap NVSHMEM trails UCCL (+9.8%) while still beating NCCL by −28.7%.
-- At mb=1 no-overlap the June ranking holds: NCCL fastest, but NVSHMEM (13.54 s) beats
-  UCCL's June 14.98 s in the unamortized regime.
-
-**Validity** — every cell: `efa_ok` on all 32 nodes (`Selected provider is efa`), 0 stalls,
-`n_steady` 20/20, `parse-runs.py` transport = **nvshmem** (NVSHMEM-over-libfabric init
-banner present on the 8 EP-group leader nodes; no UCCL proxy lines). Iteration-1 `lm loss`
-13.43885 / 13.43207 / 13.43359 (mb4-ovlon / mb4-ovloff / mb1-ovloff); the mb4-ovlon value
-matches the June arms' quoted 13.438850/13.438960 to 5 significant figures — same numerical
-work, bf16 round-off apart. As designed, every NVSHMEM run wrote `STATUS` then exited 1 at
-NVSHMEM finalize (benign; see `../run-ab-rawpods.sh`).
 
 ## Appendix — 16-node PP4 (128× B300), campaign `20260604T051726Z-uccl-ab-pp4-16n-v2`
 

--- a/3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md
@@ -1,7 +1,7 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <!-- SPDX-License-Identifier: MIT-0 -->
 
-# Kimi-K2 (literal 384-expert MoE) — UCCL-EP vs NCCL all-to-all — Benchmark Results
+# Kimi-K2 (literal 384-expert MoE) — EP dispatcher results (NCCL / DeepEP+UCCL / DeepEP+NVSHMEM)
 
 MoE token-dispatcher A/B on **literal Kimi-K2** (`moonshotai/Kimi-K2-Base`: 61 layers,
 384 routed experts, top-8, MLA, 64 attention heads, `n_group=1`, no MTP), built via
@@ -10,10 +10,14 @@ MoE token-dispatcher A/B on **literal Kimi-K2** (`moonshotai/Kimi-K2-Base`: 61 l
 This is the first dispatcher A/B measured on the real K2 architecture.
 
 The only toggle that changes between arms is `MOE_DISPATCHER`
-(`alltoall` → NCCL baseline, `deepep` → UCCL-EP over EFA); everything else (model,
-mock data, seq 4096, GBS 256, bf16, seed, image, EFA env, `MOE_A2A_OVERLAP` flags)
-is held fixed within a cell. 24 iterations per run, `log_interval=1`; the first 4
-iterations (incl. the ~300 s compile) are dropped from perf stats.
+(`alltoall` → NCCL baseline, `deepep` → DeepEP-over-EFA, whose *transport* — UCCL or
+NVSHMEM — is fixed by the image; see the arm table in [`../README.md`](../README.md));
+everything else (model, mock data, seq 4096, GBS 256, bf16, seed, EFA env,
+`MOE_A2A_OVERLAP` flags) is held fixed within a cell. 24 iterations per run,
+`log_interval=1`; the first 4 iterations (incl. the ~300 s compile) are dropped from
+perf stats. The June campaign measured UCCL vs NCCL same-campaign; the
+[DeepEP+NVSHMEM section](#deepepnvshmem-arm--32-node-pp8-2026-07-14-20260714t0515z-k2-nvshmem-pp8-32n-ue1)
+adds the third arm from a 2026-07-14 campaign (cross-campaign caveat noted there).
 
 - Image: `megatron-bridge-uccl:nemo-26.04.01-uccl-0dc87eb` (Bridge 0.4.2, Core 0.17.1)
 - Raw logs (no overwrite, all ranks): `/fsx/megatron-bridge-bench/<campaign>/kimi-k2/<arm>-mb<m>-ovl<on|off>/`
@@ -77,6 +81,45 @@ The 32-node Capacity Block ended at 2026-06-04 ~10:51Z (EC2 reclaims instances
   remain the separate 2026-06-01 campaign in [`../../dsv3/benchmarks/RESULTS.md`](../../dsv3/benchmarks/RESULTS.md)
   (same image/layout, but not same-campaign apples-to-apples).
 
+## DeepEP+NVSHMEM arm — 32-node PP8 (2026-07-14, `20260714T0515Z-k2-nvshmem-pp8-32n-ue1`)
+
+The third dispatcher arm (see the arm table in [`../README.md`](../README.md)): **NVIDIA
+DeepEP v1 over NVSHMEM-libfabric/EFA** — the
+[`deepep-benchmark`](../../../../../micro-benchmarks/expert-parallelism/deepep-benchmark) build,
+image `megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13` (NVSHMEM v3.7.0-0,
+DeepEP `567632d`). Same bench entrypoint, layout (TP8/PP8/EP32/DP4, 256× B300), GBS 256,
+seq 4096, mock data, 24 iters, warmup 4 as the June campaign.
+
+> **Cross-campaign comparison, not a same-campaign A/B.** The NVSHMEM cells ran on a
+> *different cluster and date* than the June UCCL/NCCL numbers: EKS
+> `ml-clusters-shared-us-east-1`, 32× p6-b300 **us-east-1-atl-2a local-zone Capacity
+> Block**, node-local NVMe (`STORAGE=hostpath`) instead of FSx, `GDRCOPY_DEV=on`
+> (see [`../README.md`](../README.md)). Same image lineage, config, and EFA env, but
+> deltas below carry cross-cluster noise the June UCCL-vs-NCCL deltas do not.
+
+| cell | DeepEP+NVSHMEM (2026-07-14) | UCCL deepep (2026-06-04) | NCCL alltoall (2026-06-04) |
+|---|---|---|---|
+| **mb=4, overlap=on** | **3.742 s/iter · 224.6 TF/GPU · 280.2k tok/s** | 3.834 s/iter · 219.1 TF/GPU · 273.5k tok/s | 5.793 s/iter · 144.8 TF/GPU · 181.0k tok/s |
+| **mb=4, overlap=off** | 6.632 s/iter · 126.4 TF/GPU · 158.1k tok/s | **6.041 s/iter · 138.8 TF/GPU** | 9.303 s/iter · 90.1 TF/GPU |
+| **mb=1, overlap=off** | 13.538 s/iter · 61.9 TF/GPU · 77.5k tok/s | 14.98 s/iter · 56.0 TF/GPU | **12.88 s/iter · 65.1 TF/GPU** |
+
+**What the numbers say** (with the cross-campaign caveat above):
+
+- **NVSHMEM DeepEP is competitive with UCCL on literal K2 at the tuned operating point**:
+  at mb=4+overlap it edges the June UCCL number (−2.4% iter time) and lands −35.4% vs the
+  June NCCL baseline — the same "DeepEP-class dispatchers win decisively at mb≥4" picture.
+- At mb=4 no-overlap NVSHMEM trails UCCL (+9.8%) while still beating NCCL by −28.7%.
+- At mb=1 no-overlap the June ranking holds: NCCL fastest, but NVSHMEM (13.54 s) beats
+  UCCL's June 14.98 s in the unamortized regime.
+
+**Validity** — every cell: `efa_ok` on all 32 nodes (`Selected provider is efa`), 0 stalls,
+`n_steady` 20/20, `parse-runs.py` transport = **nvshmem** (NVSHMEM-over-libfabric init
+banner present on the 8 EP-group leader nodes; no UCCL proxy lines). Iteration-1 `lm loss`
+13.43885 / 13.43207 / 13.43359 (mb4-ovlon / mb4-ovloff / mb1-ovloff); the mb4-ovlon value
+matches the June arms' quoted 13.438850/13.438960 to 5 significant figures — same numerical
+work, bf16 round-off apart. As designed, every NVSHMEM run wrote `STATUS` then exited 1 at
+NVSHMEM finalize (benign; see `../run-ab-rawpods.sh`).
+
 ## Appendix — 16-node PP4 (128× B300), campaign `20260604T051726Z-uccl-ab-pp4-16n-v2`
 
 Parallelism **TP8 / PP4 / EP32 / DP2** — *not directly comparable to the PP8 table*
@@ -95,9 +138,10 @@ figures through the 13.44 → 0.03 mock-data collapse).
 ## Reproduce / parse
 
 ```bash
-# launch one cell (see ../../run-ab-rawpods.sh for all knobs)
-MODEL=kimi-k2 ARM=deepep MICRO_BATCH=4 MOE_A2A_OVERLAP=on NNODES=32 \
-  CAMPAIGN_ID=<id> bash ../../run-ab-rawpods.sh
+# launch one cell — the arm (alltoall|deepep) is the POSITIONAL arg, NNODES the second
+# (see ../../run-ab-rawpods.sh for all knobs)
+MODEL=kimi-k2 MICRO_BATCH=4 MOE_A2A_OVERLAP=on \
+  CAMPAIGN_ID=<id> bash ../../run-ab-rawpods.sh deepep 32
 
 # full matrix, serial, one campaign root
 MODELS="kimi-k2" CELLS="4:on 4:off 1:off 1:on" ARMS="deepep alltoall" \

--- a/3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md
+++ b/3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md
@@ -27,8 +27,9 @@ perf stats. The headline table merges two campaigns — NCCL+UCCL (same-campaign
 
 ## Headline — 32-node PP8 (256× B300), all three arms
 
-Parallelism **TP8 / PP8 / EP32 / DP4** (the canonical layout, same as the published
-DSV3 numbers). Steady-state mean over iters 5–24, zero stalls, EFA active 32/32 in
+Parallelism **TP8 / PP8 / EP32 / DP4** — the reference layout shared by all 256-GPU
+dispatcher numbers in this library (chosen for the published DSV3 A/B and reused here
+so cells are comparable across model cases; not a tuned-optimal layout for K2). Steady-state mean over iters 5–24, zero stalls, EFA active 32/32 in
 every run. Two measurement campaigns feed this table:
 
 - **¹ NCCL + UCCL**: same-campaign A/B, `20260604T083049Z-uccl-ab-pp8-32n-v2`

--- a/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
+++ b/3.test_cases/megatron/megatron-bridge/run-ab-rawpods.sh
@@ -63,6 +63,9 @@ RECOMPUTE="${RECOMPUTE:-}"
 # Transport label recorded in env.txt for the 3-way comparison (uccl|nvshmem|"" for the
 # NCCL alltoall arm). Informational only — the actual transport is fixed by the IMG.
 EP_BACKEND="${EP_BACKEND:-}"
+# Staging dir on FSx holds the bench entrypoints + the Kimi-K2 HF config dir (hf/).
+STAGE="${STAGE:-/fsx/kimi-k2}"
+
 # HF hub config/tokenizer access. The qwen3-235b recipe builds its model provider via
 # AutoBridge.from_hf_pretrained(...) (config + tokenizer only; load_weights=False), so it
 # needs either pod egress to huggingface.co OR a pre-staged offline cache. Point HF_HOME at
@@ -70,8 +73,32 @@ EP_BACKEND="${EP_BACKEND:-}"
 HF_HOME="${HF_HOME:-${STAGE}/hf-cache}"
 HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-0}"
 
-# Staging dir on FSx holds the bench entrypoints + the Kimi-K2 HF config dir (hf/).
-STAGE="${STAGE:-/fsx/kimi-k2}"
+# Volume backing /fsx. Default is the FSx Lustre PVC (shared across all nodes). On clusters
+# without FSx (e.g. local-zone capacity blocks), set STORAGE=hostpath to back /fsx with
+# node-local NVMe (HOSTPATH_ROOT). In hostpath mode ${STAGE} must be pre-staged on EVERY
+# node and each node holds only its own rank's logs — harvest with a utility DaemonSet
+# after every cell (see kimi-k2/README.md).
+STORAGE="${STORAGE:-pvc}"
+FSX_PVC="${FSX_PVC:-fsx-kimi-k2}"
+HOSTPATH_ROOT="${HOSTPATH_ROOT:-/mnt/k8s-disks/0/bench-fsx}"
+case "${STORAGE}" in
+  pvc)      FSX_VOLUME_SRC="persistentVolumeClaim: {claimName: ${FSX_PVC}}" ;;
+  hostpath) FSX_VOLUME_SRC="hostPath: {path: ${HOSTPATH_ROOT}, type: DirectoryOrCreate}" ;;
+  *) echo "STORAGE must be 'pvc' or 'hostpath', got '${STORAGE}'" >&2; exit 2 ;;
+esac
+
+# GDRCOPY_DEV=on mounts the host's /dev/gdrdrv into the pod (privileged). Needed for the
+# NVSHMEM arm when its symmetric heap outgrows the init chunk: NVSHMEM's dynamic (CUDA-VMM)
+# heap growth registers chunks over libfabric/EFA via GDRCopy, and on clusters whose nvidia
+# container toolkit does not honor NVIDIA_GDRCOPY=enabled the device is absent in-container
+# and every rank dies at register_mem_handle (mem_heap.cpp:1361). No-op for UCCL/alltoall.
+GDRCOPY_DEV="${GDRCOPY_DEV:-off}"
+GDR_MOUNT_LINE=""; GDR_VOLUME_LINE=""; SECURITY_LINE=""
+if [ "${GDRCOPY_DEV}" = "on" ]; then
+  GDR_MOUNT_LINE='- {name: gdrdrv, mountPath: /dev/gdrdrv}'
+  GDR_VOLUME_LINE='- {name: gdrdrv, hostPath: {path: /dev/gdrdrv, type: CharDevice}}'
+  SECURITY_LINE='securityContext: {privileged: true}'
+fi
 case "${MODEL}" in
   dsv3)       DEFAULT_BENCH="${STAGE}/bench_dsv3_pretrain.py" ;;
   kimi-k2)    DEFAULT_BENCH="${STAGE}/bench_kimi_k2_pretrain.py" ;;
@@ -165,6 +192,7 @@ spec:
           TENSOR_PARALLEL=${TP} PIPELINE_PARALLEL=${PP} EXPERT_PARALLEL=${EP}
           TRAIN_ITERS=${TRAIN_ITERS} GLOBAL_BATCH=${GLOBAL_BATCH} MICRO_BATCH=${MICRO_BATCH} SEQ_LEN=${SEQ_LEN}
           LOSS_PROBE=${LOSS_PROBE} RECOMPUTE=${RECOMPUTE} NUM_LAYERS=${NUM_LAYERS:-} QWEN3_SIZE=${QWEN3_SIZE}
+          HF_HOME=${HF_HOME} HF_HUB_OFFLINE=${HF_HUB_OFFLINE}
           FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_FORK_SAFE=1
           NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=INIT,NET NCCL_SOCKET_IFNAME=^docker,lo,veth ;
           torchrun --nnodes=${NNODES} --nproc_per_node=${GPUS_PER_NODE}
@@ -173,14 +201,17 @@ spec:
       resources:
         requests: {nvidia.com/gpu: ${GPUS_PER_NODE}, vpc.amazonaws.com/efa: ${EFA_PER_NODE}}
         limits:   {nvidia.com/gpu: ${GPUS_PER_NODE}, vpc.amazonaws.com/efa: ${EFA_PER_NODE}}
+      ${SECURITY_LINE}
       volumeMounts:
         - {name: fsx, mountPath: /fsx}
         - {name: shmem, mountPath: /dev/shm}
+        ${GDR_MOUNT_LINE}
   volumes:
     - name: fsx
-      persistentVolumeClaim: {claimName: fsx-kimi-k2}
+      ${FSX_VOLUME_SRC}
     - name: shmem
       emptyDir: {medium: Memory, sizeLimit: 32Gi}
+    ${GDR_VOLUME_LINE}
 EOF
 }
 

--- a/micro-benchmarks/expert-parallelism/ep-backend-comparison/README.md
+++ b/micro-benchmarks/expert-parallelism/ep-backend-comparison/README.md
@@ -2,8 +2,10 @@
 
 Head-to-head MoE dispatch/combine micro-benchmark across three communication backends, run
 at the **same EP world size** on the same GPU nodes (designed for 8× `p6-b300.48xlarge`,
-64 ranks). This directory is the orchestration layer; the benchmarks themselves live in the
-sibling directories.
+64 ranks; also exercised at **32 nodes / 256 ranks** — see
+[Scaling beyond 8 nodes](#scaling-beyond-8-nodes-256-rank-findings) for the hard backend
+limits that appear there). This directory is the orchestration layer; the benchmarks
+themselves live in the sibling directories.
 
 | Config | What it is | Source benchmark |
 |---|---|---|
@@ -56,7 +58,7 @@ If the DeepEP values differ from 4096/7168/8/256, edit the bench args in
 ```bash
 aws sts get-caller-identity                          # confirm the target account
 kubectl config current-context                       # confirm the target cluster
-kubectl get nodes -l node.kubernetes.io/instance-type=p6-b300.48xlarge   # confirm 8 schedulable
+kubectl get nodes -l node.kubernetes.io/instance-type=p6-b300.48xlarge   # confirm $NUM_NODES schedulable
 kubectl get crd mpijobs.kubeflow.org                 # confirm MPI Operator
 ```
 
@@ -128,6 +130,32 @@ date, and any config deltas. Eyeball one real launcher log against the parser be
 Results are recorded per platform: [`RESULTS.md`](RESULTS.md) (B300) and
 [`RESULTS-p5.md`](RESULTS-p5.md) (P5/H100). For other instance types set `INSTANCE_TYPE` and
 `EFA_PER_NODE` accordingly (e.g. `p5.48xlarge` exposes **32** EFA NICs vs **16** on `p6-b300`).
+
+## Scaling beyond 8 nodes (256-rank findings)
+
+The full matrix was pushed to 16 and 32 nodes (128 / 256 ranks) on a 32× `p6-b300` Capacity
+Block on 2026-07-14. **Every DeepEP-class kernel hits a hard implementation limit between
+65 and 256 ranks; only the NCCL reference runs at 256.** Details and the per-limit source
+citations are in [`RESULTS.md`](RESULTS.md) ("32 / 16 nodes" section). Operational notes for
+anyone re-running at scale:
+
+- **HT internode**: DeepEP asserts at >160 ranks (`NUM_MAX_NVL_PEERS 8 × NUM_MAX_RDMA_PEERS 20`,
+  `kernels/configs.cuh`) and its stock combine tuning tables already abort at 16 nodes; UCCL
+  overflows an `int32` buffer bound above 64 ranks. Treat the HT comparison as an
+  **8-nodes-per-EP-domain benchmark** — which matches how training deploys these kernels
+  (EP32/EP64 groups inside a larger world).
+- **Low-latency**: both implementations cap between 64 and 128 ranks (UCCL: compile-time
+  signaling-buffer arena; NVSHMEM/DeepEP: libfabric host-proxy retry exhaustion with moving
+  victims per run).
+- **GDRCopy at scale (NVSHMEM)**: past ~1 GiB of LL buffer, NVSHMEM grows its symmetric heap
+  dynamically and must register each chunk over libfabric via **GDRCopy inside the container**.
+  The manifests set `NVIDIA_GDRCOPY=enabled`, but some clusters' nvidia container toolkit
+  ignores it — if every rank dies at `mem_heap.cpp:1361 register_mem_handle failed` after a
+  `GDRCopy support not enabled` warning, hostPath-mount `/dev/gdrdrv` into the worker
+  (requires `privileged: true`) and ensure the host loads `gdrdrv` (gdrcopy-loader DaemonSet
+  or DLAMI).
+- **NCCL at 32 nodes** works unmodified (`NUM_NODES=32`, `NP=256`); expect matched-size busbw
+  to drop vs 8 nodes (fan-out cost).
 
 ## Caveats
 

--- a/micro-benchmarks/expert-parallelism/ep-backend-comparison/RESULTS.md
+++ b/micro-benchmarks/expert-parallelism/ep-backend-comparison/RESULTS.md
@@ -26,6 +26,51 @@ of the same matrix — and the cross-generation contrast (the winner flips by GP
 > 2-node internode run from it gives dispatch ~92 / combine ~60 GB/s (RDMA), consistent with the
 > table — so it reproduces these results.
 
+## 32 / 16 nodes — 256 / 128 ranks (2026-07-14 scale run)
+
+A 32× `p6-b300.48xlarge` Capacity Block (**us-east-1-atl-2a local zone**, EKS, same images
+as below) was used to push the same matched config past the 8-node primary. Headline:
+**every DeepEP-class kernel hits a hard implementation limit between 65 and 256 ranks —
+at 256 ranks only the NCCL all-to-all reference runs.** The 8-node table below remains the
+canonical 3-way comparison; this section documents the scale envelope.
+
+| Backend / kernel | 128 ranks (16n) | 256 ranks (32n) | Limit (source) |
+|---|---|---|---|
+| NCCL all-to-all | **73.8** matched / 84.0 peak GB/s | **54.7** matched / 74.4 peak GB/s | none observed |
+| NVSHMEM (DeepEP) HT internode | dispatch tunes to **74.7 GB/s** (RDMA); combine aborts in the stock tuning sweep¹ | constructor abort² | ≤160 ranks hard; ≤8 nodes practical |
+| UCCL (UCCL-EP) HT internode | constructor abort³ | constructor abort³ | 64 < cap ≤ 128 ranks |
+| NVSHMEM (DeepEP) low-latency | init traffic abort⁴ | init traffic abort⁴ | 64 < cap ≤ 128 PEs (host-proxy) |
+| UCCL (UCCL-EP) low-latency | buffer-config abort⁵ | buffer-config abort⁵ | 64 < cap ≤ 128 ranks |
+
+¹ `internode.cu:2363` — `num_max_nvl_chunked_recv_tokens / num_rdma_ranks > max(send chunk)`:
+the shipped chunk configs were tuned for ≤8-node EP domains; at 16 RDMA peers the combine
+sweep violates the constraint. Dispatch (74.7 GB/s RDMA, ~143 GB/s NVL) is a valid datapoint.
+² `deep_ep.cpp:158` — `num_ranks <= NUM_MAX_NVL_PEERS(8) × NUM_MAX_RDMA_PEERS(20) = 160 or
+low_latency_mode`. DeepEP v1's HT kernels decompose every rank into `(rdma_rank, nvl_rank)`
+against fixed 8×20 compile-time tables (`kernels/configs.cuh`). The same assert block also
+bounds `num_rdma_bytes <= INT_MAX` for HT — waiting behind the peer cap even if it were raised.
+³ `uccl_ep.cc:431` — HT `num_rdma_bytes` (∝ ranks at matched config) exceeds `INT_MAX`
+somewhere between 64 ranks (8n, June: passes at 93 GB/s) and 128 ranks.
+⁴ NVSHMEM 3.7 libfabric **host-proxy** retry exhaustion: `Max amount of libfabric retries
+reached, -11 (EAGAIN)` in `nvshmemi_process_multisend_rma`, killing ~2 nodes per run with
+**different victims each run** (4 runs: ranks {12,29}, {9,12}, {12}, {6,11}) — a statistical
+fan-out limit of the single proxy thread at ≥128 PEs on EFA, not a bad node and not geometry.
+Registration itself is solvable: the ≥1 GiB LL buffer forces dynamic (CUDA-VMM) heap growth
+whose remote-chunk registration needs **GDRCopy in-container** — on clusters whose toolkit
+ignores `NVIDIA_GDRCOPY=enabled`, hostPath-mount `/dev/gdrdrv` (privileged); a >2 GiB static
+heap is no workaround (exceeds EFA's single-MR registration limit).
+⁵ `ep_config.hpp:279` — LL per-peer signaling buffer (∝ ranks) exceeds the compile-time
+`kAtomicBufferSize` arena at ≥128 ranks.
+
+**Reading.** DeepEP-class dispatchers are engineered for EP domains of ~64–160 ranks —
+matching how training actually deploys them (EP32/EP64 groups inside a larger world; the
+[`kimi-k2`](../../../3.test_cases/megatron/megatron-bridge/kimi-k2/benchmarks/RESULTS.md)
+NVSHMEM arm ran clean on 256 GPUs precisely because its `deep_ep` domains are 32-rank EP
+groups). A *flat* EP domain >64 ranks is already off the map for both low-latency paths on
+EFA, and >160 for HT; NCCL all-to-all is the only working option there. NCCL's per-rank
+busbw at the matched ~56 MiB payload drops 73.8 → 54.7 GB/s from 128 to 256 ranks
+(like-for-like on this cluster; the 8-node 72.5 below is from the June us-west-2 run).
+
 ## 8 nodes — 64 ranks (primary)
 
 | Backend | Mode | Dispatch (GB/s) | Combine (GB/s) |

--- a/micro-benchmarks/expert-parallelism/ep-backend-comparison/RESULTS.md
+++ b/micro-benchmarks/expert-parallelism/ep-backend-comparison/RESULTS.md
@@ -29,16 +29,36 @@ of the same matrix — and the cross-generation contrast (the winner flips by GP
 ## 32 / 16 nodes — 256 / 128 ranks (2026-07-14 scale run)
 
 A 32× `p6-b300.48xlarge` Capacity Block (**us-east-1-atl-2a local zone**, EKS, same images
-as below) was used to push the same matched config past the 8-node primary. Headline:
+as below) was used to sweep the same matched config from 2 to 32 nodes. Headline:
 **every DeepEP-class kernel hits a hard implementation limit between 65 and 256 ranks —
-at 256 ranks only the NCCL all-to-all reference runs.** The 8-node table below remains the
-canonical 3-way comparison; this section documents the scale envelope.
+at 256 ranks only the NCCL all-to-all reference runs.**
+
+**HT internode scaling (like-for-like, this cluster, 2026-07-14).** The matched config
+(`num-experts=256`) is only *runnable* at power-of-2 node counts:
+`tests/test_internode.py:30` asserts `num_experts % num_ranks == 0`, and 256 divides
+16/32/64/128/256 ranks but not the 24/48/96/144/160 of DeepEP's other instantiated
+shapes ({3, 6, 12, 18, 20} nodes — a menu cut for 288-expert models, where those counts
+do divide). Dispatch/combine are the RDMA leg in GB/s:
+
+| nodes | ranks | NVSHMEM (DeepEP) disp / comb | UCCL disp / comb | NCCL matched / peak |
+|---|---|---|---|---|
+| 2 | 16 | **126.6 / 106.4** | 91.9 / 59.6 | 104.9 / 179.6 |
+| 4 | 32 | 97.1 / 95.4 | **102.1 / 95.3** | 94.0 / 116.9 |
+| 8 | 64 | 84.2 / 73.1 | **93.9 / 90.5** | 74.0 / 103.2 |
+| 16 | 128 | 74.7 / tuning abort¹ | constructor abort³ | 73.8 / 84.0 |
+| 32 | 256 | constructor abort² | constructor abort³ | 54.7 / 74.4 |
+
+Two reads: **(a)** the 8-node row reproduces the June `us-west-2` primary table below
+within ~1% on a different cluster (NVSHMEM 84.2/73.1 vs 83.7/72.7; UCCL 93.9/90.5 vs
+93.4/90.7; NCCL 74.0 vs 72.5) — strong cross-cluster reproducibility for these
+benchmarks. **(b)** the winner flips with scale: NVSHMEM leads at 2 nodes, UCCL from
+4 nodes up — per-rank bandwidth decays smoothly for all three as fan-out grows.
+
+**Low-latency kernels** cap between 64 and 128 ranks on both implementations
+(⁴ and ⁵ below); at 256 ranks nothing but NCCL runs:
 
 | Backend / kernel | 128 ranks (16n) | 256 ranks (32n) | Limit (source) |
 |---|---|---|---|
-| NCCL all-to-all | **73.8** matched / 84.0 peak GB/s | **54.7** matched / 74.4 peak GB/s | none observed |
-| NVSHMEM (DeepEP) HT internode | dispatch tunes to **74.7 GB/s** (RDMA); combine aborts in the stock tuning sweep¹ | constructor abort² | ≤160 ranks hard; ≤8 nodes practical |
-| UCCL (UCCL-EP) HT internode | constructor abort³ | constructor abort³ | 64 < cap ≤ 128 ranks |
 | NVSHMEM (DeepEP) low-latency | init traffic abort⁴ | init traffic abort⁴ | 64 < cap ≤ 128 PEs (host-proxy) |
 | UCCL (UCCL-EP) low-latency | buffer-config abort⁵ | buffer-config abort⁵ | 64 < cap ≤ 128 ranks |
 
@@ -68,8 +88,8 @@ matching how training actually deploys them (EP32/EP64 groups inside a larger wo
 NVSHMEM arm ran clean on 256 GPUs precisely because its `deep_ep` domains are 32-rank EP
 groups). A *flat* EP domain >64 ranks is already off the map for both low-latency paths on
 EFA, and >160 for HT; NCCL all-to-all is the only working option there. NCCL's per-rank
-busbw at the matched ~56 MiB payload drops 73.8 → 54.7 GB/s from 128 to 256 ranks
-(like-for-like on this cluster; the 8-node 72.5 below is from the June us-west-2 run).
+busbw at the matched ~56 MiB payload decays smoothly with fan-out across the whole sweep:
+104.9 → 94.0 → 74.0 → 73.8 → 54.7 GB/s over 16 → 256 ranks (like-for-like, this cluster).
 
 ## 8 nodes — 64 ranks (primary)
 

--- a/micro-benchmarks/expert-parallelism/ep-backend-comparison/env_vars.example
+++ b/micro-benchmarks/expert-parallelism/ep-backend-comparison/env_vars.example
@@ -9,8 +9,11 @@
 export INSTANCE_TYPE=p6-b300.48xlarge
 export GPU_PER_NODE=8
 export EFA_PER_NODE=16
+# 8 = primary 3-way comparison. 32 (256 ranks) works for NCCL and the low-latency kernels
+# only — both HT internode paths hit hard caps past 64-160 ranks (see README "Scaling
+# beyond 8 nodes").
 export NUM_NODES=8
-export NP=$((NUM_NODES * GPU_PER_NODE))   # 64 ranks; used by the NCCL baseline
+export NP=$((NUM_NODES * GPU_PER_NODE))   # ranks; used by the NCCL baseline (64 at 8 nodes)
 
 # Per-backend image URIs.
 # NVSHMEM: built from ../deepep-benchmark/deepep.Dockerfile (CUDA 13, sm_90+sm_100).

--- a/micro-benchmarks/expert-parallelism/ep-backend-comparison/nccl-alltoall.yaml
+++ b/micro-benchmarks/expert-parallelism/ep-backend-comparison/nccl-alltoall.yaml
@@ -30,6 +30,10 @@ spec:
           - key: nvidia.com/gpu
             operator: Exists
             effect: NoSchedule
+          - key: workload
+            value: bench
+            operator: Equal
+            effect: NoSchedule
           - key: capacity-reservation
             operator: Exists
             effect: NoSchedule
@@ -70,6 +74,10 @@ spec:
           tolerations:
           - key: nvidia.com/gpu
             operator: Exists
+            effect: NoSchedule
+          - key: workload
+            value: bench
+            operator: Equal
             effect: NoSchedule
           - key: capacity-reservation
             operator: Exists

--- a/micro-benchmarks/expert-parallelism/uccl-ep-benchmark/kubernetes/test-internode.yaml
+++ b/micro-benchmarks/expert-parallelism/uccl-ep-benchmark/kubernetes/test-internode.yaml
@@ -29,6 +29,10 @@ spec:
           - key: nvidia.com/gpu
             operator: Exists
             effect: NoSchedule
+          - key: workload
+            value: bench
+            operator: Equal
+            effect: NoSchedule
           - key: capacity-reservation
             operator: Exists
             effect: NoSchedule
@@ -91,6 +95,10 @@ spec:
           tolerations:
           - key: nvidia.com/gpu
             operator: Exists
+            effect: NoSchedule
+          - key: workload
+            value: bench
+            operator: Equal
             effect: NoSchedule
           - key: capacity-reservation
             operator: Exists

--- a/micro-benchmarks/expert-parallelism/uccl-ep-benchmark/kubernetes/test-intranode.yaml
+++ b/micro-benchmarks/expert-parallelism/uccl-ep-benchmark/kubernetes/test-intranode.yaml
@@ -24,6 +24,10 @@ spec:
           - key: nvidia.com/gpu
             operator: Exists
             effect: NoSchedule
+          - key: workload
+            value: bench
+            operator: Equal
+            effect: NoSchedule
           - key: capacity-reservation
             operator: Exists
             effect: NoSchedule
@@ -76,6 +80,10 @@ spec:
           tolerations:
           - key: nvidia.com/gpu
             operator: Exists
+            effect: NoSchedule
+          - key: workload
+            value: bench
+            operator: Equal
             effect: NoSchedule
           - key: capacity-reservation
             operator: Exists

--- a/micro-benchmarks/expert-parallelism/uccl-ep-benchmark/kubernetes/test-low-latency.yaml
+++ b/micro-benchmarks/expert-parallelism/uccl-ep-benchmark/kubernetes/test-low-latency.yaml
@@ -25,6 +25,10 @@ spec:
           - key: nvidia.com/gpu
             operator: Exists
             effect: NoSchedule
+          - key: workload
+            value: bench
+            operator: Equal
+            effect: NoSchedule
           - key: capacity-reservation
             operator: Exists
             effect: NoSchedule
@@ -78,6 +82,10 @@ spec:
           tolerations:
           - key: nvidia.com/gpu
             operator: Exists
+            effect: NoSchedule
+          - key: workload
+            value: bench
+            operator: Equal
             effect: NoSchedule
           - key: capacity-reservation
             operator: Exists


### PR DESCRIPTION
## Summary

- Adds the **DeepEP v1 + NVSHMEM-over-EFA dispatcher arm** to the `kimi-k2` Megatron-Bridge test case (third arm, mirroring the `qwen3-235b` 3-way pattern) with **measured 32-node results** on literal Kimi-K2 (256× B300, TP8/PP8/EP32) — the parent README's "not yet validated at 16–32 nodes" follow-up is now closed.
- Extends `micro-benchmarks/expert-parallelism/ep-backend-comparison` with a **16/32-node (128/256-rank) scale run**: new NCCL reference numbers plus source-cited documentation of the hard scale limits every DeepEP-class kernel hits past 64–160 ranks.
- Launcher (`run-ab-rawpods.sh`) gains two env-gated, default-off capabilities needed to run on FSx-less local-zone capacity blocks (`STORAGE=hostpath`, `GDRCOPY_DEV=on`) and two bug fixes.

## Changes

### kimi-k2: DeepEP+NVSHMEM arm (`3.test_cases/megatron/megatron-bridge/`)

Measured 2026-07-14 on a 32× `p6-b300.48xlarge` Capacity Block (us-east-1-atl-2a local zone), campaign `20260714T0515Z-k2-nvshmem-pp8-32n-ue1`, image `megatron-bridge-uccl:nemo-26.04.01-deepep-nvshmem-567632d-cu13` (NVSHMEM v3.7.0-0, DeepEP `567632d`, the [`deepep-benchmark`](https://github.com/awslabs/awsome-distributed-ai/tree/main/micro-benchmarks/expert-parallelism/deepep-benchmark) NVSHMEM-over-libfabric/EFA build):

| cell | DeepEP+NVSHMEM (2026-07-14) | UCCL deepep (2026-06-04) | NCCL alltoall (2026-06-04) |
|---|---|---|---|
| mb=4, overlap=on | **3.742 s/iter · 224.6 TF/GPU · 280.2k tok/s** | 3.834 · 219.1 · 273.5k | 5.793 · 144.8 · 181.0k |
| mb=4, overlap=off | 6.632 s/iter · 126.4 TF/GPU | **6.041 · 138.8** | 9.303 · 90.1 |
| mb=1, overlap=off | 13.538 s/iter · 61.9 TF/GPU | 14.98 · 56.0 | **12.88 · 65.1** |

Cross-campaign comparison (different cluster/date/storage than the June UCCL/NCCL A/B) — caveat documented in RESULTS.md. Validity per cell: `Selected provider is efa` on all 32 nodes, 0 stalls, `n_steady` 20/20, `parse-runs.py` transport = nvshmem, iteration-1 loss matches the June arms to 5 significant figures.

- `kimi-k2/README.md`: 3-arm table, NVSHMEM run instructions, `GDRCOPY_DEV` section, "running without FSx (`STORAGE=hostpath`)" section (per-node staging incl. the offline `deepseek-ai/DeepSeek-V3` HF cache the DSV3 recipe scaffolding needs, per-cell harvest loop)
- `kimi-k2/benchmarks/RESULTS.md`: new NVSHMEM section + fixed reproduce block (`ARM` is positional, the old example passed it as env and would not run)
- `README.md` (parent): recommendation bullet updated with the measured 32-node outcome; kimi-k2 models-table row now 3-way

### Launcher (`run-ab-rawpods.sh`) — env-gated, defaults unchanged

- `STORAGE=pvc|hostpath` (+ `FSX_PVC`, `HOSTPATH_ROOT`): the `/fsx` volume source was hard-coded to the `fsx-kimi-k2` PVC; `hostpath` backs it with node-local NVMe for clusters without FSx
- `GDRCOPY_DEV=on`: hostPath-mounts `/dev/gdrdrv` (privileged). NVSHMEM grows its symmetric heap dynamically (CUDA-VMM) once buffers outgrow the 1 GiB init chunk, and registering grown chunks over libfabric/EFA requires GDRCopy **in-container**; on clusters whose nvidia container toolkit ignores `NVIDIA_GDRCOPY=enabled`, every rank dies at `mem_heap.cpp:1361 register_mem_handle failed` without this
- Fix: `set -u` crash on direct invocation (`HF_HOME` default referenced `STAGE` before it was set)
- Fix: `HF_HOME`/`HF_HUB_OFFLINE` were computed but never threaded into the pod env (dead variables)

### ep-backend-comparison: 16/32-node scale run (`micro-benchmarks/expert-parallelism/`)

- `RESULTS.md`: new "32 / 16 nodes — 256 / 128 ranks" section. NCCL alltoall matched-size busbw 73.8 GB/s (128 ranks) / 54.7 GB/s (256 ranks); NVSHMEM HT dispatch tunes to 74.7 GB/s RDMA at 16 nodes. Hard limits (each reproduced ≥2×, source-cited):
  - DeepEP HT: 160-rank cap (`NUM_MAX_NVL_PEERS 8 × NUM_MAX_RDMA_PEERS 20`, `kernels/configs.cuh`); per-node-count template instantiation table; stock combine tuning aborts at 16 RDMA peers (`internode.cu:2363`)
  - UCCL HT: `int32` `num_rdma_bytes` overflow above 64 ranks (`uccl_ep.cc:431`)
  - UCCL LL: `kAtomicBufferSize` signaling-arena overflow at ≥128 ranks (`ep_config.hpp:279`)
  - DeepEP LL over NVSHMEM-libfabric: host-proxy `FI_EAGAIN` retry exhaustion at ≥128 PEs with different victim ranks each run (statistical fan-out limit, not a bad node — verified across 4 runs)
- `README.md`: "Scaling beyond 8 nodes" section (operational guidance incl. the gdrdrv workaround); `env_vars.example` annotated
- Toleration fix: `nccl-alltoall.yaml` and the three `uccl-ep-benchmark` manifests were missing the `workload=bench` toleration the deepep manifests already carry — pods stay `Pending` on tainted B300 pools without it (launcher + worker both patched)

## Test plan

- All three kimi-k2 NVSHMEM cells run end-to-end on real hardware (32× p6-b300) and pass every `parse-runs.py` gate; numbers above are from `index.csv`
- All ep-backend numbers from launcher logs collated with `collect_results.py` and cross-checked against raw logs
- Each documented limit reproduced at least twice; DeepEP/UCCL assert lines quoted verbatim from the shipped sources
- `bash -n run-ab-rawpods.sh` clean; default-path pod rendering unchanged (PVC volume, no privileged, no gdrdrv mount)
- All manifests re-validated as YAML after the toleration patch; relative links in all modified markdown verified to resolve
