### PR TITLE
fix(gpu-cluster-healthcheck): reboot-first remediation guidance; classify Xid 64 as ISOLATE

### DIFF
--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/README.md
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/README.md
@@ -105,7 +105,7 @@ All check results are classified into four severity levels that map directly to 
 |----------|---------|--------|
 | **ISOLATE** | Critical hardware fault confirmed | Drain node, initiate instance replacement |
 | **REBOOT** | Node reboot required to clear error | Drain/cordon node, reboot, re-test |
-| **RESET** | GPU reset may resolve the issue | Attempt GPU reset (`nvidia-smi --gpu-reset`); may require power-cycle |
+| **RESET** | GPU-level error, recoverable without replacement | Reboot the instance. A GPU-level reset (`nvidia-smi --gpu-reset`) requires all GPU processes stopped and does not recover all fault states, so an instance reboot is the reliable path |
 | **MONITOR** | Minor anomaly, not service-affecting | Keep in service, flag for review |
 
 ## Instance Profiles
@@ -144,10 +144,10 @@ Verifies basic GPU driver functionality:
 | RESTART_VM | 151 | REBOOT | RESTART_VM | VM restart required |
 | BOOT_REATTEMPT | 168 | REBOOT | BOOT_REATTEMPT_OR_ENABLE_ECC | Boot reattempt or enable ECC |
 | WORKFLOW_XID_48 | 48 | RESET | WORKFLOW_XID_48 | Workflow-driven; Xid 154 parsing may escalate |
-| DRAM_RETIREMENT | 64 | RESET (A100→REBOOT) | RESET_GPU | DRAM retirement failure; A100 needs reboot |
+| DRAM_RETIREMENT | 64 | ISOLATE | RESET_GPU + CONTACT_SUPPORT | Row-remapping failure; an RMA criterion per [NVIDIA GPU Memory Error Management](https://docs.nvidia.com/deploy/a100-gpu-mem-error-mgmt/index.html) — replace the instance |
 | RESET_GPU | 95 | RESET (A100+MIG_off→REBOOT) | RESET_GPU | GPU reset required; A100 w/o MIG needs reboot |
 | RESET_GPU | 109, 110, 119, 120, 136, 140, 143, 155, 156, 158 | RESET | RESET_GPU | GPU reset or node reboot clears the error |
-| WORKFLOW_NVLINK | 74 | `NVLINK_DEFAULT` | WORKFLOW_NVLINK_ERR | NVLink error; configurable (default: RESET) |
+| WORKFLOW_NVLINK | 74 | `NVLINK_DEFAULT` | WORKFLOW_NVLINK_ERR | NVLink error; configurable (default: REBOOT) |
 | WORKFLOW_NVLINK5 | 144-150 | `NVLINK5_DEFAULT` | WORKFLOW_NVLINK5_ERR | Blackwell NVLink5; configurable (default: MONITOR) |
 | CHECK_UVM | 159 | RESET if UVM in use, else MONITOR | CHECK_UVM | C2C/CHI UVM error; conditional |
 | PSHC_INFO | 162, 163 | MONITOR | PSHC_INFO | PSHC informational |
@@ -159,8 +159,8 @@ Verifies basic GPU driver functionality:
 | CONTACT_SUPPORT | 81, 125, 157 | MONITOR | CONTACT_SUPPORT | Deprecated/unused; escalate to humans if seen |
 
 - **Xid 154 derived action parsing**: Xid 154 lines carry authoritative recovery action text. The check parses for "Node Reboot Required" (→REBOOT), "GPU Reset Required" / "Drain and Reset" / "Drain P2P" (→RESET). Unrecognized or "(None)" stays MONITOR.
-- **Tunables**: `KERNEL_LOG_LINES` (default: 4000), `NVIDIA_LOG_TAIL` (default: 200), `STRICT_PSHC` (default: 0), `NVLINK5_DEFAULT` (default: MONITOR), `NVLINK_DEFAULT` (default: RESET). NVLink tunables accept MONITOR, RESET, or REBOOT.
-- Scans kernel log for SXid (NVSwitch) errors; SXid alongside Xid 74 indicates NVSwitch root cause
+- **Tunables**: `KERNEL_LOG_LINES` (default: 4000), `NVIDIA_LOG_TAIL` (default: 200), `STRICT_PSHC` (default: 0), `NVLINK5_DEFAULT` (default: MONITOR), `NVLINK_DEFAULT` (default: REBOOT). NVLink tunables accept MONITOR, RESET, or REBOOT.
+- Scans kernel log for SXid (NVSwitch) errors; SXid alongside Xid 74 indicates a fabric-level fault (recommend REBOOT)
 - Checks GPU persistence mode status
 - Captures GPU serial numbers and UUIDs to `gpu-uuids.csv` for asset tracking
 
@@ -340,7 +340,7 @@ DCGM diagnostic results include a `warning_level` field per test per GPU:
 | Warning Level | Severity | Action |
 |--------------|----------|--------|
 | 3 | **ISOLATE** | Drain node, initiate instance replacement |
-| 2 | **RESET** | Attempt GPU reset via `nvidia-smi --gpu-reset` |
+| 2 | **RESET** | Reboot the instance (`nvidia-smi --gpu-reset` is often insufficient) |
 | 1 | **MONITOR** | Keep in service, flag for review |
 | 0 | **PASS** | No action required |
 
@@ -498,9 +498,9 @@ Or update Pyxis to v0.20 or newer. The script's default already uses the `docker
 
 Xid severity classification is aligned with the [NVIDIA XID Errors r590](https://docs.nvidia.com/deploy/pdf/XID_Errors.pdf) catalog. The four severity tiers are:
 
-- **ISOLATE** (Xid 54; Xid 165 with `STRICT_PSHC=1`): Critical hardware fault. Drain the node and replace the instance.
-- **REBOOT** (Xid 79, 151, 168; Xid 64 on A100; Xid 95 on A100 w/o MIG): Node reboot required. Reboot and re-test; escalate to replacement if recurring.
-- **RESET** (Xid 48, 109, 110, 119, 120, 136, 140, 143, 155, 156, 158; Xid 64, 95 on non-A100): GPU reset required. Attempt `nvidia-smi --gpu-reset`; may require power-cycle.
+- **ISOLATE** (Xid 54, 64; Xid 165 with `STRICT_PSHC=1`): Critical hardware fault. Drain the node and replace the instance. Xid 64 (row-remapping failure) means the GPU has exhausted its memory self-repair path — an RMA criterion per [NVIDIA GPU Memory Error Management](https://docs.nvidia.com/deploy/a100-gpu-mem-error-mgmt/index.html).
+- **REBOOT** (Xid 79, 151, 168; Xid 95 on A100 w/o MIG): Node reboot required. Reboot and re-test; escalate to replacement if recurring.
+- **RESET** (Xid 48, 109, 110, 119, 120, 136, 140, 143, 155, 156, 158; Xid 95 on non-A100): Recoverable GPU-level error. Reboot the instance; `nvidia-smi --gpu-reset` requires all GPU processes stopped and does not recover all fault states.
 - **MONITOR** (Xid 13, 31, 43, 63, 81, 92, 94, 121, 125, 126, 154, 157, 162-164): Application-level fault or informational. No node action required.
 
 Xid 154 carries authoritative recovery action text — the check parses it for "Node Reboot Required" (→REBOOT) or "GPU Reset Required" / "Drain and Reset" / "Drain P2P" (→RESET).
@@ -531,5 +531,5 @@ GDRCopy enables GPU memory registration for RDMA. If the sanity check fails:
 Disable MIG before running L4 diagnostics:
 ```bash
 sudo nvidia-smi -i 0 -mig 0    # Disable MIG on GPU 0
-sudo nvidia-smi --gpu-reset     # Reset GPUs (requires no running processes)
+sudo reboot                     # Reboot to apply (preferred over nvidia-smi --gpu-reset)
 ```

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/checks/0-nvidia-smi-check.sh
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/checks/0-nvidia-smi-check.sh
@@ -17,7 +17,7 @@ KERNEL_LOG_LINES="${KERNEL_LOG_LINES:-4000}"
 NVIDIA_LOG_TAIL="${NVIDIA_LOG_TAIL:-200}"
 STRICT_PSHC="${STRICT_PSHC:-0}"
 NVLINK5_DEFAULT="${NVLINK5_DEFAULT:-MONITOR}"
-NVLINK_DEFAULT="${NVLINK_DEFAULT:-RESET}"
+NVLINK_DEFAULT="${NVLINK_DEFAULT:-REBOOT}"
 
 # Validate NVLink tunables
 for _var in NVLINK5_DEFAULT NVLINK_DEFAULT; do
@@ -171,13 +171,12 @@ run_check() {
                 # RESET: workflow-driven (Xid 154 parsing may escalate)
                 48)
                     code_severity="RESET"; code_group="WORKFLOW_XID_48" ;;
-                # RESET: DRAM retirement failure (A100 override → REBOOT)
+                # ISOLATE: DRAM retirement / row-remapping failure. The GPU has
+                # exhausted its memory self-repair path, which is an RMA criterion
+                # per NVIDIA GPU Memory Error Management; a reboot may restore
+                # temporary operation but the instance should be replaced.
                 64)
-                    code_severity="RESET"; code_group="DRAM_RETIREMENT_FAILURE"
-                    if [[ "${is_a100}" == true ]]; then
-                        code_severity="REBOOT"
-                    fi
-                    ;;
+                    code_severity="ISOLATE"; code_group="DRAM_RETIREMENT_FAILURE" ;;
                 # RESET: GPU reset required (A100+MIG_off override → REBOOT)
                 95)
                     code_severity="RESET"; code_group="RESET_GPU"
@@ -286,7 +285,7 @@ run_check() {
 
         # SXid alongside Xid 74 suggests NVSwitch root cause
         if [[ -n "${xid_errors}" ]] && echo "${xid_errors}" | sed -nE 's/.*Xid[^)]*\):[[:space:]]*([0-9]+).*/\1/p' | grep -qw '74'; then
-            sxid_msg+="; SXid with Xid 74 indicates likely NVSwitch root cause (recommend RESET)"
+            sxid_msg+="; SXid with Xid 74 indicates a fabric-level fault (recommend REBOOT)"
         fi
 
         check_warn "${CHECK_NAME}" "${sxid_msg}"

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/lib/aggregate-results.py
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/lib/aggregate-results.py
@@ -28,7 +28,7 @@ SEVERITY_PRIORITY = {
 ACTIONS = {
     "ISOLATE": "Drain node from Slurm, initiate instance replacement",
     "REBOOT":  "Drain/cordon node, reboot (scontrol reboot nextstate=resume)",
-    "RESET":   "Attempt GPU reset via nvidia-smi --gpu-reset",
+    "RESET":   "Reboot the instance (nvidia-smi --gpu-reset is often insufficient)",
     "MONITOR": "Keep in service, flag for review",
     "PASS":    "No action required",
 }

--- a/4.validation_and_observability/2.gpu-cluster-healthcheck/lib/parse-dcgm-results.py
+++ b/4.validation_and_observability/2.gpu-cluster-healthcheck/lib/parse-dcgm-results.py
@@ -26,7 +26,7 @@ SEVERITY_MAP = {
 ACTIONS = {
     "ISOLATE": "Drain node from Slurm, initiate instance replacement",
     "REBOOT":  "Drain/cordon node, reboot (scontrol reboot nextstate=resume)",
-    "RESET":   "Attempt GPU reset via nvidia-smi --gpu-reset",
+    "RESET":   "Reboot the instance (nvidia-smi --gpu-reset is often insufficient)",
     "MONITOR": "Keep in service, flag for review",
     "PASS":    "No action required",
 }


### PR DESCRIPTION
## Summary

Aligns the gpu-cluster-healthcheck remediation guidance with NVIDIA's published fault-handling documentation in two ways: Xid 64 is reclassified as a terminal hardware fault, and all RESET-tier action text now recommends an instance reboot rather than `nvidia-smi --gpu-reset`.

### 1. Xid 64 → ISOLATE (was RESET, with an A100→REBOOT override)

Xid 64 (`INFOROM_DRAM_RETIREMENT_FAILURE`) reports a row-remapping **failure**: the GPU attempted to remap a degraded DRAM row and could not (bank already has 8 uncorrectable-error rows remapped, a remap hit an already-remapped row, or 512 total remaps are exhausted; on Blackwell this fires only after HBM channel repair is also exhausted). Per the [NVIDIA GPU Memory Error Management RMA policy](https://docs.nvidia.com/deploy/a100-gpu-mem-error-mgmt/index.html), the row-remapping failure condition is an RMA criterion — the memory self-repair path is exhausted and there is no recovery beyond that point.

The [r590 Xid catalog](https://docs.nvidia.com/deploy/pdf/XID_Errors.pdf) lists the immediate action for Xid 64 as RESET_GPU with investigatory CONTACT_SUPPORT; a reset can restore temporary operation because pending remaps activate on reset. On a cloud instance, however, the operator cannot run the NVIDIA Field Diagnostic or RMA the board — the actionable equivalent of "meets RMA criteria" is draining the node and replacing the instance. Returning the node to service after a reboot would put workloads back on a GPU with exhausted memory repair.

### 2. Reboot-first remediation for the RESET tier

`nvidia-smi --gpu-reset` requires all GPU processes to be stopped, is not uniformly supported across platforms/topologies (see [NVIDIA GPU debug guidelines](https://docs.nvidia.com/deploy/gpu-debug-guidelines/index.html) on reset capabilities and limitations), and does not recover all fault states — in practice an instance reboot is the reliable recovery path and costs little more in a drain/re-test workflow. This PR changes the prescribed action text in the README, `lib/parse-dcgm-results.py`, and `lib/aggregate-results.py`; raises the `NVLINK_DEFAULT` (Xid 74) default from RESET to REBOOT; and updates the SXid+Xid74 co-occurrence message to recommend REBOOT without speculating about NVSwitch root cause (which a node-local check cannot confirm and the operator cannot act on).

The RESET severity tier itself is retained so existing consumers of check output (severity strings in JSON results, `determine-severity.py`, dashboards) are unaffected; only the recommended action changes.

## Changes

- `checks/0-nvidia-smi-check.sh`: Xid 64 → ISOLATE (removes A100 special case); `NVLINK_DEFAULT` default RESET → REBOOT; SXid+74 message wording
- `lib/parse-dcgm-results.py`, `lib/aggregate-results.py`: RESET action string → instance reboot
- `README.md`: severity table, Xid classification table, DCGM warning-level table, troubleshooting tiers, and MIG cheat-sheet updated to match

## Testing

- `bash -n` on the modified check; `python3 -m py_compile` on both libs
- `checks/0-nvidia-smi-check.sh --dry-run` passes
- Classification-table change only — no GPU-hardware validation run was performed for this PR. Verified the new classifications line-by-line against the r590 catalog PDF and the GPU Memory Error Management doc (links above).

## Planned follow-ups (separate PRs, keeping each small)

1. Flag-based ECC health: gate on `remapped_rows.failure`/`remapped_rows.pending` and the SRAM Threshold Exceeded flag instead of legacy `retired_pages.*` fields, which report N/A on Ampere+ GPUs (all instance types in `instance-profiles.conf`)
2. Xid co-occurrence/sequence analysis (r590 `WORKFLOW_XID_48`: 48+63/64 → drain-and-reset; sympathetic-code suppression for 45/159)
3. Throttle-reason monitoring (thermal slowdown / power-brake as fault signals, timestamped bitmask trace)
4. Single-node NVLink collective validation (`all_reduce_perf` over NVLink) to complement DCGM coverage
