### PR TITLE
Grant fsx:DescribeFileSystems to the SageMaker HyperPod execution role

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/sagemaker_iam_role/main.tf
+++ b/1.architectures/5.sagemaker-hyperpod/terraform-modules/hyperpod-slurm-tf/modules/sagemaker_iam_role/main.tf
@@ -37,7 +37,8 @@ data "aws_iam_policy_document" "sagemaker_vpc_policy" {
       "ec2:DescribeSubnets",
       "ec2:DescribeSecurityGroups",
       "ec2:DetachNetworkInterface",
-      "ec2:CreateTags"
+      "ec2:CreateTags",
+      "fsx:DescribeFileSystems"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Purpose

When a HyperPod cluster mounts an EFA-enabled FSx for Lustre filesystem, the lifecycle scripts (`mount_fsx.sh` → `verify_fsx_efa_compatibility()`) and the `configure-efa-fsx-lustre-client` tooling call `fsx:DescribeFileSystems` to check that the filesystem was created with EFA enabled and is in the same AZ as the instance. The execution role generated by the `hyperpod-slurm-tf` `sagemaker_iam_role` module does not grant that permission, so the check fails with an authorization error and EFA configuration is **silently skipped** — Lustre traffic quietly stays on TCP even when EFA is available and correctly configured, with no error surfaced anywhere.

## Changes

- Add `fsx:DescribeFileSystems` to the existing `sagemaker_vpc_policy` statement in `terraform-modules/hyperpod-slurm-tf/modules/sagemaker_iam_role/main.tf`. `fsx:DescribeFileSystems` does not support resource-level scoping in IAM, so it is granted on `resources = ["*"]`, consistent with the other actions already in that statement (e.g. `ec2:CreateTags`).

## Test Plan

**Environment:**
- AWS Service: SageMaker HyperPod (Slurm), FSx for Lustre created with EFA enabled
- Instance type: EFA-capable GPU instances
- Number of nodes: multi-node cluster

**Test commands:**
```bash
terraform validate   # module still validates

# from a cluster node, with the updated execution role:
aws fsx describe-file-systems --file-system-ids <fsx-id>
```

## Test Results

- Before: the FSx describe call from a cluster node fails with an authorization error, `mount_fsx.sh` logs `[WARN] Could not describe FSx filesystem - proceeding without EFA verification`, and EFA configuration is skipped despite the filesystem being EFA-enabled and in the same AZ.
- After: `describe-file-systems` succeeds from the node's role, `verify_fsx_efa_compatibility()` passes, and the EFA client configuration proceeds; Lustre OSS traffic runs over EFA (confirmed via LNet `send_count`/`recv_count` deltas under generated I/O).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`). *(N/A — no dependencies added)*
- [ ] A README is included or updated with prerequisites, instructions, and known issues. *(N/A — one-line IAM policy fix)*
- [ ] New test cases follow the expected directory structure. *(N/A — not a test case)*

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
