### PR TITLE
Aggregate LNet counters across multiple EFA interfaces in mount_fsx.sh

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh
@@ -238,10 +238,11 @@ verify_efa_transport()
         return 1
     fi
 
-    # Capture baseline EFA counters before generating I/O
+    # Capture baseline EFA counters before generating I/O, summed across all
+    # EFA interfaces (multi-EFA instances report one counter line per interface)
     local send_before recv_before
-    send_before=$(lnetctl net show -v --net efa | awk '/send_count:/ {print $2}')
-    recv_before=$(lnetctl net show -v --net efa | awk '/recv_count:/ {print $2}')
+    send_before=$(lnetctl net show -v --net efa | awk '/send_count:/ {sum += $2} END {print sum + 0}')
+    recv_before=$(lnetctl net show -v --net efa | awk '/recv_count:/ {sum += $2} END {print sum + 0}')
 
     echo "[INFO] EFA counters before I/O — send: $send_before, recv: $recv_before"
 
@@ -255,8 +256,8 @@ verify_efa_transport()
 
     # Capture EFA counters after I/O
     local send_after recv_after
-    send_after=$(lnetctl net show -v --net efa | awk '/send_count:/ {print $2}')
-    recv_after=$(lnetctl net show -v --net efa | awk '/recv_count:/ {print $2}')
+    send_after=$(lnetctl net show -v --net efa | awk '/send_count:/ {sum += $2} END {print sum + 0}')
+    recv_after=$(lnetctl net show -v --net efa | awk '/recv_count:/ {sum += $2} END {print sum + 0}')
 
     echo "[INFO] EFA counters after I/O — send: $send_after, recv: $recv_after"
 


### PR DESCRIPTION
## Purpose

Relates to #989, which added the EFA transport verification to `mount_fsx.sh`.

`verify_efa_transport()` reads LNet counters with `awk '/send_count:/ {print $2}'`. `lnetctl net show -v --net efa` prints one `send_count:`/`recv_count:` line **per EFA interface**, so on instances with more than one EFA interface the pipeline emits a newline-separated list of numbers instead of a single integer. The subsequent `[[ "$send_after" -le "$send_before" ]]` comparison then fails with a bash "integer expression expected" error, aborting the verification (and, via the `ERR` trap, the lifecycle script) — on exactly the instance families most likely to use EFA.

## Changes

- Sum the per-interface counters inside `awk` (`{sum += $2} END {print sum + 0}`) for the before/after `send_count` and `recv_count` reads, so the comparison always receives a single integer regardless of how many EFA interfaces the instance exposes. `sum + 0` prints `0` rather than an empty string when no lines match, preserving the existing comparison semantics.

## Test Plan

**Environment:**
- AWS Service: SageMaker HyperPod (Slurm), FSx for Lustre created with EFA enabled
- Instance type: instances with multiple EFA interfaces (p5/p6 families), plus a single-EFA-interface control
- Number of nodes: multi-node cluster

**Test commands:**
```bash
bash -n 1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh

# on an EFA-enabled node with the FSx mount:
lnetctl net show -v --net efa | awk '/send_count:/ {sum += $2} END {print sum + 0}'
```

## Test Results

- Before: on a multi-EFA-interface instance, `verify_efa_transport()` aborts with `integer expression expected` — the awk pipeline emits one value per interface as a newline-separated list.
- After: counters aggregate to a single integer, the sum increases under generated I/O, and the verification passes/fails based on actual EFA traffic as intended. Behavior on single-interface instances is unchanged.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`). *(N/A — no dependencies added)*
- [ ] A README is included or updated with prerequisites, instructions, and known issues. *(N/A — focused bug fix)*
- [ ] New test cases follow the expected directory structure. *(N/A — not a test case)*

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
