### PR TITLE
fix(hyperpod-eks): drop LD_LIBRARY_PATH from helm-chart-installer to fix ssl INIT failure

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/helm-chart-stack.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/helm-chart-stack.yaml
@@ -118,7 +118,6 @@ Resources:
           CHART_PATH: !Ref HelmRepoPath
           NAMESPACE: !Ref Namespace
           RELEASE_NAME: !Ref HelmRelease
-          LD_LIBRARY_PATH: '/opt/python/lib'
       Handler: lambda_function.lambda_handler
       Role: !GetAtt HelmCustomResourceRole.Arn
       Runtime: python3.12


### PR DESCRIPTION

## Purpose

Relates to #1205

Deploying HyperPod on EKS with these templates currently fails at the `helm-chart-installer` custom resource. The Lambda dies at INIT with:

```
cannot import name 'ssl' from 'urllib3.util.ssl_'
```

That `urllib3` message is secondary — what actually fails is loading Python's standard `ssl` module. **Root cause:** the Lambda Layer bundles its own OpenSSL, and the function sets `LD_LIBRARY_PATH=/opt/python/lib`, so `python3.12`'s `_ssl` loads the layer's older `libcrypto` instead of the runtime's and cannot resolve the `OPENSSL_3.3.0` symbol it requires:

```
/opt/python/lib/libcrypto.so.3: version 'OPENSSL_3.3.0' not found
(required by /var/lang/.../_ssl.cpython-312-...so)
```

## Changes

- Remove the `LD_LIBRARY_PATH: '/opt/python/lib'` environment variable from the `helm-chart-installer` Lambda in [`nested-stacks/helm-chart-stack.yaml`](https://github.com/awslabs/awsome-distributed-ai/blob/4f1c49c/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/helm-chart-stack.yaml#L121). One-line deletion; no other files changed.

Removing the env var lets `_ssl` bind to the runtime's OpenSSL. The layer's bundled `git` / `helm` / `kubectl` do not depend on this variable and continue to work. The Layer and function zips are unchanged — only the template's env var is removed.

## Test Plan

Reproduced the INIT import in the actual Lambda `python3.12` runtime image using this repo's real function + layer artifacts, with `LD_LIBRARY_PATH` set (before) and removed (after).

**Environment:**
- AWS Service: AWS Lambda (`helm-chart-installer` custom resource), HyperPod on EKS
- Runtime image: `public.ecr.aws/lambda/python:3.12` (x86_64)
- Number of nodes: n/a (Lambda INIT reproduction)

**Test commands:**
```bash
# real layer + function zips mounted into the actual Lambda python3.12 runtime image
# before: LD_LIBRARY_PATH=/opt/python/lib set   -> import fails
# after : LD_LIBRARY_PATH unset                 -> import succeeds
python3 -c "import lambda_function; import urllib3.util.ssl_ as s; print('ssl ok:', hasattr(s,'ssl'))"
```

## Test Results

- **Before (with `LD_LIBRARY_PATH`):** `ImportError: cannot import name 'ssl' from 'urllib3.util.ssl_'` (underlying loader error `libcrypto.so.3: version 'OPENSSL_3.3.0' not found`).
- **After (env var removed):** the handler module imports cleanly, `urllib3.util.ssl_` has a working `ssl`, and the Lambda reaches SUCCESS with the Helm chart installed.
- **Confirmed end-to-end in a real deployment:** with this change applied, a HyperPod-on-EKS deployment that was previously failing at this step proceeded past the `helm-chart-installer` and the cluster came up successfully.

Note on provenance: git history does not reveal why `LD_LIBRARY_PATH` was originally added (the template was re-introduced wholesale during a repo reorg, so its origin predates the current history). However, removing it is safe in practice — the layer's bundled `git` / `helm` / `kubectl` keep working without it, the handler reaches SUCCESS, and a full cluster deployment has been verified as noted above.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained.
- [x] No external dependency versions are changed by this PR.
- [ ] A README is included or updated — n/a (one-line bug fix to an existing template; no new test case).
- [ ] New test cases follow the expected directory structure — n/a (no new test case).
