### PR TITLE
Order FSx automount after configure-efa-fsx-lustre-client.service when EFA is configured

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh
@@ -178,6 +178,26 @@ mount_fs() {
     echo "[INFO] Mounting FSx Lustre on $MOUNT_POINT..."
     echo "[INFO] Using test file: $test_file"
 
+    # Build the mount options. When EFA was configured for this client
+    # (configure_efa_lustre set EFA_CONFIGURED=true), order the automount
+    # *after* configure-efa-fsx-lustre-client.service so the mount does not
+    # race ahead of EFA/LNet setup on reboot.
+    #
+    # We use x-systemd.after= (ordering only), NOT x-systemd.requires=, on
+    # purpose:
+    #   - requires= would fail the mount outright if the EFA config service
+    #     fails, losing the safe TCP fallback the client otherwise keeps;
+    #   - requires= also pulls the service in even when an operator has
+    #     deliberately disabled it (e.g. running EFA-off as a mitigation),
+    #     which would fight that operational choice.
+    # after= gives the correct ordering when EFA is on, is a no-op when the
+    # service is disabled/masked, and preserves TCP fallback if config fails.
+    local mount_opts="noatime,flock,_netdev,x-systemd.automount,x-systemd.requires=network-online.target"
+    if [[ "$EFA_CONFIGURED" == "true" ]]; then
+        mount_opts="${mount_opts},x-systemd.after=configure-efa-fsx-lustre-client.service"
+        echo "[INFO] EFA configured — ordering the FSx automount after configure-efa-fsx-lustre-client.service"
+    fi
+
     while (( attempt <= max_attempts )); do
         echo "============================"
         echo "[INFO] Attempt $attempt of $max_attempts"
@@ -185,7 +205,7 @@ mount_fs() {
 
         echo "[STEP] Mounting FSx..."
         if ! ansible localhost -b -m ansible.posix.mount -a \
-            "path=$MOUNT_POINT src=$FSX_DNS_NAME@tcp:/$FSX_MOUNTNAME fstype=lustre opts=noatime,flock,_netdev,x-systemd.automount,x-systemd.requires=network-online.target dump=0 passno=0 state=mounted"; then
+            "path=$MOUNT_POINT src=$FSX_DNS_NAME@tcp:/$FSX_MOUNTNAME fstype=lustre opts=$mount_opts dump=0 passno=0 state=mounted"; then
             echo "[WARN] Mount command failed — retrying in $delay seconds"
             sleep "$delay"; ((attempt++)); continue
         fi


### PR DESCRIPTION
## Purpose

`mount_fs()` in `mount_fsx.sh` mounts FSx for Lustre with `x-systemd.automount` ordered only on `network-online.target`. When EFA is configured for the client (via `configure_efa_lustre()` → `configure-efa-fsx-lustre-client.service`), the automount can fire **before** that service finishes setting up the EFA LNet transport. The filesystem then comes up over TCP even on a node where EFA was meant to be active, with no visible error.

This gap was surfaced by the SageMaker support team while triaging a HyperPod + EFA-enabled FSx for Lustre incident: nodes did not always come back cleanly on reboot, and the automount had no ordering dependency on the EFA client configuration. The FSx documentation for EFA-enabled filesystems does recommend adding such a dependency ([mount-fs-auto-mount-onreboot](https://docs.aws.amazon.com/fsx/latest/LustreGuide/mount-fs-auto-mount-onreboot.html)).

## Changes

- In `mount_fs()`, build the mount options into a variable and, **only when `EFA_CONFIGURED=true`**, append `x-systemd.after=configure-efa-fsx-lustre-client.service`.
- Non-EFA mounts are unchanged (backward-compatible).

### Why `after=` and not `requires=`

The FSx docs suggest `x-systemd.requires=configure-efa-fsx-lustre-client.service`. This PR deliberately uses `x-systemd.after=` (ordering only) instead, because `requires=`:

- **fails the mount outright if the EFA config service fails** — losing the safe TCP fallback the Lustre client otherwise keeps (a degraded-but-working node becomes a node with no filesystem); and
- **pulls the service in even when an operator has deliberately disabled it** — e.g. when running EFA-off as a mitigation for an EFA-side issue, a `requires=` dependency would try to start the disabled service back up, fighting that operational choice.

`after=` gives the correct ordering when EFA is on, is a no-op when the service is disabled/masked, and preserves TCP fallback if configuration fails. To turn EFA off operationally, disable (or mask) `configure-efa-fsx-lustre-client.service`; the mount still succeeds over TCP.

## Relationship to #1204

Complementary, non-overlapping. #1204 hardens the **service side** (retries the IMDS query so `configure-efa-fsx-lustre-client.service` doesn't fail on a boot-time IMDS race). This PR fixes the **mount side** (orders the automount after that service so it doesn't race ahead of EFA setup). Together they make reboot recovery behave like a fresh lifecycle run for FSx+EFA nodes. Neither depends on the other; they touch different parts of `mount_fsx.sh` and can merge in either order.

## Test Plan

**Environment:** SageMaker HyperPod (Slurm), FSx for Lustre created with EFA enabled; EFA-capable GPU instances.

**Commands:**
```bash
bash -n 1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh

# on a node after boot, with EFA configured:
systemctl show -p After fsx.mount | tr ' ' '\n' | grep configure-efa   # ordering present
systemd-analyze verify fsx.mount 2>&1 || true
# reboot and confirm the mount comes up over EFA (LNet efa net present,
# send/recv counters move under I/O) rather than silently on TCP.
```

**Results so far:**
- `bash -n` passes.
- opts-building logic verified both ways: non-EFA produces the original option string unchanged; `EFA_CONFIGURED=true` appends `x-systemd.after=configure-efa-fsx-lustre-client.service`.
- **Done — full on-node reboot verification on an EFA-enabled HyperPod Slurm cluster (ml.g6.16xlarge worker, EFA-enabled PERSISTENT_2 FSx, this branch’s lifecycle scripts unmodified): after reboot the automount fired during EFA setup and the `x-systemd.after=` ordering held the mount until the service finished; the mount came up with an `@efa` NID and EFA LNet counters moving under direct I/O. Backward compat also verified: with `configure-efa-fsx-lustre-client.service` masked, reboot → mount succeeds immediately over TCP (tcp-only NIDs). Full logs: [verification comment](https://github.com/awslabs/awsome-distributed-ai/pull/1208#issuecomment-5141554911).**

## Credit

Thanks to the SageMaker support engineer who flagged the missing automount → EFA-config ordering dependency during incident triage.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate (nearest is #1204, which is complementary and touches the service side, not the mount options).
- [x] The contribution is self-contained.
- [ ] External dependencies are pinned. *(N/A — no new dependencies)*
- [ ] A README is included or updated. *(N/A — focused ordering fix)*
- [ ] New test cases follow the expected directory structure. *(N/A — not a test case)*

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

