### PR TITLE
fix: grant fsx:DescribeFileSystems in Slurm/EKS CFN, JSON, and EKS Terraform (follow-up to #1202)

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/1.AmazonSageMakerClustersExecutionRolePolicy.json
+++ b/1.architectures/5.sagemaker-hyperpod/1.AmazonSageMakerClustersExecutionRolePolicy.json
@@ -87,6 +87,14 @@
             "Resource": [
                 "arn:aws:ec2:*:*:network-interface/*"
             ]
+        },
+        {
+            "Sid": "FSxDescribeForEfaVerification",
+            "Effect": "Allow",
+            "Action": [
+                "fsx:DescribeFileSystems"
+            ],
+            "Resource": "*"
         }
     ]
 }

--- a/1.architectures/5.sagemaker-hyperpod/2.SageMakerVPC.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/2.SageMakerVPC.yaml
@@ -509,7 +509,8 @@ Resources:
                     "ec2:DescribeSubnets",
                     "ec2:DescribeSecurityGroups",
                     "ec2:DetachNetworkInterface",
-                    "ec2:CreateTags"
+                    "ec2:CreateTags",
+                    "fsx:DescribeFileSystems"
                 ]
                 Resource: "*"
   LCScriptsBucket:

--- a/1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml
@@ -531,7 +531,8 @@ Resources:
                     "ec2:DescribeSubnets",
                     "ec2:DescribeSecurityGroups",
                     "ec2:DetachNetworkInterface",
-                    "ec2:CreateTags"
+                    "ec2:CreateTags",
+                    "fsx:DescribeFileSystems"
                 ]
                 Resource: "*"
   LCScriptsBucket:

--- a/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/sagemaker-iam-role-stack.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/sagemaker-iam-role-stack.yaml
@@ -56,6 +56,7 @@ Resources:
                   - 'ecr:GetDownloadUrlForLayer'
                   - 'eks-auth:AssumeRoleForPodIdentity'
                   - 'cloudwatch:DescribeAlarms'
+                  - 'fsx:DescribeFileSystems'
                 Resource: '*'
               - Effect: Allow
                 Action: 

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/sagemaker_iam_role/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/sagemaker_iam_role/main.tf
@@ -110,7 +110,8 @@ resource "aws_iam_policy" "sagemaker_execution_policy" {
           "ec2:DescribeVpcs",
           "ec2:DescribeDhcpOptions",
           "ec2:DescribeSecurityGroups",
-          "ec2:DetachNetworkInterface"
+          "ec2:DetachNetworkInterface",
+          "fsx:DescribeFileSystems"
         ]
         Resource = "*"
 


### PR DESCRIPTION
#1202 fixed the missing `fsx:DescribeFileSystems` permission on the SageMaker HyperPod execution role, **but only in the Slurm Terraform module** (`terraform-modules/hyperpod-slurm-tf/modules/sagemaker_iam_role/main.tf`). The same execution role is defined independently in five other places in this repo, and none of them grant `fsx:DescribeFileSystems`. As a result, users deploying with any of the following paths still hit the same silent failure #1202 describes:

- README/manual `aws iam create-policy` flow that consumes `1.AmazonSageMakerClustersExecutionRolePolicy.json`
- `automate-smhp-slurm/automate-cluster-creation.sh` multi-headnode path (which also attaches that JSON)
- Slurm main CFN stack (`sagemaker-hyperpod.yaml`)
- Slurm VPC-only CFN stack (`2.SageMakerVPC.yaml`)
- EKS nested-stack CFN (`cfn-templates/nested-stacks/sagemaker-iam-role-stack.yaml`)
- EKS Terraform module (`terraform-modules/hyperpod-eks-tf/modules/sagemaker_iam_role/main.tf`)

The lifecycle script `LifecycleScripts/base-config/mount_fsx.sh` calls `aws fsx describe-file-systems` in `verify_fsx_efa_compatibility()` to determine whether the FSx filesystem is EFA-enabled and in the same AZ. Without the IAM permission the call returns an authorization error, the function returns early with `[WARN] Could not describe FSx filesystem - proceeding without EFA verification`, and EFA configuration is silently skipped — Lustre traffic then stays on TCP even when EFA is available. The failure surfaces nowhere except as unexplained low FSx throughput.

The AWS managed policy `AmazonSageMakerClusterInstanceRolePolicy` (attached in every role definition above) does not include `fsx:DescribeFileSystems`, so it must be granted explicitly.

## Changes

Adds `fsx:DescribeFileSystems` on `Resource: "*"` in the five remaining role-definition locations:

1. `1.architectures/5.sagemaker-hyperpod/1.AmazonSageMakerClustersExecutionRolePolicy.json` — new `FSxDescribeForEfaVerification` statement.
2. `1.architectures/5.sagemaker-hyperpod/sagemaker-hyperpod.yaml` — appended to the existing `AmazonSagemakerClusterVPCPolicy` action list.
3. `1.architectures/5.sagemaker-hyperpod/2.SageMakerVPC.yaml` — same edit as (2).
4. `1.architectures/7.sagemaker-hyperpod-eks/cfn-templates/nested-stacks/sagemaker-iam-role-stack.yaml` — appended to the wildcard-Resource statement of the inline `ExecutionRolePolicy`.
5. `1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/sagemaker_iam_role/main.tf` — appended to the second (wildcard-Resource) statement of `aws_iam_policy.sagemaker_execution_policy`.

`fsx:DescribeFileSystems` does not support resource-level scoping in IAM, so `Resource: "*"` is used everywhere — consistent with #1202 and with the other actions (`ec2:DescribeVpcs`, `ec2:DescribeDhcpOptions`, `cloudwatch:DescribeAlarms`, etc.) already granted in these same statements.

The multi-headnode template `sagemaker-hyperpod-slurm-multi-headnode.yaml` is intentionally not modified — its `SlurmExecutionRole` does not carry the FSx/VPC block; the JSON in (1) is attached to it at runtime by `automate-cluster-creation.sh`, so fixing (1) transitively covers that path.
## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:
- Instance type:
- Number of nodes:

**Test commands:**
```bash

```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
