### PR TITLE
Slurm HMA CloudWatch bridge + widen EventBridge rule

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/IDEAS.md
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/IDEAS.md
@@ -3,6 +3,14 @@
 Enhancement ideas beyond the current solution. None are built yet; each notes
 what it would take and the main constraint to check first.
 
+## Shipped
+
+- **HMA CloudWatch bridge (Slurm)** — subscription-filter → tiny Lambda →
+  `events:PutEvents` synthetic Warn. Closes the Slurm-side gap where HyperPod
+  does not natively emit HMA-attribution EventBridge events. Slurm-only,
+  gated by `EnableHmaCloudWatchBridge` (auto-set by `make deploy`). See
+  [IMPLEMENTATION.md > HMA CloudWatch bridge](IMPLEMENTATION.md#hma-cloudwatch-bridge-slurm-only).
+
 ## Weekly digest for GPU-utilization + FinOps signals
 
 Absolute-utilization thresholds (e.g. "average <80% over 7d") don't work as

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/IMPLEMENTATION.md
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/IMPLEMENTATION.md
@@ -26,8 +26,9 @@ custom resources for the two gaps CloudFormation can't cover natively:
 | **Foundation** | `AWS::IAM::Role` (Agent Space monitor role + Webapp role), `AWS::DevOpsAgent::AgentSpace` (with IAM operator app), `AWS::DevOpsAgent::Association` (AWS-monitor, topology discovery). |
 | **EKS access** (EKS only) | `AWS::EKS::AccessEntry` granting the Agent Space role read-only `AmazonAIOpsAssistantPolicy` (cluster scope). Skipped for Slurm. |
 | **Webhook** | `AWS::SecretsManager::Secret` + `Custom::WebhookProvisioner` — registers/associates the eventChannel and stashes the once-shown URL+HMAC secret. (No native `eventChannel` ServiceType, and the URL/secret aren't exposed via `Fn::GetAtt`, so a custom resource is required.) |
-| **Webhook bridge** | Lambda + EventBridge rule (`source: aws.sagemaker`, the 3 HyperPod detail-types) → HMAC-signed POST to the webhook. |
+| **Webhook bridge** | Lambda + EventBridge rule (`source: aws.sagemaker` or `hyperpod-devops-agent-hma-cw-bridge`; `detail-type` is the three HyperPod detail-types plus a `SageMaker HyperPod` prefix catch-all) → HMAC-signed POST to the webhook. |
 | **Periodic audit** | Lambda + `AWS::Scheduler::Schedule` (15 min) + daily heartbeat schedule. Detects Kubernetes CrashLoop/NotReady (EKS) and fires only on a real issue; heartbeat-only on Slurm. |
+| **HMA CloudWatch bridge** (Slurm only) | Lambda + `AWS::Logs::SubscriptionFilter` on the cluster's log group → `events:PutEvents` a synthetic `SageMaker HyperPod Cluster Event Warn`. Closes the Slurm-specific gap where HyperPod's control plane does not emit HMA-attribution events natively (see [dedicated section](#hma-cloudwatch-bridge-slurm-only)). |
 | **Email notifier** | Lambda + EventBridge rule (`source: aws.aidevops`, scoped to this Agent Space) + S3 dedup-marker bucket → SES email. |
 | **Skills** | `Custom::SkillUploader` uploads the triage + RCA skills (and any staged upstream skills) from the S3 assets bucket. |
 
@@ -345,6 +346,50 @@ Three channels stack:
 3. **Slack / ServiceNow / PagerDuty / Microsoft Teams** — configure once in the
    Agent Space console. The same `aws.aidevops` event stream the email notifier
    listens on is available for any additional fan-out.
+
+Note on Monitor re-checks: the RCA skill emits verdict text like "next re-check
+in 30 min" for `Monitor` chains, but there is no dedicated re-check timer. Those
+re-checks ride on the next HyperPod EventBridge event for the same instance
+group (a state-change, a replacement completion, an escalation) — the triage
+skill links it, the RCA skill sees the updated cluster state, and the verdict is
+recomputed. A control-plane `Monitor` chain on a Slurm cluster that emits no
+follow-up event will be re-checked at the next daily heartbeat run instead.
+
+## HMA CloudWatch bridge (Slurm only)
+
+**Why**: EKS-orchestrated HyperPod clusters emit a `Warn`-level `Cluster Event`
+on EventBridge whenever HMA detects a GPU fault. Slurm-orchestrated clusters
+do not emit that event today — HMA still writes to CloudWatch Logs and
+HyperPod still initiates replacement, but no operator-visible EventBridge event
+is produced, so the DevOps Agent pipeline never runs.
+
+**Approach**: On Slurm deployments, a `AWS::Logs::SubscriptionFilter` on the
+cluster's log group with FilterPattern
+`{ $.HealthMonitoringAgentDetectionEvent = "HealthEvent" }` invokes a small
+Lambda (`hma_cw_bridge`). It parses the HMA JSON record, extracts fault type +
+repair action + instance ID, and calls `events:PutEvents` with a synthetic
+`SageMaker HyperPod Cluster Event Warn` shaped identically to the native EKS
+event. The existing webhook bridge picks it up unchanged.
+
+**Why not alternatives**: polling HMA CloudWatch every 15 min from the periodic
+audit would add 0–15 min latency to a fault path that HyperPod handles in
+minutes. A CloudWatch metric filter with an alarm would be per-threshold, not
+per-event, and would lose the per-fault detail needed by the RCA skill.
+
+**Gating**: `deploy.sh` auto-resolves `EnableHmaCloudWatchBridge=true` for
+Slurm and `false` for EKS. Deploying on EKS with `true` would produce duplicate
+investigations (native event + synthesized twin); the triage skill's LINK
+dedup would mitigate but the extra work is wasted. Override in `params.json`
+only if you have a specific reason.
+
+**Failure semantics**: the CloudWatch Logs → Lambda invocation is async. If
+the Lambda errors, CloudWatch retries by default. If `events:PutEvents`
+throttles, the Lambda retries once before returning. A permanent failure
+(e.g., malformed HMA record) is logged as a structured JSON `WARN` event and
+that single record is skipped — subsequent records in the same batch still
+process. The workaround is an additive path; disabling it (set
+`EnableHmaCloudWatchBridge=false` and redeploy) cleanly deletes all four new
+CFN resources.
 
 ## DevOps Agent integration surfaces
 

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/README.md
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/README.md
@@ -420,6 +420,44 @@ is enabled. On a Continuous Slurm cluster, a capacity-error fault is caught and
 notified via the bridge with a specific "What happened" email subject; the audit
 stays out of it and the heartbeat fires as expected.
 
+### HMA CloudWatch bridge (Slurm-only workaround)
+
+On EKS-orchestrated HyperPod clusters the control plane emits a `Warn`-level
+`SageMaker HyperPod Cluster Event` on EventBridge whenever HMA detects a GPU
+fault (e.g. `NvidiaGPUUnhealthy` / Xid errors / ECC DBE). That flows through the
+webhook bridge into DevOps Agent, produces an investigation, and delivers an
+email — no extra wiring needed.
+
+On **Slurm-orchestrated** HyperPod clusters, the control plane does not
+currently emit that Warn event for HMA-attributed faults today. HMA still
+writes its detection JSON to the cluster's CloudWatch log group
+(`/aws/sagemaker/Clusters/<name>/<id>` under
+`SagemakerHealthMonitoringAgent/<group>/<instance>` streams), and HyperPod
+still initiates node replacement — but no operator-visible EventBridge event
+is produced, so the DevOps Agent pipeline never runs for HMA-origin faults on
+Slurm.
+
+This solution ships a Slurm-only workaround: a CloudWatch Logs subscription
+filter on the cluster's log group, plus a tiny `hma_cw_bridge` Lambda that
+parses the HMA JSON record and calls `events:PutEvents` with a synthetic
+`SageMaker HyperPod Cluster Event Warn` shaped exactly like the native EKS
+event. The existing webhook bridge Lambda picks it up unchanged.
+
+`make deploy` auto-enables the workaround for Slurm clusters and disables it
+for EKS (where it would produce duplicate investigations for the same fault).
+Override via `params.json` if you have a specific reason:
+
+```json
+"__off_EnableHmaCloudWatchBridge": "false",
+"__off_HmaLogGroupName": "/aws/sagemaker/Clusters/my-cluster/abc123"
+```
+
+When set to `false`, the four bridge resources (Lambda, IAM role, subscription
+filter, permission) are not deployed. Rollback is `EnableHmaCloudWatchBridge=false`
++ redeploy. See [IMPLEMENTATION.md](IMPLEMENTATION.md#hma-cloudwatch-bridge-slurm-only)
+for the design rationale, latency (~1–5 s end-to-end from HMA detection to
+DevOps Agent), and failure semantics.
+
 ## Layout
 
 ```
@@ -437,6 +475,7 @@ stays out of it and the heartbeat fires as expected.
 │   │   ├── webhook_bridge.py         - HyperPod event -> DevOps Agent payload
 │   │   ├── periodic_audit.py         - K8s-state audit (CrashLoop/NotReady) + heartbeat
 │   │   ├── email_notifier.py         - Investigation event -> formatted SES email
+│   │   ├── hma_cw_bridge.py          - HMA CloudWatch log record -> synthesized EventBridge event (Slurm-only)
 │   │   ├── cr_webhook_provisioner.py - custom resource: register/associate eventChannel + write secret
 │   │   ├── cr_skill_uploader.py      - custom resource: upload skill assets from S3
 │   │   └── cfnresponse.py            - CFN response shim for the S3-packaged skill uploader

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/deploy.sh
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/deploy.sh
@@ -168,6 +168,78 @@ else
     fi
 fi
 
+# --------------------- auto-resolve HMA CloudWatch bridge (Slurm-only workaround)
+# The HMA CW bridge is a Slurm-only workaround: on EKS, HyperPod natively emits
+# the HMA-attribution Warn event on EventBridge, so deploying the bridge would
+# produce duplicate investigations. On Slurm the native emission does not
+# happen today, so the bridge fills the gap by tailing HMA CloudWatch logs and
+# synthesizing an equivalent EventBridge event.
+#
+# `deploy.sh` auto-resolves BOTH parameters unless the user set them in
+# params.json. To force-override (e.g., disable on a Slurm cluster or enable
+# on EKS for testing), set them explicitly in params.json.
+#
+# HmaLogGroupName is derived from the HyperPod cluster's ARN suffix (the
+# 12-char cluster ID) — matches the pattern
+#   /aws/sagemaker/Clusters/<ClusterName>/<ClusterId>
+# under which HMA writes its detection log streams.
+
+# Only auto-resolve if the user didn't set it. The USER_PARAMS array is
+# `Key=Value` entries; grep the array to see if the key is present.
+_user_has_param() {
+    local key="$1"
+    local p
+    for p in "${USER_PARAMS[@]}"; do
+        [[ "${p%%=*}" == "${key}" ]] && return 0
+    done
+    return 1
+}
+
+HMA_BRIDGE_ENABLED_AUTO=""
+if [[ -z "${EKS_CLUSTER_NAME}" ]]; then
+    # Slurm cluster — enable the bridge by default.
+    HMA_BRIDGE_ENABLED_AUTO="true"
+else
+    # EKS cluster — disable the bridge by default.
+    HMA_BRIDGE_ENABLED_AUTO="false"
+fi
+
+if _user_has_param "EnableHmaCloudWatchBridge"; then
+    HMA_BRIDGE_ENABLED="$(for p in "${USER_PARAMS[@]}"; do [[ "${p%%=*}" == "EnableHmaCloudWatchBridge" ]] && printf '%s' "${p#*=}"; done)"
+    echo "    HMA CW bridge:    ${HMA_BRIDGE_ENABLED} (user-set)"
+    # Sanity: warn if enabling on EKS (duplicate events risk).
+    if [[ "${HMA_BRIDGE_ENABLED}" == "true" && -n "${EKS_CLUSTER_NAME}" ]]; then
+        echo "    WARNING: EnableHmaCloudWatchBridge=true on an EKS cluster produces DUPLICATE" >&2
+        echo "             investigations (HyperPod already emits HMA Warn events natively on EKS)." >&2
+        echo "             Set EnableHmaCloudWatchBridge=false or remove the entry to use the default." >&2
+    fi
+else
+    HMA_BRIDGE_ENABLED="${HMA_BRIDGE_ENABLED_AUTO}"
+    echo "    HMA CW bridge:    ${HMA_BRIDGE_ENABLED} (auto-resolved from orchestrator)"
+fi
+
+# HmaLogGroupName: only derive when the bridge is enabled AND the user didn't
+# set the log-group name. Auto-derivation reads the cluster's ARN suffix from
+# the describe-cluster response we already fetched.
+HMA_LOG_GROUP_AUTO=""
+if [[ "${HMA_BRIDGE_ENABLED}" == "true" ]] && ! _user_has_param "HmaLogGroupName"; then
+    HMA_CLUSTER_ID="$(printf '%s' "${CLUSTER_JSON}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+arn = d.get('ClusterArn') or ''
+# ARN shape: arn:aws:sagemaker:<region>:<account>:cluster/<cluster-id>
+print(arn.rsplit('/', 1)[-1] if arn else '')
+")"
+    if [[ -n "${HMA_CLUSTER_ID}" ]]; then
+        HMA_LOG_GROUP_AUTO="/aws/sagemaker/Clusters/${HYPERPOD_CLUSTER_NAME}/${HMA_CLUSTER_ID}"
+        echo "    HMA log group:    ${HMA_LOG_GROUP_AUTO} (auto-derived)"
+    else
+        echo "Error: HMA CW bridge enabled but cluster ARN missing — cannot derive HmaLogGroupName." >&2
+        echo "       Set HmaLogGroupName explicitly in params.json or disable the bridge." >&2
+        exit 1
+    fi
+fi
+
 # --------------------------------------------------------- boto3 preflight
 # Building the skill-uploader Lambda bundles a current boto3 (the Lambda runtime's
 # built-in boto3 predates the DevOps Agent Asset API). Verify it's present up front
@@ -239,6 +311,16 @@ PARAMS+=("SkillsVersion=${SKILLS_VERSION}")
 PARAMS+=("SkillsManifest=${SKILLS_MANIFEST}")
 PARAMS+=("SkillUploaderS3Bucket=${UPLOADER_BUCKET}")
 PARAMS+=("SkillUploaderS3Key=${UPLOADER_KEY}")
+
+# HMA CW bridge params: append the auto-resolved values ONLY when the user
+# didn't set them (auto-derived values need to appear AFTER user params so the
+# CFN "later value wins" rule doesn't clobber a deliberate user override).
+if ! _user_has_param "EnableHmaCloudWatchBridge"; then
+    PARAMS+=("EnableHmaCloudWatchBridge=${HMA_BRIDGE_ENABLED}")
+fi
+if [[ -n "${HMA_LOG_GROUP_AUTO}" ]]; then
+    PARAMS+=("HmaLogGroupName=${HMA_LOG_GROUP_AUTO}")
+fi
 
 echo
 echo "==> Deploying stack ${STACK_NAME}"

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/hyperpod_devops_agent.template.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/hyperpod_devops_agent.template.yaml
@@ -74,6 +74,12 @@ Metadata:
           - ForceSend
           - MarkerExpirationDays
       - Label:
+          default: "HMA CloudWatch bridge (Slurm-only)"
+        Parameters:
+          - EnableHmaCloudWatchBridge
+          - HmaLogGroupName
+          - HmaBridgeLambdaMemory
+      - Label:
           default: "Advanced"
         Parameters:
           - AgentSpaceDescription
@@ -272,6 +278,46 @@ Parameters:
     Default: "arn:aws:s3:::sagemaker-*-bucket"
     Description: "ARN pattern for HyperPod lifecycle-script buckets, granting the Agent Space role s3:GetObject/ListBucket so RCA can read on_create.sh. Set to '' to skip."
 
+  # ------------------------------------------------- HMA CloudWatch bridge (Slurm-only workaround)
+  #
+  # On EKS-orchestrated HyperPod clusters the control plane emits a Warn-level
+  # `SageMaker HyperPod Cluster Event` on EventBridge when HMA detects a GPU
+  # fault, and the webhook bridge picks it up natively -- no extra wiring needed.
+  #
+  # On Slurm-orchestrated HyperPod clusters today the control plane does NOT
+  # emit that Warn event for HMA-attributed faults, so the DevOps Agent pipeline
+  # never runs and no investigation email is produced. HMA still writes its
+  # detection JSON to the cluster's CloudWatch log group.
+  #
+  # These parameters enable a CloudWatch Logs subscription filter + tiny Lambda
+  # (`hma_cw_bridge`) that reads the HMA JSON record and forwards it onto
+  # EventBridge shaped exactly like the native EKS event. The existing bridge
+  # picks it up unchanged.
+  #
+  # `deploy.sh` sets EnableHmaCloudWatchBridge = "true" for Slurm and "false"
+  # for EKS automatically. Deploying on EKS with "true" would produce duplicate
+  # investigations (native + synthesized) -- triage-skill LINK dedup mitigates
+  # but it's still wasted work; keep the default.
+  EnableHmaCloudWatchBridge:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: "Deploy the HMA CloudWatch bridge (Slurm-only workaround). Set to 'true' for Slurm clusters. 'make deploy' auto-sets this based on orchestrator."
+
+  HmaLogGroupName:
+    Type: String
+    Default: ""
+    Description: "CloudWatch log group where HMA writes its detection events. Empty (default) means 'make deploy' auto-derives it as /aws/sagemaker/Clusters/<ClusterName>/<ClusterId>. Only used when EnableHmaCloudWatchBridge=true."
+
+  HmaBridgeLambdaMemory:
+    Type: Number
+    Default: 128
+    MinValue: 128
+    MaxValue: 1024
+    Description: "Memory (MB) for the HMA CloudWatch bridge Lambda. Small event-transform workload; default is sufficient. Only used when EnableHmaCloudWatchBridge=true."
+
 Conditions:
 
   IsEksCluster: !Not [!Equals [!Ref EksClusterName, ""]]
@@ -288,6 +334,7 @@ Conditions:
   HasAgentSpaceDescription: !Not [!Equals [!Ref AgentSpaceDescription, ""]]
   HasAgentSpaceRoleName: !Not [!Equals [!Ref AgentSpaceRoleName, ""]]
   HasWebappRoleName: !Not [!Equals [!Ref WebappRoleName, ""]]
+  HmaCloudWatchBridgeEnabled: !Equals [!Ref EnableHmaCloudWatchBridge, "true"]
 
 Resources:
 
@@ -584,19 +631,124 @@ Resources:
     Properties:
       Description: "Route HyperPod cluster events to the DevOps Agent webhook bridge."
       State: ENABLED
+      # Detail-type match: keeps the three explicit detail-types from PR #1191
+      # (Cluster State Change, Cluster Node Health Event, Cluster Event) and
+      # adds a `prefix: "SageMaker HyperPod"` catch-all so any future
+      # `SageMaker HyperPod <NewName>` variant HyperPod adds is routed too.
+      # Unknown/unhandled detail-types fall to the bridge Lambda's generic
+      # fallback branch, which inlines the raw detail JSON into the description
+      # so operators still get an actionable investigation email.
+      #
+      # Two accepted sources:
+      #   - `aws.sagemaker`: native HyperPod-emitted events (all clusters).
+      #   - `hyperpod-devops-agent-hma-cw-bridge`: synthesized events from the
+      #     Slurm-only HMA CW bridge Lambda. EventBridge reserves the `aws.`
+      #     prefix for AWS service events, so the workaround publishes onto a
+      #     custom source that this rule explicitly accepts. Name matches the
+      #     pattern used by the periodic-audit synthesized events
+      #     (`hyperpod-devops-agent-periodic-audit`) for within-codebase
+      #     consistency.
       EventPattern: |
         {
-          "source": ["aws.sagemaker"],
+          "source": ["aws.sagemaker", "hyperpod-devops-agent-hma-cw-bridge"],
           "detail-type": [
             "SageMaker HyperPod Cluster State Change",
             "SageMaker HyperPod Cluster Node Health Event",
-            "SageMaker HyperPod Cluster Event"
+            "SageMaker HyperPod Cluster Event",
+            {"prefix": "SageMaker HyperPod"}
           ]
         }
       Targets:
         - Arn: !GetAtt WebhookBridgeFunction.Arn
           Id: "WebhookBridgeLambdaTarget"
           RoleArn: !GetAtt WebhookBridgeEventRole.Arn
+
+  # ============================================================ HMA CloudWatch bridge (Slurm-only workaround)
+  #
+  # See the parameter block for the "why". Four resources, all gated by
+  # HmaCloudWatchBridgeEnabled so an EKS deploy creates zero of them:
+  #
+  #   HmaCwBridgeExecutionRole  - IAM role for the Lambda: log-writes + events:PutEvents.
+  #   HmaCwBridgeFunction       - The Lambda itself. Small event-transform.
+  #   HmaCwBridgeLogPermission  - Grants CloudWatch Logs the right to invoke the Lambda.
+  #   HmaCwBridgeLogSubscription - The subscription filter that triggers the Lambda
+  #                                on HMA detection log records.
+
+  HmaCwBridgeExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: HmaCloudWatchBridgeEnabled
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: HmaCwBridgeExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*:log-stream:*"
+              # events:PutEvents scoped to the default event bus in THIS
+              # account+region. The Lambda synthesizes a `SageMaker HyperPod
+              # Cluster Event` and PutEvents-forwards it back onto the default
+              # bus, where HyperPodEventRule (above) picks it up.
+              - Effect: Allow
+                Action:
+                  - events:PutEvents
+                Resource:
+                  - !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default"
+
+  HmaCwBridgeFunction:
+    Type: AWS::Lambda::Function
+    Condition: HmaCloudWatchBridgeEnabled
+    Properties:
+      Role: !GetAtt HmaCwBridgeExecutionRole.Arn
+      Runtime: python3.13
+      Handler: index.lambda_handler
+      Timeout: 30
+      MemorySize: !Ref HmaBridgeLambdaMemory
+      Environment:
+        Variables:
+          CLUSTER_NAME: !Ref HyperPodClusterName
+          EVENT_BUS_NAME: "default"
+      Code:
+        ZipFile: |
+          # HMA_CW_BRIDGE_CODE_PLACEHOLDER
+
+  HmaCwBridgeLogPermission:
+    Type: AWS::Lambda::Permission
+    Condition: HmaCloudWatchBridgeEnabled
+    Properties:
+      FunctionName: !Ref HmaCwBridgeFunction
+      Action: lambda:InvokeFunction
+      Principal: !Sub "logs.${AWS::Region}.amazonaws.com"
+      SourceArn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${HmaLogGroupName}:*"
+
+  HmaCwBridgeLogSubscription:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: HmaCloudWatchBridgeEnabled
+    # The permission must exist before CloudWatch Logs can validate the
+    # subscription target -- otherwise CreateSubscriptionFilter fails with an
+    # InvalidParameterException on the destination Lambda.
+    DependsOn: HmaCwBridgeLogPermission
+    Properties:
+      LogGroupName: !Ref HmaLogGroupName
+      # HMA writes one JSON object per log line with a discriminator field
+      # `HealthMonitoringAgentDetectionEvent`. Selecting on that field means
+      # unrelated lines in the same log group (e.g., LifecycleConfig streams)
+      # never invoke the Lambda.
+      FilterPattern: '{ $.HealthMonitoringAgentDetectionEvent = "HealthEvent" }'
+      DestinationArn: !GetAtt HmaCwBridgeFunction.Arn
 
   # ============================================================ Periodic audit (toggleable)
 
@@ -975,3 +1127,8 @@ Outputs:
   EmailNotifierFunctionName:
     Value: !Ref EmailNotifierFunction
     Description: "Name of the email notifier Lambda (for log tailing)."
+
+  HmaCwBridgeFunctionName:
+    Condition: HmaCloudWatchBridgeEnabled
+    Value: !Ref HmaCwBridgeFunction
+    Description: "Name of the HMA CloudWatch bridge Lambda (Slurm-only, for log tailing)."

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/hyperpod_devops_agent.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/hyperpod_devops_agent.yaml
@@ -877,6 +877,27 @@ Resources:
           # (comma-separated) if needed without redeploying.
           _DEFAULT_DROP_LEVELS = {"info"}
 
+          # Known detail-types with dedicated handlers in `_title_and_description`.
+          # Any detail-type NOT in this set (e.g. a future `SageMaker HyperPod
+          # <NewName>` variant that the widened prefix rule newly routes here) is
+          # gated by EventLevel in `lambda_handler` before reaching the generic-
+          # fallback branch — see `_is_unknown_detail_type_below_severity`. This
+          # preserves the "POST only on real issues" cost model on the DevOps
+          # Agent side: we only pay for a triage/RCA when the emitter labels the
+          # event severity as high, or when the detail-type is one of the three
+          # we already know how to shape.
+          _KNOWN_DETAIL_TYPES = frozenset({
+              "SageMaker HyperPod Cluster State Change",
+              "SageMaker HyperPod Cluster Node Health Event",
+              "SageMaker HyperPod Cluster Event",
+          })
+
+          # EventLevel values considered "real issue" for unknown detail-types.
+          # Missing/empty EventLevel is treated as below threshold — safer default
+          # since a level-less unknown-type emission gives us no signal to base
+          # a paid investigation on.
+          _UNKNOWN_TYPE_FORWARD_LEVELS = frozenset({"warn", "error", "critical"})
+
 
           _secrets_cache: dict[str, str] = {}
           _sagemaker_client = None
@@ -993,6 +1014,26 @@ Resources:
               ev_details = detail.get("EventDetails", {})
               description = ev_details.get("Description", "")
               return "lost orchestration-ready status" in description
+
+
+          def _is_unknown_detail_type_below_severity(event: dict) -> bool:
+              """Drop-check for detail-types the prefix rule caught but we don't
+              have a dedicated handler for.
+
+              Rationale: the widened rule (`prefix: "SageMaker HyperPod"`) routes
+              all current AND future HyperPod-native detail-types to this Lambda.
+              For the three we know (see `_KNOWN_DETAIL_TYPES`), the existing per-
+              detail-type handlers in `_title_and_description` produce structured
+              titles. For anything else we don't know the shape, so gate on
+              EventLevel to keep the cost model of "one paid investigation per
+              real issue". Level-less or `Info` events from an unknown detail-type
+              are dropped here.
+              """
+              detail_type = event.get("detail-type", "")
+              if detail_type in _KNOWN_DETAIL_TYPES:
+                  return False
+              level = (_event_level(event) or "").lower()
+              return level not in _UNKNOWN_TYPE_FORWARD_LEVELS
 
 
           def _should_drop(event: dict) -> tuple[bool, str | None]:
@@ -1196,12 +1237,18 @@ Resources:
                       description += f" EventMetadata: {extras_str}."
                   return title, description
 
-              # -------------------- Generic fallback (improved) --------------------
-              # Any unrecognized detail-type falls here. Rather than emitting an empty
-              # description that hides the event body from the RCA skill, inline a
-              # compact JSON of the raw detail so operators still get an actionable
-              # investigation email. Truncated to a reasonable size to keep the payload
-              # bounded — the full event is still available in `data.originalEvent`.
+              # -------------------- Generic fallback (post-severity-gate) --------------------
+              # By the time execution reaches here we know:
+              #   (a) detail_type is NOT one of the three known types (they returned
+              #       above via their dedicated branches), AND
+              #   (b) EventLevel is Warn/Error/Critical (else
+              #       `_is_unknown_detail_type_below_severity` in lambda_handler
+              #       already dropped this event before we were called).
+              # So this is a real-severity unknown detail-type — worth an investigation
+              # email. Inline a compact JSON of the raw detail so the RCA skill has
+              # structured signal to reason from. Truncated to a reasonable size to
+              # keep the payload bounded — the full event is still available in
+              # `data.originalEvent`.
               try:
                   detail_json = json.dumps(detail, default=str, sort_keys=True)
               except (TypeError, ValueError):
@@ -1319,6 +1366,13 @@ Resources:
               if _is_scale_progress_noise(event):
                   _log("INFO", "event_dropped", reason="scale-progress-noise")
                   return {"statusCode": 200, "body": json.dumps({"dropped": True, "reason": "scale-progress-noise"})}
+
+              if _is_unknown_detail_type_below_severity(event):
+                  _log("INFO", "event_dropped",
+                       reason="unknown-detail-type-below-severity",
+                       detailType=event.get("detail-type"),
+                       eventLevel=_event_level(event) or "unset")
+                  return {"statusCode": 200, "body": json.dumps({"dropped": True, "reason": "unknown-detail-type-below-severity"})}
 
               webhook_url, secret = _load_webhook_credentials()
               payload = _build_payload(event)
@@ -1669,7 +1723,7 @@ Resources:
 
               detail = {
                   "EventDetails": {
-                      "EventId": "synthetic-hma-cw-bridge",  # not a real cluster-event ID
+                      "EventId": "",  # not a real cluster-event ID
                       "ClusterArn": cluster_arn,
                       "ClusterName": cluster_name,
                       "InstanceGroupName": instance_group,

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/hyperpod_devops_agent.yaml
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/hyperpod_devops_agent.yaml
@@ -74,6 +74,12 @@ Metadata:
           - ForceSend
           - MarkerExpirationDays
       - Label:
+          default: "HMA CloudWatch bridge (Slurm-only)"
+        Parameters:
+          - EnableHmaCloudWatchBridge
+          - HmaLogGroupName
+          - HmaBridgeLambdaMemory
+      - Label:
           default: "Advanced"
         Parameters:
           - AgentSpaceDescription
@@ -272,6 +278,46 @@ Parameters:
     Default: "arn:aws:s3:::sagemaker-*-bucket"
     Description: "ARN pattern for HyperPod lifecycle-script buckets, granting the Agent Space role s3:GetObject/ListBucket so RCA can read on_create.sh. Set to '' to skip."
 
+  # ------------------------------------------------- HMA CloudWatch bridge (Slurm-only workaround)
+  #
+  # On EKS-orchestrated HyperPod clusters the control plane emits a Warn-level
+  # `SageMaker HyperPod Cluster Event` on EventBridge when HMA detects a GPU
+  # fault, and the webhook bridge picks it up natively -- no extra wiring needed.
+  #
+  # On Slurm-orchestrated HyperPod clusters today the control plane does NOT
+  # emit that Warn event for HMA-attributed faults, so the DevOps Agent pipeline
+  # never runs and no investigation email is produced. HMA still writes its
+  # detection JSON to the cluster's CloudWatch log group.
+  #
+  # These parameters enable a CloudWatch Logs subscription filter + tiny Lambda
+  # (`hma_cw_bridge`) that reads the HMA JSON record and forwards it onto
+  # EventBridge shaped exactly like the native EKS event. The existing bridge
+  # picks it up unchanged.
+  #
+  # `deploy.sh` sets EnableHmaCloudWatchBridge = "true" for Slurm and "false"
+  # for EKS automatically. Deploying on EKS with "true" would produce duplicate
+  # investigations (native + synthesized) -- triage-skill LINK dedup mitigates
+  # but it's still wasted work; keep the default.
+  EnableHmaCloudWatchBridge:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: "Deploy the HMA CloudWatch bridge (Slurm-only workaround). Set to 'true' for Slurm clusters. 'make deploy' auto-sets this based on orchestrator."
+
+  HmaLogGroupName:
+    Type: String
+    Default: ""
+    Description: "CloudWatch log group where HMA writes its detection events. Empty (default) means 'make deploy' auto-derives it as /aws/sagemaker/Clusters/<ClusterName>/<ClusterId>. Only used when EnableHmaCloudWatchBridge=true."
+
+  HmaBridgeLambdaMemory:
+    Type: Number
+    Default: 128
+    MinValue: 128
+    MaxValue: 1024
+    Description: "Memory (MB) for the HMA CloudWatch bridge Lambda. Small event-transform workload; default is sufficient. Only used when EnableHmaCloudWatchBridge=true."
+
 Conditions:
 
   IsEksCluster: !Not [!Equals [!Ref EksClusterName, ""]]
@@ -288,6 +334,7 @@ Conditions:
   HasAgentSpaceDescription: !Not [!Equals [!Ref AgentSpaceDescription, ""]]
   HasAgentSpaceRoleName: !Not [!Equals [!Ref AgentSpaceRoleName, ""]]
   HasWebappRoleName: !Not [!Equals [!Ref WebappRoleName, ""]]
+  HmaCloudWatchBridgeEnabled: !Equals [!Ref EnableHmaCloudWatchBridge, "true"]
 
 Resources:
 
@@ -1149,10 +1196,24 @@ Resources:
                       description += f" EventMetadata: {extras_str}."
                   return title, description
 
+              # -------------------- Generic fallback (improved) --------------------
+              # Any unrecognized detail-type falls here. Rather than emitting an empty
+              # description that hides the event body from the RCA skill, inline a
+              # compact JSON of the raw detail so operators still get an actionable
+              # investigation email. Truncated to a reasonable size to keep the payload
+              # bounded — the full event is still available in `data.originalEvent`.
+              try:
+                  detail_json = json.dumps(detail, default=str, sort_keys=True)
+              except (TypeError, ValueError):
+                  detail_json = str(detail)
+              if len(detail_json) > 2000:
+                  detail_json = detail_json[:2000] + "…(truncated)"
+
               return (
                   f"HyperPod event: {detail_type} on {cluster_name}",
                   f"HyperPod cluster '{cluster_name}' (account {account}, {region}) emitted an event of type "
-                  f"'{detail_type}'. Raw detail attached.",
+                  f"'{detail_type}'. No dedicated handler for this detail-type; the RCA skill should treat "
+                  f"the following inlined detail as ground truth. Detail: {detail_json}",
               )
 
 
@@ -1301,19 +1362,552 @@ Resources:
     Properties:
       Description: "Route HyperPod cluster events to the DevOps Agent webhook bridge."
       State: ENABLED
+      # Detail-type match: keeps the three explicit detail-types from PR #1191
+      # (Cluster State Change, Cluster Node Health Event, Cluster Event) and
+      # adds a `prefix: "SageMaker HyperPod"` catch-all so any future
+      # `SageMaker HyperPod <NewName>` variant HyperPod adds is routed too.
+      # Unknown/unhandled detail-types fall to the bridge Lambda's generic
+      # fallback branch, which inlines the raw detail JSON into the description
+      # so operators still get an actionable investigation email.
+      #
+      # Two accepted sources:
+      #   - `aws.sagemaker`: native HyperPod-emitted events (all clusters).
+      #   - `hyperpod-devops-agent-hma-cw-bridge`: synthesized events from the
+      #     Slurm-only HMA CW bridge Lambda. EventBridge reserves the `aws.`
+      #     prefix for AWS service events, so the workaround publishes onto a
+      #     custom source that this rule explicitly accepts. Name matches the
+      #     pattern used by the periodic-audit synthesized events
+      #     (`hyperpod-devops-agent-periodic-audit`) for within-codebase
+      #     consistency.
       EventPattern: |
         {
-          "source": ["aws.sagemaker"],
+          "source": ["aws.sagemaker", "hyperpod-devops-agent-hma-cw-bridge"],
           "detail-type": [
             "SageMaker HyperPod Cluster State Change",
             "SageMaker HyperPod Cluster Node Health Event",
-            "SageMaker HyperPod Cluster Event"
+            "SageMaker HyperPod Cluster Event",
+            {"prefix": "SageMaker HyperPod"}
           ]
         }
       Targets:
         - Arn: !GetAtt WebhookBridgeFunction.Arn
           Id: "WebhookBridgeLambdaTarget"
           RoleArn: !GetAtt WebhookBridgeEventRole.Arn
+
+  # ============================================================ HMA CloudWatch bridge (Slurm-only workaround)
+  #
+  # See the parameter block for the "why". Four resources, all gated by
+  # HmaCloudWatchBridgeEnabled so an EKS deploy creates zero of them:
+  #
+  #   HmaCwBridgeExecutionRole  - IAM role for the Lambda: log-writes + events:PutEvents.
+  #   HmaCwBridgeFunction       - The Lambda itself. Small event-transform.
+  #   HmaCwBridgeLogPermission  - Grants CloudWatch Logs the right to invoke the Lambda.
+  #   HmaCwBridgeLogSubscription - The subscription filter that triggers the Lambda
+  #                                on HMA detection log records.
+
+  HmaCwBridgeExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: HmaCloudWatchBridgeEnabled
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: HmaCwBridgeExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*:log-stream:*"
+              # events:PutEvents scoped to the default event bus in THIS
+              # account+region. The Lambda synthesizes a `SageMaker HyperPod
+              # Cluster Event` and PutEvents-forwards it back onto the default
+              # bus, where HyperPodEventRule (above) picks it up.
+              - Effect: Allow
+                Action:
+                  - events:PutEvents
+                Resource:
+                  - !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default"
+
+  HmaCwBridgeFunction:
+    Type: AWS::Lambda::Function
+    Condition: HmaCloudWatchBridgeEnabled
+    Properties:
+      Role: !GetAtt HmaCwBridgeExecutionRole.Arn
+      Runtime: python3.13
+      Handler: index.lambda_handler
+      Timeout: 30
+      MemorySize: !Ref HmaBridgeLambdaMemory
+      Environment:
+        Variables:
+          CLUSTER_NAME: !Ref HyperPodClusterName
+          EVENT_BUS_NAME: "default"
+      Code:
+        ZipFile: |
+          """Bridge HMA CloudWatch Logs detection events onto EventBridge (Slurm only).
+
+          Why this exists
+          ---------------
+          On EKS-orchestrated HyperPod clusters, the control plane emits a Warn-level
+          `SageMaker HyperPod Cluster Event` on EventBridge whenever HMA detects a GPU
+          fault (NvidiaGPUUnhealthy, ECC DBE, etc.). That event flows through the
+          webhook bridge Lambda into DevOps Agent and produces an investigation email.
+
+          On Slurm-orchestrated HyperPod clusters today, the HyperPod control plane
+          does NOT emit that Warn-level event for HMA-attributed faults. HMA still
+          writes its detection JSON to the cluster's CloudWatch log group
+          (SagemakerHealthMonitoringAgent/<group>/<instance>), and HyperPod still
+          initiates node replacement, but no operator-visible EventBridge event is
+          produced -- the DevOps Agent pipeline never runs for HMA-origin faults on
+          Slurm.
+
+          This Lambda closes that gap. A CloudWatch Logs subscription filter on the
+          cluster's log group (with FilterPattern
+          `{ $.HealthMonitoringAgentDetectionEvent = "HealthEvent" }`) invokes this
+          Lambda for every HMA detection record. The Lambda extracts fault type +
+          repair action + instance ID from the HMA record and calls `events:PutEvents`
+          with a synthetic `SageMaker HyperPod Cluster Event` shaped identically to
+          what HyperPod emits on EKS -- so the existing webhook bridge picks it up
+          unchanged, no downstream code changes required.
+
+          This is a Slurm-only workaround. Enabled by the CFN parameter
+          `EnableHmaCloudWatchBridge`, which `deploy.sh` auto-resolves to `true` for
+          Slurm and `false` for EKS. On EKS the subscription filter and this Lambda
+          are simply not deployed -- HyperPod's native event still flows.
+
+          Environment variables
+          ---------------------
+            CLUSTER_NAME     HyperPod cluster name (goes into the synthetic event).
+            EVENT_BUS_NAME   EventBridge bus to publish onto. Default: "default".
+            LOG_LEVEL        Structured-log level (INFO or DEBUG). Default: INFO.
+
+          CloudWatch Logs invocation contract
+          -----------------------------------
+          CloudWatch delivers a gzipped, base64-encoded payload:
+
+            {
+              "awslogs": {
+                "data": "<base64-encoded gzip of the actual JSON>"
+              }
+            }
+
+          The decoded JSON has this shape:
+
+            {
+              "messageType": "DATA_MESSAGE",
+              "owner": "<account-id>",
+              "logGroup": "/aws/sagemaker/Clusters/<name>/<id>",
+              "logStream": "SagemakerHealthMonitoringAgent/<group>/<instance>",
+              "subscriptionFilters": [...],
+              "logEvents": [
+                {"id": "...", "timestamp": ..., "message": "<HMA JSON record>"},
+                ...
+              ]
+            }
+
+          Each `message` is a JSON string that HMA wrote, e.g.:
+
+            {"level":"info","ts":"2026-07-20T22:53:17Z",
+             "msg":"DCGM Policy Violation found ",
+             "condition: ":"XID Error","data: ":{"ErrNum":79},
+             "HealthMonitoringAgentDetectionEvent":"HealthEvent"}
+
+          On EKS the corresponding record (which we don't run against) has richer
+          context including `"Event detail":{"Action":"replace","Type":"NvidiaGPUUnhealthy",...}`.
+          We support both shapes below via best-effort field extraction.
+          """
+          import base64
+          import datetime
+          import gzip
+          import json
+          import os
+          import re
+
+          import boto3
+
+
+          _events_client = None
+
+
+          def _log(level: str, event: str, **kwargs) -> None:
+              """Emit one structured-JSON log line for CloudWatch Logs Insights.
+
+              Matches the shape used by webhook_bridge.py / periodic_audit.py /
+              email_notifier.py: one JSON object per line with `level`, `event`, and
+              arbitrary context kwargs.
+              """
+              print(json.dumps({"level": level, "event": event, **kwargs}, default=str))
+
+
+          def _events():
+              global _events_client
+              if _events_client is None:
+                  _events_client = boto3.client("events")
+              return _events_client
+
+
+          def _now_iso() -> str:
+              return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+          # Instance-id parsing from the log stream name.
+          # Stream shape: SagemakerHealthMonitoringAgent/<instance-group>/<instance-id>
+          _STREAM_RE = re.compile(
+              r"^SagemakerHealthMonitoringAgent/(?P<ig>[^/]+)/(?P<iid>i-[0-9a-f]+)$"
+          )
+
+
+          def _parse_log_stream(log_stream: str) -> tuple[str, str]:
+              """Return (instance_group, instance_id) parsed from the log-stream name.
+
+              Falls back to ("", "") if the stream doesn't match the expected shape --
+              the synthesized event will carry empty fields rather than fail, and the
+              RCA skill can still reason from Description + timestamp.
+              """
+              if not log_stream:
+                  return "", ""
+              m = _STREAM_RE.match(log_stream)
+              if not m:
+                  return "", ""
+              return m.group("ig"), m.group("iid")
+
+
+          def _extract_fault(record: dict) -> tuple[str, str, str]:
+              """Return (fault_type, repair_action, message) from an HMA JSON record.
+
+              HMA records come in a few different shapes depending on the emitting
+              daemon and orchestrator. We try each known shape in order, falling back
+              to best-effort text extraction. Returns empty strings for any field we
+              can't confidently populate -- downstream code inlines a raw excerpt.
+              """
+              # Shape 1: EKS NPD-caught health event (richest)
+              #   {"Event detail":{"Action":"replace","Type":"NvidiaGPUUnhealthy",
+              #                    "Reason":"NvidiaGpuXidErrorPendingReplacement",
+              #                    "Message":"NVRM: Xid (...): 74 ..."}}
+              ev = record.get("Event detail") or record.get("EventDetail") or {}
+              if isinstance(ev, dict) and ev:
+                  return (
+                      str(ev.get("Type") or ev.get("Reason") or "").strip(),
+                      str(ev.get("Action") or "").strip(),
+                      str(ev.get("Message") or "").strip(),
+                  )
+
+              # Shape 2: Slurm DCGM Policy Violation
+              #   {"msg":"DCGM Policy Violation found ",
+              #    "condition: ":"XID Error","data: ":{"ErrNum":79}}
+              msg = str(record.get("msg") or "").strip()
+              cond = str(record.get("condition: ") or record.get("condition") or "").strip()
+              data = record.get("data: ") or record.get("data") or {}
+              if cond:
+                  # Compose a fault_type from condition + specific error number if present
+                  fault_type = cond
+                  if isinstance(data, dict):
+                      err_num = data.get("ErrNum") or data.get("errNum") or data.get("Xid")
+                      if err_num is not None:
+                          fault_type = f"{cond} (code={err_num})"
+                  # DCGM Policy Violation events on Slurm typically imply replace-grade
+                  return fault_type, "Replace", msg or f"HMA detected {fault_type}"
+
+              # Shape 3: NPD condition transition
+              #   {"msg":"NPD caught positive condition",
+              #    "condition details":{"type":"NvidiaGPUUnhealthy","status":"True", ...}}
+              cd = record.get("condition details") or {}
+              if isinstance(cd, dict) and cd.get("type"):
+                  return (
+                      str(cd.get("type") or "").strip(),
+                      "Replace",  # NPD-caught HMA conditions are treated as replace-grade
+                      str(cd.get("message") or msg or "").strip(),
+                  )
+
+              # Shape 4: last-resort — echo the msg as fault_type if that's all we have
+              if msg:
+                  return msg, "", msg
+
+              return "", "", ""
+
+
+          def _build_synthetic_event(
+              cluster_name: str,
+              instance_group: str,
+              instance_id: str,
+              fault_type: str,
+              repair_action: str,
+              original_message: str,
+              event_time_iso: str,
+              region: str,
+              account_id: str,
+          ) -> dict:
+              """Shape a synthetic `SageMaker HyperPod Cluster Event` for PutEvents.
+
+              Matches the shape HyperPod emits natively on EKS (see round-2 live
+              verification 2026-07-20T22:54:17Z on test-eks), so the existing webhook
+              bridge Lambda's Cluster Event handler picks it up verbatim.
+              """
+              cluster_arn = f"arn:aws:sagemaker:{region}:{account_id}:cluster/{cluster_name}" if account_id and region else ""
+              # Description matches EKS control-plane wording so operators see identical
+              # subject lines regardless of orchestrator.
+              fault_display = fault_type or "unknown fault"
+              action_display = repair_action or "unknown"
+              description = (
+                  f"Instance {instance_id} is unhealthy. "
+                  f"HyperPod Health Monitoring Agent (HMA) has detected fault type "
+                  f"{fault_display} on this node and is unhealthy. "
+                  f"Repair action: {action_display}."
+              )
+              if original_message and original_message not in description:
+                  description += f" HMA detail: {original_message}"
+
+              detail = {
+                  "EventDetails": {
+                      "EventId": "synthetic-hma-cw-bridge",  # not a real cluster-event ID
+                      "ClusterArn": cluster_arn,
+                      "ClusterName": cluster_name,
+                      "InstanceGroupName": instance_group,
+                      "InstanceId": instance_id,
+                      "ResourceType": "Instance",
+                      "EventTime": event_time_iso,
+                      "Description": description,
+                      "EventLevel": "Warn",
+                      "OperationId": "",
+                      "EventMetadata": {
+                          "Instance": {
+                              "NodeHealthInfo": {
+                                  "HealthStatus": "Unhealthy",
+                                  "HealthStatusReason": (
+                                      f"HyperPod Health Monitoring Agent (HMA) has detected "
+                                      f"fault type {fault_display} on this node and is unhealthy."
+                                  ),
+                                  "RepairAction": repair_action or "",
+                                  "Recommendation": (
+                                      "HyperPod is working on repairing the unhealthy node. "
+                                      "Please wait for the RepairAction to complete."
+                                  ),
+                              }
+                          }
+                      },
+                      # Provenance marker so operators can distinguish synthesized vs native
+                      # events in the DevOps Agent journal / CloudWatch trail.
+                      "SyntheticSource": "hma-cw-bridge",
+                  }
+              }
+              return {
+                  # Custom source. AWS EventBridge reserves the `aws.*` prefix for events
+                  # emitted by AWS services, so PutEvents from customer code cannot spoof
+                  # `aws.sagemaker` — a first attempt with that source returned
+                  # `NotAuthorizedForSourceException`. Naming matches the pattern used by
+                  # periodic_audit.py's synthesized `originalEvent.source`
+                  # (`hyperpod-devops-agent-periodic-audit`) for within-codebase
+                  # consistency. `HyperPodEventRule.EventPattern` in the CFN template
+                  # explicitly accepts this source alongside `aws.sagemaker`.
+                  "Source": "hyperpod-devops-agent-hma-cw-bridge",
+                  "DetailType": "SageMaker HyperPod Cluster Event",
+                  "Detail": json.dumps(detail),
+                  "EventBusName": os.environ.get("EVENT_BUS_NAME", "default"),
+              }
+
+
+          def _decode_cwlogs_payload(event: dict) -> dict:
+              """Decode the gzipped+base64 payload CloudWatch Logs delivers.
+
+              Raises ValueError on malformed input rather than swallowing -- Lambda
+              will surface it and CloudWatch will retry.
+              """
+              if "awslogs" not in event or "data" not in event["awslogs"]:
+                  raise ValueError("event missing awslogs.data envelope")
+              raw = base64.b64decode(event["awslogs"]["data"])
+              decompressed = gzip.decompress(raw)
+              return json.loads(decompressed)
+
+
+          def _parse_hma_record(message: str) -> dict:
+              """Parse the raw log-line message as JSON, or {} on failure.
+
+              HMA writes JSON per line. Non-JSON lines (unlikely given the subscription
+              filter's FilterPattern, but not impossible) are silently skipped so a
+              single malformed record doesn't fail the whole batch.
+              """
+              if not message:
+                  return {}
+              try:
+                  parsed = json.loads(message)
+                  return parsed if isinstance(parsed, dict) else {}
+              except (json.JSONDecodeError, TypeError, ValueError):
+                  return {}
+
+
+          def _put_events_with_retry(entries: list[dict], max_attempts: int = 2) -> dict:
+              """Best-effort PutEvents with one retry on ThrottlingException.
+
+              Returns the PutEvents response of the last attempt. Non-throttling errors
+              bubble up (Lambda logs them; CloudWatch Logs subscription doesn't retry
+              async invocations by default -- see IMPLEMENTATION.md for the failure
+              semantics).
+              """
+              last_response = None
+              for attempt in range(max_attempts):
+                  response = _events().put_events(Entries=entries)
+                  last_response = response
+                  failed_count = response.get("FailedEntryCount", 0)
+                  if failed_count == 0:
+                      return response
+                  # Throttling shows up as ErrorCode "ThrottlingException" per entry
+                  transient = any(
+                      (e.get("ErrorCode") or "") in ("ThrottlingException", "InternalException")
+                      for e in response.get("Entries", [])
+                      if "ErrorCode" in e
+                  )
+                  if not transient or attempt == max_attempts - 1:
+                      _log(
+                          "ERROR",
+                          "put_events_failed",
+                          failedCount=failed_count,
+                          entries=response.get("Entries"),
+                      )
+                      return response
+                  _log("WARN", "put_events_retry", attempt=attempt + 1, failedCount=failed_count)
+              return last_response or {}
+
+
+          def lambda_handler(event, context):
+              """CloudWatch Logs subscription invocation entry point."""
+              cluster_name = os.environ.get("CLUSTER_NAME", "unknown-cluster")
+              region = os.environ.get("AWS_REGION", "")
+              account_id = ""
+              # AWS Lambda populates AWS_LAMBDA_FUNCTION_ARN; parse account from it.
+              fn_arn = os.environ.get("AWS_LAMBDA_FUNCTION_ARN", "")
+              if fn_arn.startswith("arn:"):
+                  parts = fn_arn.split(":")
+                  if len(parts) >= 5:
+                      account_id = parts[4]
+
+              try:
+                  payload = _decode_cwlogs_payload(event)
+              except (ValueError, gzip.BadGzipFile) as exc:
+                  _log("ERROR", "payload_decode_failed", error=repr(exc))
+                  # Re-raise so Lambda records the failure metric; do not silently drop.
+                  raise
+
+              log_stream = payload.get("logStream", "")
+              log_events = payload.get("logEvents", []) or []
+              _log(
+                  "INFO",
+                  "cw_batch_received",
+                  logStream=log_stream,
+                  recordCount=len(log_events),
+              )
+
+              instance_group, instance_id = _parse_log_stream(log_stream)
+
+              entries: list[dict] = []
+              skipped = 0
+              for record_wrapper in log_events:
+                  message = record_wrapper.get("message", "")
+                  record = _parse_hma_record(message)
+                  if not record:
+                      skipped += 1
+                      continue
+                  # Extra defensive gate: even though the CW subscription-filter
+                  # FilterPattern already selects only records with
+                  # HealthMonitoringAgentDetectionEvent == "HealthEvent", re-check here
+                  # so a mis-configured filter can't accidentally forward arbitrary
+                  # non-HMA log lines onto EventBridge.
+                  if record.get("HealthMonitoringAgentDetectionEvent") != "HealthEvent":
+                      skipped += 1
+                      continue
+
+                  fault_type, repair_action, original_message = _extract_fault(record)
+                  if not fault_type:
+                      _log(
+                          "WARN",
+                          "unparseable_hma_record",
+                          logStream=log_stream,
+                          sample=message[:200],
+                      )
+                      skipped += 1
+                      continue
+
+                  # Prefer HMA-record timestamp; fall back to CW record timestamp; last
+                  # resort is now().
+                  event_time_iso = str(record.get("ts") or "").strip()
+                  if not event_time_iso:
+                      ts_ms = record_wrapper.get("timestamp")
+                      if isinstance(ts_ms, int):
+                          event_time_iso = datetime.datetime.fromtimestamp(
+                              ts_ms / 1000, tz=datetime.timezone.utc
+                          ).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+                  if not event_time_iso:
+                      event_time_iso = _now_iso()
+
+                  synthesized = _build_synthetic_event(
+                      cluster_name=cluster_name,
+                      instance_group=instance_group,
+                      instance_id=instance_id,
+                      fault_type=fault_type,
+                      repair_action=repair_action,
+                      original_message=original_message,
+                      event_time_iso=event_time_iso,
+                      region=region,
+                      account_id=account_id,
+                  )
+                  entries.append(synthesized)
+                  _log(
+                      "INFO",
+                      "hma_record_processed",
+                      faultType=fault_type,
+                      action=repair_action,
+                      instanceId=instance_id,
+                      eventTime=event_time_iso,
+                  )
+
+              if not entries:
+                  _log("INFO", "no_entries_to_forward", skipped=skipped)
+                  return {"forwarded": 0, "skipped": skipped}
+
+              # PutEvents accepts up to 10 entries per call; batch defensively.
+              forwarded = 0
+              for i in range(0, len(entries), 10):
+                  batch = entries[i : i + 10]
+                  response = _put_events_with_retry(batch)
+                  failed_count = response.get("FailedEntryCount", 0)
+                  forwarded += len(batch) - failed_count
+
+              _log("INFO", "batch_complete", forwarded=forwarded, skipped=skipped)
+              return {"forwarded": forwarded, "skipped": skipped}
+
+  HmaCwBridgeLogPermission:
+    Type: AWS::Lambda::Permission
+    Condition: HmaCloudWatchBridgeEnabled
+    Properties:
+      FunctionName: !Ref HmaCwBridgeFunction
+      Action: lambda:InvokeFunction
+      Principal: !Sub "logs.${AWS::Region}.amazonaws.com"
+      SourceArn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${HmaLogGroupName}:*"
+
+  HmaCwBridgeLogSubscription:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: HmaCloudWatchBridgeEnabled
+    # The permission must exist before CloudWatch Logs can validate the
+    # subscription target -- otherwise CreateSubscriptionFilter fails with an
+    # InvalidParameterException on the destination Lambda.
+    DependsOn: HmaCwBridgeLogPermission
+    Properties:
+      LogGroupName: !Ref HmaLogGroupName
+      # HMA writes one JSON object per log line with a discriminator field
+      # `HealthMonitoringAgentDetectionEvent`. Selecting on that field means
+      # unrelated lines in the same log group (e.g., LifecycleConfig streams)
+      # never invoke the Lambda.
+      FilterPattern: '{ $.HealthMonitoringAgentDetectionEvent = "HealthEvent" }'
+      DestinationArn: !GetAtt HmaCwBridgeFunction.Arn
 
   # ============================================================ Periodic audit (toggleable)
 
@@ -3035,3 +3629,8 @@ Outputs:
   EmailNotifierFunctionName:
     Value: !Ref EmailNotifierFunction
     Description: "Name of the email notifier Lambda (for log tailing)."
+
+  HmaCwBridgeFunctionName:
+    Condition: HmaCloudWatchBridgeEnabled
+    Value: !Ref HmaCwBridgeFunction
+    Description: "Name of the HMA CloudWatch bridge Lambda (Slurm-only, for log tailing)."

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/lambda/hma_cw_bridge.py
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/lambda/hma_cw_bridge.py
@@ -1,0 +1,429 @@
+"""Bridge HMA CloudWatch Logs detection events onto EventBridge (Slurm only).
+
+Why this exists
+---------------
+On EKS-orchestrated HyperPod clusters, the control plane emits a Warn-level
+`SageMaker HyperPod Cluster Event` on EventBridge whenever HMA detects a GPU
+fault (NvidiaGPUUnhealthy, ECC DBE, etc.). That event flows through the
+webhook bridge Lambda into DevOps Agent and produces an investigation email.
+
+On Slurm-orchestrated HyperPod clusters today, the HyperPod control plane
+does NOT emit that Warn-level event for HMA-attributed faults. HMA still
+writes its detection JSON to the cluster's CloudWatch log group
+(SagemakerHealthMonitoringAgent/<group>/<instance>), and HyperPod still
+initiates node replacement, but no operator-visible EventBridge event is
+produced -- the DevOps Agent pipeline never runs for HMA-origin faults on
+Slurm.
+
+This Lambda closes that gap. A CloudWatch Logs subscription filter on the
+cluster's log group (with FilterPattern
+`{ $.HealthMonitoringAgentDetectionEvent = "HealthEvent" }`) invokes this
+Lambda for every HMA detection record. The Lambda extracts fault type +
+repair action + instance ID from the HMA record and calls `events:PutEvents`
+with a synthetic `SageMaker HyperPod Cluster Event` shaped identically to
+what HyperPod emits on EKS -- so the existing webhook bridge picks it up
+unchanged, no downstream code changes required.
+
+This is a Slurm-only workaround. Enabled by the CFN parameter
+`EnableHmaCloudWatchBridge`, which `deploy.sh` auto-resolves to `true` for
+Slurm and `false` for EKS. On EKS the subscription filter and this Lambda
+are simply not deployed -- HyperPod's native event still flows.
+
+Environment variables
+---------------------
+  CLUSTER_NAME     HyperPod cluster name (goes into the synthetic event).
+  EVENT_BUS_NAME   EventBridge bus to publish onto. Default: "default".
+  LOG_LEVEL        Structured-log level (INFO or DEBUG). Default: INFO.
+
+CloudWatch Logs invocation contract
+-----------------------------------
+CloudWatch delivers a gzipped, base64-encoded payload:
+
+  {
+    "awslogs": {
+      "data": "<base64-encoded gzip of the actual JSON>"
+    }
+  }
+
+The decoded JSON has this shape:
+
+  {
+    "messageType": "DATA_MESSAGE",
+    "owner": "<account-id>",
+    "logGroup": "/aws/sagemaker/Clusters/<name>/<id>",
+    "logStream": "SagemakerHealthMonitoringAgent/<group>/<instance>",
+    "subscriptionFilters": [...],
+    "logEvents": [
+      {"id": "...", "timestamp": ..., "message": "<HMA JSON record>"},
+      ...
+    ]
+  }
+
+Each `message` is a JSON string that HMA wrote, e.g.:
+
+  {"level":"info","ts":"2026-07-20T22:53:17Z",
+   "msg":"DCGM Policy Violation found ",
+   "condition: ":"XID Error","data: ":{"ErrNum":79},
+   "HealthMonitoringAgentDetectionEvent":"HealthEvent"}
+
+On EKS the corresponding record (which we don't run against) has richer
+context including `"Event detail":{"Action":"replace","Type":"NvidiaGPUUnhealthy",...}`.
+We support both shapes below via best-effort field extraction.
+"""
+import base64
+import datetime
+import gzip
+import json
+import os
+import re
+
+import boto3
+
+
+_events_client = None
+
+
+def _log(level: str, event: str, **kwargs) -> None:
+    """Emit one structured-JSON log line for CloudWatch Logs Insights.
+
+    Matches the shape used by webhook_bridge.py / periodic_audit.py /
+    email_notifier.py: one JSON object per line with `level`, `event`, and
+    arbitrary context kwargs.
+    """
+    print(json.dumps({"level": level, "event": event, **kwargs}, default=str))
+
+
+def _events():
+    global _events_client
+    if _events_client is None:
+        _events_client = boto3.client("events")
+    return _events_client
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+# Instance-id parsing from the log stream name.
+# Stream shape: SagemakerHealthMonitoringAgent/<instance-group>/<instance-id>
+_STREAM_RE = re.compile(
+    r"^SagemakerHealthMonitoringAgent/(?P<ig>[^/]+)/(?P<iid>i-[0-9a-f]+)$"
+)
+
+
+def _parse_log_stream(log_stream: str) -> tuple[str, str]:
+    """Return (instance_group, instance_id) parsed from the log-stream name.
+
+    Falls back to ("", "") if the stream doesn't match the expected shape --
+    the synthesized event will carry empty fields rather than fail, and the
+    RCA skill can still reason from Description + timestamp.
+    """
+    if not log_stream:
+        return "", ""
+    m = _STREAM_RE.match(log_stream)
+    if not m:
+        return "", ""
+    return m.group("ig"), m.group("iid")
+
+
+def _extract_fault(record: dict) -> tuple[str, str, str]:
+    """Return (fault_type, repair_action, message) from an HMA JSON record.
+
+    HMA records come in a few different shapes depending on the emitting
+    daemon and orchestrator. We try each known shape in order, falling back
+    to best-effort text extraction. Returns empty strings for any field we
+    can't confidently populate -- downstream code inlines a raw excerpt.
+    """
+    # Shape 1: EKS NPD-caught health event (richest)
+    #   {"Event detail":{"Action":"replace","Type":"NvidiaGPUUnhealthy",
+    #                    "Reason":"NvidiaGpuXidErrorPendingReplacement",
+    #                    "Message":"NVRM: Xid (...): 74 ..."}}
+    ev = record.get("Event detail") or record.get("EventDetail") or {}
+    if isinstance(ev, dict) and ev:
+        return (
+            str(ev.get("Type") or ev.get("Reason") or "").strip(),
+            str(ev.get("Action") or "").strip(),
+            str(ev.get("Message") or "").strip(),
+        )
+
+    # Shape 2: Slurm DCGM Policy Violation
+    #   {"msg":"DCGM Policy Violation found ",
+    #    "condition: ":"XID Error","data: ":{"ErrNum":79}}
+    msg = str(record.get("msg") or "").strip()
+    cond = str(record.get("condition: ") or record.get("condition") or "").strip()
+    data = record.get("data: ") or record.get("data") or {}
+    if cond:
+        # Compose a fault_type from condition + specific error number if present
+        fault_type = cond
+        if isinstance(data, dict):
+            err_num = data.get("ErrNum") or data.get("errNum") or data.get("Xid")
+            if err_num is not None:
+                fault_type = f"{cond} (code={err_num})"
+        # DCGM Policy Violation events on Slurm typically imply replace-grade
+        return fault_type, "Replace", msg or f"HMA detected {fault_type}"
+
+    # Shape 3: NPD condition transition
+    #   {"msg":"NPD caught positive condition",
+    #    "condition details":{"type":"NvidiaGPUUnhealthy","status":"True", ...}}
+    cd = record.get("condition details") or {}
+    if isinstance(cd, dict) and cd.get("type"):
+        return (
+            str(cd.get("type") or "").strip(),
+            "Replace",  # NPD-caught HMA conditions are treated as replace-grade
+            str(cd.get("message") or msg or "").strip(),
+        )
+
+    # Shape 4: last-resort — echo the msg as fault_type if that's all we have
+    if msg:
+        return msg, "", msg
+
+    return "", "", ""
+
+
+def _build_synthetic_event(
+    cluster_name: str,
+    instance_group: str,
+    instance_id: str,
+    fault_type: str,
+    repair_action: str,
+    original_message: str,
+    event_time_iso: str,
+    region: str,
+    account_id: str,
+) -> dict:
+    """Shape a synthetic `SageMaker HyperPod Cluster Event` for PutEvents.
+
+    Matches the shape HyperPod emits natively on EKS (see round-2 live
+    verification 2026-07-20T22:54:17Z on test-eks), so the existing webhook
+    bridge Lambda's Cluster Event handler picks it up verbatim.
+    """
+    cluster_arn = f"arn:aws:sagemaker:{region}:{account_id}:cluster/{cluster_name}" if account_id and region else ""
+    # Description matches EKS control-plane wording so operators see identical
+    # subject lines regardless of orchestrator.
+    fault_display = fault_type or "unknown fault"
+    action_display = repair_action or "unknown"
+    description = (
+        f"Instance {instance_id} is unhealthy. "
+        f"HyperPod Health Monitoring Agent (HMA) has detected fault type "
+        f"{fault_display} on this node and is unhealthy. "
+        f"Repair action: {action_display}."
+    )
+    if original_message and original_message not in description:
+        description += f" HMA detail: {original_message}"
+
+    detail = {
+        "EventDetails": {
+            "EventId": "synthetic-hma-cw-bridge",  # not a real cluster-event ID
+            "ClusterArn": cluster_arn,
+            "ClusterName": cluster_name,
+            "InstanceGroupName": instance_group,
+            "InstanceId": instance_id,
+            "ResourceType": "Instance",
+            "EventTime": event_time_iso,
+            "Description": description,
+            "EventLevel": "Warn",
+            "OperationId": "",
+            "EventMetadata": {
+                "Instance": {
+                    "NodeHealthInfo": {
+                        "HealthStatus": "Unhealthy",
+                        "HealthStatusReason": (
+                            f"HyperPod Health Monitoring Agent (HMA) has detected "
+                            f"fault type {fault_display} on this node and is unhealthy."
+                        ),
+                        "RepairAction": repair_action or "",
+                        "Recommendation": (
+                            "HyperPod is working on repairing the unhealthy node. "
+                            "Please wait for the RepairAction to complete."
+                        ),
+                    }
+                }
+            },
+            # Provenance marker so operators can distinguish synthesized vs native
+            # events in the DevOps Agent journal / CloudWatch trail.
+            "SyntheticSource": "hma-cw-bridge",
+        }
+    }
+    return {
+        # Custom source. AWS EventBridge reserves the `aws.*` prefix for events
+        # emitted by AWS services, so PutEvents from customer code cannot spoof
+        # `aws.sagemaker` — a first attempt with that source returned
+        # `NotAuthorizedForSourceException`. Naming matches the pattern used by
+        # periodic_audit.py's synthesized `originalEvent.source`
+        # (`hyperpod-devops-agent-periodic-audit`) for within-codebase
+        # consistency. `HyperPodEventRule.EventPattern` in the CFN template
+        # explicitly accepts this source alongside `aws.sagemaker`.
+        "Source": "hyperpod-devops-agent-hma-cw-bridge",
+        "DetailType": "SageMaker HyperPod Cluster Event",
+        "Detail": json.dumps(detail),
+        "EventBusName": os.environ.get("EVENT_BUS_NAME", "default"),
+    }
+
+
+def _decode_cwlogs_payload(event: dict) -> dict:
+    """Decode the gzipped+base64 payload CloudWatch Logs delivers.
+
+    Raises ValueError on malformed input rather than swallowing -- Lambda
+    will surface it and CloudWatch will retry.
+    """
+    if "awslogs" not in event or "data" not in event["awslogs"]:
+        raise ValueError("event missing awslogs.data envelope")
+    raw = base64.b64decode(event["awslogs"]["data"])
+    decompressed = gzip.decompress(raw)
+    return json.loads(decompressed)
+
+
+def _parse_hma_record(message: str) -> dict:
+    """Parse the raw log-line message as JSON, or {} on failure.
+
+    HMA writes JSON per line. Non-JSON lines (unlikely given the subscription
+    filter's FilterPattern, but not impossible) are silently skipped so a
+    single malformed record doesn't fail the whole batch.
+    """
+    if not message:
+        return {}
+    try:
+        parsed = json.loads(message)
+        return parsed if isinstance(parsed, dict) else {}
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {}
+
+
+def _put_events_with_retry(entries: list[dict], max_attempts: int = 2) -> dict:
+    """Best-effort PutEvents with one retry on ThrottlingException.
+
+    Returns the PutEvents response of the last attempt. Non-throttling errors
+    bubble up (Lambda logs them; CloudWatch Logs subscription doesn't retry
+    async invocations by default -- see IMPLEMENTATION.md for the failure
+    semantics).
+    """
+    last_response = None
+    for attempt in range(max_attempts):
+        response = _events().put_events(Entries=entries)
+        last_response = response
+        failed_count = response.get("FailedEntryCount", 0)
+        if failed_count == 0:
+            return response
+        # Throttling shows up as ErrorCode "ThrottlingException" per entry
+        transient = any(
+            (e.get("ErrorCode") or "") in ("ThrottlingException", "InternalException")
+            for e in response.get("Entries", [])
+            if "ErrorCode" in e
+        )
+        if not transient or attempt == max_attempts - 1:
+            _log(
+                "ERROR",
+                "put_events_failed",
+                failedCount=failed_count,
+                entries=response.get("Entries"),
+            )
+            return response
+        _log("WARN", "put_events_retry", attempt=attempt + 1, failedCount=failed_count)
+    return last_response or {}
+
+
+def lambda_handler(event, context):
+    """CloudWatch Logs subscription invocation entry point."""
+    cluster_name = os.environ.get("CLUSTER_NAME", "unknown-cluster")
+    region = os.environ.get("AWS_REGION", "")
+    account_id = ""
+    # AWS Lambda populates AWS_LAMBDA_FUNCTION_ARN; parse account from it.
+    fn_arn = os.environ.get("AWS_LAMBDA_FUNCTION_ARN", "")
+    if fn_arn.startswith("arn:"):
+        parts = fn_arn.split(":")
+        if len(parts) >= 5:
+            account_id = parts[4]
+
+    try:
+        payload = _decode_cwlogs_payload(event)
+    except (ValueError, gzip.BadGzipFile) as exc:
+        _log("ERROR", "payload_decode_failed", error=repr(exc))
+        # Re-raise so Lambda records the failure metric; do not silently drop.
+        raise
+
+    log_stream = payload.get("logStream", "")
+    log_events = payload.get("logEvents", []) or []
+    _log(
+        "INFO",
+        "cw_batch_received",
+        logStream=log_stream,
+        recordCount=len(log_events),
+    )
+
+    instance_group, instance_id = _parse_log_stream(log_stream)
+
+    entries: list[dict] = []
+    skipped = 0
+    for record_wrapper in log_events:
+        message = record_wrapper.get("message", "")
+        record = _parse_hma_record(message)
+        if not record:
+            skipped += 1
+            continue
+        # Extra defensive gate: even though the CW subscription-filter
+        # FilterPattern already selects only records with
+        # HealthMonitoringAgentDetectionEvent == "HealthEvent", re-check here
+        # so a mis-configured filter can't accidentally forward arbitrary
+        # non-HMA log lines onto EventBridge.
+        if record.get("HealthMonitoringAgentDetectionEvent") != "HealthEvent":
+            skipped += 1
+            continue
+
+        fault_type, repair_action, original_message = _extract_fault(record)
+        if not fault_type:
+            _log(
+                "WARN",
+                "unparseable_hma_record",
+                logStream=log_stream,
+                sample=message[:200],
+            )
+            skipped += 1
+            continue
+
+        # Prefer HMA-record timestamp; fall back to CW record timestamp; last
+        # resort is now().
+        event_time_iso = str(record.get("ts") or "").strip()
+        if not event_time_iso:
+            ts_ms = record_wrapper.get("timestamp")
+            if isinstance(ts_ms, int):
+                event_time_iso = datetime.datetime.fromtimestamp(
+                    ts_ms / 1000, tz=datetime.timezone.utc
+                ).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        if not event_time_iso:
+            event_time_iso = _now_iso()
+
+        synthesized = _build_synthetic_event(
+            cluster_name=cluster_name,
+            instance_group=instance_group,
+            instance_id=instance_id,
+            fault_type=fault_type,
+            repair_action=repair_action,
+            original_message=original_message,
+            event_time_iso=event_time_iso,
+            region=region,
+            account_id=account_id,
+        )
+        entries.append(synthesized)
+        _log(
+            "INFO",
+            "hma_record_processed",
+            faultType=fault_type,
+            action=repair_action,
+            instanceId=instance_id,
+            eventTime=event_time_iso,
+        )
+
+    if not entries:
+        _log("INFO", "no_entries_to_forward", skipped=skipped)
+        return {"forwarded": 0, "skipped": skipped}
+
+    # PutEvents accepts up to 10 entries per call; batch defensively.
+    forwarded = 0
+    for i in range(0, len(entries), 10):
+        batch = entries[i : i + 10]
+        response = _put_events_with_retry(batch)
+        failed_count = response.get("FailedEntryCount", 0)
+        forwarded += len(batch) - failed_count
+
+    _log("INFO", "batch_complete", forwarded=forwarded, skipped=skipped)
+    return {"forwarded": forwarded, "skipped": skipped}

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/lambda/hma_cw_bridge.py
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/lambda/hma_cw_bridge.py
@@ -213,7 +213,7 @@ def _build_synthetic_event(
 
     detail = {
         "EventDetails": {
-            "EventId": "synthetic-hma-cw-bridge",  # not a real cluster-event ID
+            "EventId": "",  # not a real cluster-event ID
             "ClusterArn": cluster_arn,
             "ClusterName": cluster_name,
             "InstanceGroupName": instance_group,

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/lambda/webhook_bridge.py
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/lambda/webhook_bridge.py
@@ -26,6 +26,27 @@ import boto3
 # (comma-separated) if needed without redeploying.
 _DEFAULT_DROP_LEVELS = {"info"}
 
+# Known detail-types with dedicated handlers in `_title_and_description`.
+# Any detail-type NOT in this set (e.g. a future `SageMaker HyperPod
+# <NewName>` variant that the widened prefix rule newly routes here) is
+# gated by EventLevel in `lambda_handler` before reaching the generic-
+# fallback branch — see `_is_unknown_detail_type_below_severity`. This
+# preserves the "POST only on real issues" cost model on the DevOps
+# Agent side: we only pay for a triage/RCA when the emitter labels the
+# event severity as high, or when the detail-type is one of the three
+# we already know how to shape.
+_KNOWN_DETAIL_TYPES = frozenset({
+    "SageMaker HyperPod Cluster State Change",
+    "SageMaker HyperPod Cluster Node Health Event",
+    "SageMaker HyperPod Cluster Event",
+})
+
+# EventLevel values considered "real issue" for unknown detail-types.
+# Missing/empty EventLevel is treated as below threshold — safer default
+# since a level-less unknown-type emission gives us no signal to base
+# a paid investigation on.
+_UNKNOWN_TYPE_FORWARD_LEVELS = frozenset({"warn", "error", "critical"})
+
 
 _secrets_cache: dict[str, str] = {}
 _sagemaker_client = None
@@ -142,6 +163,26 @@ def _is_scale_progress_noise(event: dict) -> bool:
     ev_details = detail.get("EventDetails", {})
     description = ev_details.get("Description", "")
     return "lost orchestration-ready status" in description
+
+
+def _is_unknown_detail_type_below_severity(event: dict) -> bool:
+    """Drop-check for detail-types the prefix rule caught but we don't
+    have a dedicated handler for.
+
+    Rationale: the widened rule (`prefix: "SageMaker HyperPod"`) routes
+    all current AND future HyperPod-native detail-types to this Lambda.
+    For the three we know (see `_KNOWN_DETAIL_TYPES`), the existing per-
+    detail-type handlers in `_title_and_description` produce structured
+    titles. For anything else we don't know the shape, so gate on
+    EventLevel to keep the cost model of "one paid investigation per
+    real issue". Level-less or `Info` events from an unknown detail-type
+    are dropped here.
+    """
+    detail_type = event.get("detail-type", "")
+    if detail_type in _KNOWN_DETAIL_TYPES:
+        return False
+    level = (_event_level(event) or "").lower()
+    return level not in _UNKNOWN_TYPE_FORWARD_LEVELS
 
 
 def _should_drop(event: dict) -> tuple[bool, str | None]:
@@ -345,12 +386,18 @@ def _title_and_description(event: dict) -> tuple[str, str]:
             description += f" EventMetadata: {extras_str}."
         return title, description
 
-    # -------------------- Generic fallback (improved) --------------------
-    # Any unrecognized detail-type falls here. Rather than emitting an empty
-    # description that hides the event body from the RCA skill, inline a
-    # compact JSON of the raw detail so operators still get an actionable
-    # investigation email. Truncated to a reasonable size to keep the payload
-    # bounded — the full event is still available in `data.originalEvent`.
+    # -------------------- Generic fallback (post-severity-gate) --------------------
+    # By the time execution reaches here we know:
+    #   (a) detail_type is NOT one of the three known types (they returned
+    #       above via their dedicated branches), AND
+    #   (b) EventLevel is Warn/Error/Critical (else
+    #       `_is_unknown_detail_type_below_severity` in lambda_handler
+    #       already dropped this event before we were called).
+    # So this is a real-severity unknown detail-type — worth an investigation
+    # email. Inline a compact JSON of the raw detail so the RCA skill has
+    # structured signal to reason from. Truncated to a reasonable size to
+    # keep the payload bounded — the full event is still available in
+    # `data.originalEvent`.
     try:
         detail_json = json.dumps(detail, default=str, sort_keys=True)
     except (TypeError, ValueError):
@@ -468,6 +515,13 @@ def lambda_handler(event, context):
     if _is_scale_progress_noise(event):
         _log("INFO", "event_dropped", reason="scale-progress-noise")
         return {"statusCode": 200, "body": json.dumps({"dropped": True, "reason": "scale-progress-noise"})}
+
+    if _is_unknown_detail_type_below_severity(event):
+        _log("INFO", "event_dropped",
+             reason="unknown-detail-type-below-severity",
+             detailType=event.get("detail-type"),
+             eventLevel=_event_level(event) or "unset")
+        return {"statusCode": 200, "body": json.dumps({"dropped": True, "reason": "unknown-detail-type-below-severity"})}
 
     webhook_url, secret = _load_webhook_credentials()
     payload = _build_payload(event)

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/lambda/webhook_bridge.py
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/lambda/webhook_bridge.py
@@ -345,10 +345,24 @@ def _title_and_description(event: dict) -> tuple[str, str]:
             description += f" EventMetadata: {extras_str}."
         return title, description
 
+    # -------------------- Generic fallback (improved) --------------------
+    # Any unrecognized detail-type falls here. Rather than emitting an empty
+    # description that hides the event body from the RCA skill, inline a
+    # compact JSON of the raw detail so operators still get an actionable
+    # investigation email. Truncated to a reasonable size to keep the payload
+    # bounded — the full event is still available in `data.originalEvent`.
+    try:
+        detail_json = json.dumps(detail, default=str, sort_keys=True)
+    except (TypeError, ValueError):
+        detail_json = str(detail)
+    if len(detail_json) > 2000:
+        detail_json = detail_json[:2000] + "…(truncated)"
+
     return (
         f"HyperPod event: {detail_type} on {cluster_name}",
         f"HyperPod cluster '{cluster_name}' (account {account}, {region}) emitted an event of type "
-        f"'{detail_type}'. Raw detail attached.",
+        f"'{detail_type}'. No dedicated handler for this detail-type; the RCA skill should treat "
+        f"the following inlined detail as ground truth. Detail: {detail_json}",
     )
 
 

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/params.example.json
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/params.example.json
@@ -20,5 +20,10 @@
   "__off_ConsoleUrlTemplate": "https://%agent_space_id%.aidevops.global.app.aws/investigation/%task_id%",
   "__off_ForceSend": "false",
   "__off_MarkerExpirationDays": "30",
-  "__off_LcsBucketArnPattern": "arn:aws:s3:::sagemaker-*-bucket"
+  "__off_LcsBucketArnPattern": "arn:aws:s3:::sagemaker-*-bucket",
+
+  "__README_HMA_BRIDGE__": "HMA CloudWatch bridge (Slurm-only workaround). 'make deploy' auto-sets EnableHmaCloudWatchBridge=true for Slurm clusters and 'false' for EKS. HmaLogGroupName is auto-derived from the cluster's ARN. Override these only if you have a non-standard cluster log-group naming pattern OR you want to force-disable the bridge on a Slurm cluster.",
+  "__off_EnableHmaCloudWatchBridge": "false",
+  "__off_HmaLogGroupName": "",
+  "__off_HmaBridgeLambdaMemory": "128"
 }

--- a/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/prepare_deployment.py
+++ b/1.architectures/5.sagemaker-hyperpod/tools/devops-agent/deploy/prepare_deployment.py
@@ -59,6 +59,7 @@ PLACEHOLDERS = {
     "PERIODIC_AUDIT_CODE_PLACEHOLDER": "periodic_audit.py",
     "EMAIL_NOTIFIER_CODE_PLACEHOLDER": "email_notifier.py",
     "CR_WEBHOOK_PROVISIONER_CODE_PLACEHOLDER": "cr_webhook_provisioner.py",
+    "HMA_CW_BRIDGE_CODE_PLACEHOLDER": "hma_cw_bridge.py",
 }
 
 # Minimum boto3 that includes the DevOps Agent Asset API (list_assets etc.).


### PR DESCRIPTION
### What

- Adds a **Slurm-only CloudWatch Logs subscription filter → tiny Lambda → `events:PutEvents`** path that synthesizes a `SageMaker HyperPod Cluster Event Warn` from HMA detection records. Downstream pipeline (bridge Lambda → DevOps Agent → RCA → email) unchanged.
- **Widens** the `HyperPodEventRule` EventBridge pattern to catch the Slurm-drift and Deep-Health-Check event families that were previously silently dropped (hybrid `prefix: "SageMaker HyperPod"` + explicit list).
- Adds **dedicated bridge Lambda handlers** for `DeepHealthCheckCompleted`/`Failed`, `SlurmConfigurationDriftDetected`, `SlurmReconfigurationCompleted`, `SlurmTopologyUpdated`, `MungeKeyCreated`. Improves the **generic-fallback branch** to inline compact JSON of `detail` for any unrecognized detail-type.
- Documentation: `README.md` (new HMA-bridge Slurm-only section), `IMPLEMENTATION.md` (short design rationale + design-boundary note on Monitor re-checks), `IDEAS.md` (marks the CloudWatch-subscription-filter idea as shipped).

### Why

- **Silent-drop bug 1 (Slurm HMA)**: On Slurm-orchestrated HyperPod clusters, the control plane does **not** currently emit the `Warn`-level HMA-attribution `Cluster Event` on EventBridge that EKS emits natively. HMA still writes its detection JSON to CloudWatch Logs and HyperPod still initiates node replacement, but no operator-visible EventBridge event is produced, so the DevOps Agent pipeline never runs for HMA-origin faults on Slurm. Live-verified on 2026-07-20: Slurm cluster HMA detected Xid 79 within 4 s of injection, wrote to CloudWatch stream `SagemakerHealthMonitoringAgent/worker-gpu/i-…`, but no operator-visible EventBridge event fired, and no email was produced.

- **Silent-drop bug 2 (EventBridge rule too narrow)**: The current rule enumerates 3 detail-types. Newer HyperPod detail-types (`SlurmConfigurationDriftDetected`, `SlurmReconfigurationCompleted`, `SlurmTopologyUpdated`, `MungeKeyCreated`, `DeepHealthCheckCompleted`/`Failed`) don't match the rule and are silently dropped before the bridge Lambda sees them.

Both are behavior bugs in the shipped solution, not new capabilities.

## Purpose

<!-- Link related issues using "Fixes #123" or "Relates to #123" -->

## Changes

<!-- Summarize the changes made in this PR -->

-

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:
- Instance type:
- Number of nodes:

**Test commands:**
```bash

```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
