### PR TITLE
docs(parallelcluster): bump ParallelCluster CLI pin to 3.15.1

### DIFF
--- a/1.architectures/2.aws-parallelcluster/README.md
+++ b/1.architectures/2.aws-parallelcluster/README.md
@@ -39,7 +39,7 @@ Before you begin, ensure you have the following tools installed on your local ma
 - **Git**: For cloning the repository and version control
   - Installation: [Git download page](https://git-scm.com/downloads)
 
-- **Python 3.8 or later**: Required for AWS ParallelCluster CLI
+- **Python 3.9 or later**: Required for AWS ParallelCluster CLI
   - Installation: [Python download page](https://www.python.org/downloads/)
   - Verify with: `python3 --version`
 
@@ -65,7 +65,7 @@ Then create a directory under home directory to store cluster config files:
 # For example
 export AWS_REGION=ap-northeast-1
 export CLUSTER_NAME=ml-cluster
-export PCLUSTER_VERSION=3.14.2
+export PCLUSTER_VERSION=3.15.1
 export CONFIG_DIR="${HOME}/${CLUSTER_NAME}_${AWS_REGION}_${PCLUSTER_VERSION}"
 
 mkdir -p ${CONFIG_DIR}
@@ -89,7 +89,7 @@ The rest of this section describes following required/optional components.
 To deploy AWS ParallelCluster, you need to be an Administrator user of the AWS account. See [this issue](https://github.com/aws/aws-parallelcluster/issues/2060) for the related discussion. You need to use the IAM user to create clusters using AWS ParallelCluster CLI from local console, for that you need to configure your AWS credentials by running `aws configure`.
 
 #### AWS ParallelCluster CLI for cluster deployment and management
-The AWS ParallelCluster CLI is a command-line tool that helps you deploy and manage HPC clusters on AWS. It provides commands for creating, updating, and deleting clusters, as well as managing cluster resources. The CLI is built on top of the AWS SDK and provides a simple interface for interacting with AWS ParallelCluster. For detailed information about the CLI and its commands, refer to the [AWS ParallelCluster Command Line Interface Reference](https://docs.aws.amazon.com/parallelcluster/latest/ug/commands-v3.html). The CLI requires Python 3.8 or later installed on your local environment.
+The AWS ParallelCluster CLI is a command-line tool that helps you deploy and manage HPC clusters on AWS. It provides commands for creating, updating, and deleting clusters, as well as managing cluster resources. The CLI is built on top of the AWS SDK and provides a simple interface for interacting with AWS ParallelCluster. For detailed information about the CLI and its commands, refer to the [AWS ParallelCluster Command Line Interface Reference](https://docs.aws.amazon.com/parallelcluster/latest/ug/commands-v3.html). The CLI requires Python 3.9 or later installed on your local environment.
 
 You can install the AWS ParallelCluster CLI using pip in a Python virtual environment:
 
@@ -333,7 +333,7 @@ cat  ${CONFIG_DIR}/config.yaml
 # Example values - these will vary by environment
 CLUSTER_NAME: ml-cluster
 AWS_REGION: eu-west-2
-PCLUSTER_VERSION: 3.14.2
+PCLUSTER_VERSION: 3.15.1
 CAPACITY_RESERVATION_ID: cr-XXXXXXXXXXXXXXXXX
 AZ: eu-west-2c
 NUM_INSTANCES: "16"
@@ -410,7 +410,7 @@ You should see output similar to:
     "cloudformationStackStatus": "CREATE_IN_PROGRESS",
     "cloudformationStackArn": "arn:aws:cloudformation:ap-northeast-1:123456789012:stack/ml-cluster/abcd1234-...",
     "region": "ap-northeast-1",
-    "version": "3.14.2",
+    "version": "3.15.1",
     "clusterStatus": "CREATE_IN_PROGRESS",
     "scheduler": {
       "type": "slurm"


### PR DESCRIPTION
Bumps the AWS ParallelCluster CLI pin in `1.architectures/2.aws-parallelcluster/README.md` from **3.14.2** to **3.15.1**, the latest stable release (2026-05-28).

Also raises the documented minimum Python from 3.8 to 3.9 — `aws-parallelcluster` 3.15.1 declares `requires_python >=3.9`, so the previous statement was inaccurate.

**Why 3.15.x matters here:** adds p6-b300 support; upgrades Slurm to 25.11.4, EFA installer to 1.47.0, NVIDIA driver to 580.126.20, CUDA to 13.0.2, DCGM to 4.5.1; and reduces EFA IP consumption to one address per instance rather than per network card. 3.15.1 additionally patches CVE-2026-31431.

**No config changes needed.** The only configuration parameter removed in the 3.14.2 → 3.15.1 delta is `LoginNodes/Pools/Ssh/KeyName`, which `cluster-templates/cluster-vanilla.yaml` does not use. Other schema additions (`LaunchTemplateOverrides`, `DevSettings: EfaInterfaceType`) are opt-in.

**Validation** (no cluster created): installed `aws-parallelcluster==3.15.1` in a clean venv, rendered `cluster-vanilla.yaml` with placeholder IDs, and ran `pcluster create-cluster --dryrun true` — it passed schema validation and failed only on the non-existent placeholder subnet. Independently confirmed by loading the rendered config through 3.15.1's `ClusterSchema`.

**Note:** 3.15.0 is the last release supporting Amazon Linux 2 (EOL 2026-06-30) and the AWS Batch scheduler; neither is used by this architecture.
