### PR TITLE
docs(pcluster): install AWS CLI v2 via official installer instead of pip

### DIFF
--- a/1.architectures/2.aws-parallelcluster/README.md
+++ b/1.architectures/2.aws-parallelcluster/README.md
@@ -91,16 +91,12 @@ To deploy AWS ParallelCluster, you need to be an Administrator user of the AWS a
 #### AWS ParallelCluster CLI for cluster deployment and management
 The AWS ParallelCluster CLI is a command-line tool that helps you deploy and manage HPC clusters on AWS. It provides commands for creating, updating, and deleting clusters, as well as managing cluster resources. The CLI is built on top of the AWS SDK and provides a simple interface for interacting with AWS ParallelCluster. For detailed information about the CLI and its commands, refer to the [AWS ParallelCluster Command Line Interface Reference](https://docs.aws.amazon.com/parallelcluster/latest/ug/commands-v3.html). The CLI requires Python 3.9 or later installed on your local environment.
 
-You also need the AWS CLI to configure your credentials (`aws configure`). Install
-**AWS CLI v2** if it is not already available on your machine — note that v2 is *not*
-distributed via pip and must be installed with the official installer:
-
-```bash
-# Skip this if `aws --version` already reports aws-cli/2.x
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip && sudo ./aws/install
-# For Graviton/ARM hosts, use awscli-exe-linux-aarch64.zip instead
-```
+You also need the AWS CLI to configure your credentials (`aws configure`). If it is
+not already available on your machine (run `aws --version` to check), install
+**AWS CLI v2** by following the official
+[Install or update to the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+guide, which covers Linux, macOS, and Windows. Note that AWS CLI v2 is *not*
+distributed via pip.
 
 You can then install the AWS ParallelCluster CLI using pip in a Python virtual environment:
 

--- a/1.architectures/2.aws-parallelcluster/README.md
+++ b/1.architectures/2.aws-parallelcluster/README.md
@@ -91,7 +91,18 @@ To deploy AWS ParallelCluster, you need to be an Administrator user of the AWS a
 #### AWS ParallelCluster CLI for cluster deployment and management
 The AWS ParallelCluster CLI is a command-line tool that helps you deploy and manage HPC clusters on AWS. It provides commands for creating, updating, and deleting clusters, as well as managing cluster resources. The CLI is built on top of the AWS SDK and provides a simple interface for interacting with AWS ParallelCluster. For detailed information about the CLI and its commands, refer to the [AWS ParallelCluster Command Line Interface Reference](https://docs.aws.amazon.com/parallelcluster/latest/ug/commands-v3.html). The CLI requires Python 3.9 or later installed on your local environment.
 
-You can install the AWS ParallelCluster CLI using pip in a Python virtual environment:
+You also need the AWS CLI to configure your credentials (`aws configure`). Install
+**AWS CLI v2** if it is not already available on your machine — note that v2 is *not*
+distributed via pip and must be installed with the official installer:
+
+```bash
+# Skip this if `aws --version` already reports aws-cli/2.x
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip && sudo ./aws/install
+# For Graviton/ARM hosts, use awscli-exe-linux-aarch64.zip instead
+```
+
+You can then install the AWS ParallelCluster CLI using pip in a Python virtual environment:
 
 
 ```bash
@@ -101,8 +112,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --user --upgrade virtualenv
 python3 -m virtualenv ${VIRTUAL_ENV_PATH} # create the virtual env
 source ${VIRTUAL_ENV_PATH}/bin/activate # activate the environment
-pip3 install awscli # install the AWS CLI
-pip3 install aws-parallelcluster==${PCLUSTER_VERSION} # then AWS ParallelCluster
+pip3 install aws-parallelcluster==${PCLUSTER_VERSION} # install AWS ParallelCluster
 ```
 
 #### Reserved accelerated instance capacity (P/Trn instances) through  On-Demand Capacity Reservation (ODCR) or EC2 Capacity Blocks (CB) for ML


### PR DESCRIPTION
## Problem

The ParallelCluster setup instructions install the AWS CLI with `pip3 install awscli` inside the Python virtual environment. Because **AWS CLI v2 is not distributed on PyPI** (pip only serves the legacy v1 `1.x` line), this silently pins users to AWS CLI v1.

## Why this is safe to change

`aws-parallelcluster` depends on `boto3`, **not** on the `awscli` package. The `aws` CLI is only needed here for the `aws configure` credential-setup step referenced earlier in the README — so it does not belong inside the pcluster venv at all.

## Fix

- Remove `pip3 install awscli` from the venv block.
- Add an AWS CLI v2 install step (official bundled installer) before the venv, with a note that v2 is not pip-installable and a Graviton/ARM variant. Guarded by a `aws --version` skip note for environments (CloudShell, DLAMI, etc.) that already ship v2.

Docs-only change.