### PR TITLE
fix(hyperpod-slurm): skip pyxis/enroot install + mount-aware tuning when HyperPod DLAMI already provisions them

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
@@ -73,23 +73,25 @@ fi
 #   - enroot as an installed apt package
 # DLAMI also handles the mount-aware enroot.conf tuning for NVMe / /opt/sagemaker
 # / /fsx
-# Running `install_enroot_pyxis.sh` on top of that produces:
+#
+# Running `install_enroot_pyxis.sh` on top of a full DLAMI baseline produces:
 #   - a duplicate SPANK registration ("srun: spank: option ... provided by both
 #     spank_pyxis.so and spank_pyxis.so" on every job launch), because LCS
 #     installs a second pyxis under /usr/local/lib/slurm/ and adds an
 #     `include .../pyxis.conf` line on top of the DLAMI's direct `required` line;
-#   - redundant apt install of the same enroot version;
-#   - redundant idempotent sed of enroot.conf paths already tuned by HostAgent.
+#   - redundant apt install of the same enroot version.
 #
 # Detect each independently so partial-baseline DLAMIs (e.g. pyxis present but
 # not enroot, or vice versa) still get the piece they are missing, and so LCS
 # behavior on older Packer-built AMIs / bare Ubuntu is unchanged.
 #
 # What is NOT skipped, regardless of detection:
-#   - `cp $BIN_DIR/enroot.conf /etc/enroot/enroot.conf` (LCS copies a different,
-#     broader scoped enroot config that differs from the DLAMI's defaults in ways
-#     containers depend on: ENROOT_ROOTFS_WRITABLE=yes, ENROOT_MOUNT_HOME=no,
-#     ENROOT_RESTRICT_DEV=no, `-comp lzo` squash options, ENROOT_CONFIG_PATH).
+#   - `cp $BIN_DIR/enroot.conf /etc/enroot/enroot.conf` (LCS ships broader flags
+#     that customer container workloads depend on: ENROOT_ROOTFS_WRITABLE=yes,
+#     ENROOT_MOUNT_HOME=no, ENROOT_RESTRICT_DEV=no, `-comp lzo` squash options,
+#     ENROOT_CONFIG_PATH).
+#   - Mount-aware sed for /opt/dlami/nvme / /opt/sagemaker / /fsx (paired with
+#     the cp above - cp brings the flags, sed rescues the paths).
 #   - slurmctld / slurmd restart at the bottom of the script.
 # ------------------------------------------------------------------------------
 DLAMI_PYXIS_INSTALLED=0
@@ -102,14 +104,14 @@ if [[ -f "$SLURM_INSTALL_DIR/lib/slurm/spank_pyxis.so" ]] \
     echo "[INFO] pyxis is already installed and registered by the HyperPod DLAMI"
     echo "[INFO]   binary: $SLURM_INSTALL_DIR/lib/slurm/spank_pyxis.so"
     echo "[INFO]   registration: $(grep -E 'spank_pyxis\.so' "$SLURM_INSTALL_DIR/etc/plugstack.conf" | head -1)"
-    echo "[INFO] LC will skip pyxis build/install and plugstack.conf edit to avoid a duplicate SPANK registration."
+    echo "[INFO] LCS will skip pyxis build/install and plugstack.conf edit to avoid a duplicate SPANK registration."
 fi
 
 if command -v enroot >/dev/null 2>&1; then
     DLAMI_ENROOT_INSTALLED=1
     echo "[INFO] enroot is already installed by the HyperPod DLAMI (version: $(enroot version 2>/dev/null | head -1))"
-    echo "[INFO] LC will skip enroot deb download/install and mount-aware enroot.conf sed"
-    echo "[INFO] (the DLAMI's on-boot HostAgent handles ENROOT_*_PATH tuning for NVMe / /opt/sagemaker / /fsx)."
+    echo "[INFO] LCS will skip the redundant enroot deb download/install."
+    echo "[INFO] Mount-aware enroot.conf tuning still runs below, since LCS's cp overwrites the file with static paths."
 fi
 
 # Guard the destructive rm of $SLURM_INSTALL_DIR/pyxis so we don't wipe the
@@ -164,89 +166,92 @@ chmod 777 -R /tmp/enroot /opt/enroot
 ################################################################################
 # Mount-aware enroot.conf tuning.
 #
-# Skipped when the DLAMI already provisioned enroot (`DLAMI_ENROOT_INSTALLED=1`),
+# ALWAYS runs, regardless of DLAMI detection. The `cp $BIN_DIR/enroot.conf ...`
+# step above unconditionally overwrites /etc/enroot/enroot.conf with LCS's
+# broad flags but *static* paths (ENROOT_CACHE_PATH=/opt/enroot on the
+# root volume, ENROOT_RUNTIME_PATH=/tmp/..., etc.). Without this sed pass
+# immediately after, ENROOT_CACHE_PATH stays on the root volume leading to
+# the first large container pull to fill the root volume and the node degrades.
+#  See: https://github.com/awslabs/awsome-distributed-training/issues/427
 #
-# On older AMIs / bare Ubuntu where LCS installed enroot itself, this block still
-# runs and does the mount-aware sed as before.
+# The `cp` and this sed are a *pair* by design: `cp` brings LCS's broadened
+# flags (writable rootfs, no home mount, lzo squash, etc.), this sed rescues
+# the paths from the `cp`'s static defaults. Do not separate them.
 ################################################################################
-if [[ "$DLAMI_ENROOT_INSTALLED" -eq 0 ]]; then
-    # Below while loop instituted to combat race condition when mapping enroot path to /opt/dlami/nvme
-    MAX_WAIT_TIME=120
-    ELAPSED_TIME=0
-    CHECK_INTERVAL=5
+# Below while loop instituted to combat race condition when mapping enroot path to /opt/dlami/nvme
+MAX_WAIT_TIME=120
+ELAPSED_TIME=0
+CHECK_INTERVAL=5
 
-    while true; do
-        # Check the ActiveState of the lib/systemd/system/dlami-nvme.service
-        ACTIVE_STATE=$(systemctl show dlami-nvme | grep "ActiveState" | cut -d '=' -f 2)
-        # Check the ExecMainStatus of the lib/systemd/system/dlami-nvme.service
-        RESULT_STATE=$(systemctl show dlami-nvme | grep "ExecMainStatus" | cut -d '=' -f 2)
+while true; do
+    # Check the ActiveState of the lib/systemd/system/dlami-nvme.service
+    ACTIVE_STATE=$(systemctl show dlami-nvme | grep "ActiveState" | cut -d '=' -f 2)
+    # Check the ExecMainStatus of the lib/systemd/system/dlami-nvme.service
+    RESULT_STATE=$(systemctl show dlami-nvme | grep "ExecMainStatus" | cut -d '=' -f 2)
 
-        echo "dlami-nvme.service ActiveState: $ACTIVE_STATE"
-        echo "dlami-nvme.service ExecMainStatus: $RESULT_STATE"
+    echo "dlami-nvme.service ActiveState: $ACTIVE_STATE"
+    echo "dlami-nvme.service ExecMainStatus: $RESULT_STATE"
 
-        if [[ "$ACTIVE_STATE" == "active" && "$RESULT_STATE" == "0" ]]; then
-            echo "dlami-nvme.service is active and successful. Proceeding with Enroot configuration on /opt/dlami/nvme if available"
-            break
-        fi
+    if [[ "$ACTIVE_STATE" == "active" && "$RESULT_STATE" == "0" ]]; then
+        echo "dlami-nvme.service is active and successful. Proceeding with Enroot configuration on /opt/dlami/nvme if available"
+        break
+    fi
 
-        ELAPSED_TIME=$((ELAPSED_TIME + CHECK_INTERVAL))
+    ELAPSED_TIME=$((ELAPSED_TIME + CHECK_INTERVAL))
 
-        if [[ $ELAPSED_TIME -ge $MAX_WAIT_TIME ]]; then
-            echo "WARN: Timeout reached: dlami-nvme.service did not become active and successful, it is possible enroot default path is /opt/sagemaker. When training larger models, dragons be here. See https://github.com/awslabs/awsome-distributed-training/issues/427 for corrective actions"
-            break
-        fi
+    if [[ $ELAPSED_TIME -ge $MAX_WAIT_TIME ]]; then
+        echo "WARN: Timeout reached: dlami-nvme.service did not become active and successful, it is possible enroot default path is /opt/sagemaker. When training larger models, dragons be here. See https://github.com/awslabs/awsome-distributed-training/issues/427 for corrective actions"
+        break
+    fi
 
-        sleep $CHECK_INTERVAL
-    done
+    sleep $CHECK_INTERVAL
+done
 
 ####################################################################################################
 
-    # Configure enroot paths based on available mounts
-    if [[ $(mount | grep /opt/dlami/nvme) ]]; then
-        sed -i \
-            -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/user-$(id -u)|' \
-            -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/dlami/nvme/enroot|' \
-            -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/data/user-$(id -u)|' \
-            -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/dlami/nvme/tmp|' \
-            /etc/enroot/enroot.conf
+# Configure enroot paths based on available mounts
+if [[ $(mount | grep /opt/dlami/nvme) ]]; then
+    sed -i \
+        -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/user-$(id -u)|' \
+        -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/dlami/nvme/enroot|' \
+        -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/data/user-$(id -u)|' \
+        -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/dlami/nvme/tmp|' \
+        /etc/enroot/enroot.conf
 
-        mkdir -p /opt/dlami/nvme/tmp/enroot/
-        chmod 1777 /opt/dlami/nvme/tmp
-        chmod 1777 /opt/dlami/nvme/tmp/enroot/
+    mkdir -p /opt/dlami/nvme/tmp/enroot/
+    chmod 1777 /opt/dlami/nvme/tmp
+    chmod 1777 /opt/dlami/nvme/tmp/enroot/
 
-        mkdir -p /opt/dlami/nvme/tmp/enroot/data/
-        chmod 1777 /opt/dlami/nvme/tmp/enroot/data/
+    mkdir -p /opt/dlami/nvme/tmp/enroot/data/
+    chmod 1777 /opt/dlami/nvme/tmp/enroot/data/
 
-        mkdir -p /opt/dlami/nvme/enroot
-        chmod 1777 /opt/dlami/nvme/enroot
+    mkdir -p /opt/dlami/nvme/enroot
+    chmod 1777 /opt/dlami/nvme/enroot
 
-    elif [[ $(mount | grep /opt/sagemaker) ]]; then
-        sed -i \
-            -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/sagemaker/tmp/enroot/user-$(id -u)|' \
-            -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/sagemaker/enroot|' \
-            -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/sagemaker/tmp/enroot/data/user-$(id -u)|' \
-            -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/sagemaker/tmp|' \
-            /etc/enroot/enroot.conf
+elif [[ $(mount | grep /opt/sagemaker) ]]; then
+    sed -i \
+        -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/sagemaker/tmp/enroot/user-$(id -u)|' \
+        -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/sagemaker/enroot|' \
+        -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/sagemaker/tmp/enroot/data/user-$(id -u)|' \
+        -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/sagemaker/tmp|' \
+        /etc/enroot/enroot.conf
 
-        mkdir -p /opt/sagemaker/tmp/enroot/
-        chmod 1777 /opt/sagemaker/tmp
-        chmod 1777 /opt/sagemaker/tmp/enroot/
+    mkdir -p /opt/sagemaker/tmp/enroot/
+    chmod 1777 /opt/sagemaker/tmp
+    chmod 1777 /opt/sagemaker/tmp/enroot/
 
-        mkdir -p /opt/sagemaker/tmp/enroot/data/
-        chmod 1777 /opt/sagemaker/tmp/enroot/data/
+    mkdir -p /opt/sagemaker/tmp/enroot/data/
+    chmod 1777 /opt/sagemaker/tmp/enroot/data/
 
-        mkdir -p /opt/sagemaker/enroot
-        chmod 1777 /opt/sagemaker/enroot
-    fi
+    mkdir -p /opt/sagemaker/enroot
+    chmod 1777 /opt/sagemaker/enroot
+fi
 
-    # Configure FSX for enroot cache if available
-    if [[ $(mount | grep /fsx) ]]; then
-        sed -i -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/fsx/enroot|' /etc/enroot/enroot.conf
-        mkdir -p /fsx/enroot
-        chmod 1777 /fsx/enroot
-    fi
-else
-    echo "[INFO] Skipping mount-aware enroot.conf tuning (DLAMI HostAgent handles NVMe / /opt/sagemaker / /fsx)."
+# Configure FSX for enroot cache if available
+if [[ $(mount | grep /fsx) ]]; then
+    sed -i -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/fsx/enroot|' /etc/enroot/enroot.conf
+    mkdir -p /fsx/enroot
+    chmod 1777 /fsx/enroot
 fi
 
 # Restart Slurm services if they're running

--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/utils/install_enroot_pyxis.sh
@@ -64,7 +64,59 @@ if [ ! -d $SLURM_INSTALL_DIR ]; then
     exit 1
 fi
 
-rm -fr $SLURM_INSTALL_DIR/pyxis
+# ------------------------------------------------------------------------------
+# Detect whether the HyperPod DLAMI has already provisioned pyxis and/or enroot.
+#
+# Current HyperPod DLAMIs ship both pre-installed and pre-registered:
+#   - pyxis SPANK plugin at /opt/slurm/lib/slurm/spank_pyxis.so, pre-registered
+#     in plugstack.conf with a direct `required` line
+#   - enroot as an installed apt package
+# DLAMI also handles the mount-aware enroot.conf tuning for NVMe / /opt/sagemaker
+# / /fsx
+# Running `install_enroot_pyxis.sh` on top of that produces:
+#   - a duplicate SPANK registration ("srun: spank: option ... provided by both
+#     spank_pyxis.so and spank_pyxis.so" on every job launch), because LCS
+#     installs a second pyxis under /usr/local/lib/slurm/ and adds an
+#     `include .../pyxis.conf` line on top of the DLAMI's direct `required` line;
+#   - redundant apt install of the same enroot version;
+#   - redundant idempotent sed of enroot.conf paths already tuned by HostAgent.
+#
+# Detect each independently so partial-baseline DLAMIs (e.g. pyxis present but
+# not enroot, or vice versa) still get the piece they are missing, and so LCS
+# behavior on older Packer-built AMIs / bare Ubuntu is unchanged.
+#
+# What is NOT skipped, regardless of detection:
+#   - `cp $BIN_DIR/enroot.conf /etc/enroot/enroot.conf` (LCS copies a different,
+#     broader scoped enroot config that differs from the DLAMI's defaults in ways
+#     containers depend on: ENROOT_ROOTFS_WRITABLE=yes, ENROOT_MOUNT_HOME=no,
+#     ENROOT_RESTRICT_DEV=no, `-comp lzo` squash options, ENROOT_CONFIG_PATH).
+#   - slurmctld / slurmd restart at the bottom of the script.
+# ------------------------------------------------------------------------------
+DLAMI_PYXIS_INSTALLED=0
+DLAMI_ENROOT_INSTALLED=0
+
+if [[ -f "$SLURM_INSTALL_DIR/lib/slurm/spank_pyxis.so" ]] \
+   && grep -qE '^[[:space:]]*required[[:space:]]+.*spank_pyxis\.so[[:space:]]*$' \
+        "$SLURM_INSTALL_DIR/etc/plugstack.conf" 2>/dev/null; then
+    DLAMI_PYXIS_INSTALLED=1
+    echo "[INFO] pyxis is already installed and registered by the HyperPod DLAMI"
+    echo "[INFO]   binary: $SLURM_INSTALL_DIR/lib/slurm/spank_pyxis.so"
+    echo "[INFO]   registration: $(grep -E 'spank_pyxis\.so' "$SLURM_INSTALL_DIR/etc/plugstack.conf" | head -1)"
+    echo "[INFO] LC will skip pyxis build/install and plugstack.conf edit to avoid a duplicate SPANK registration."
+fi
+
+if command -v enroot >/dev/null 2>&1; then
+    DLAMI_ENROOT_INSTALLED=1
+    echo "[INFO] enroot is already installed by the HyperPod DLAMI (version: $(enroot version 2>/dev/null | head -1))"
+    echo "[INFO] LC will skip enroot deb download/install and mount-aware enroot.conf sed"
+    echo "[INFO] (the DLAMI's on-boot HostAgent handles ENROOT_*_PATH tuning for NVMe / /opt/sagemaker / /fsx)."
+fi
+
+# Guard the destructive rm of $SLURM_INSTALL_DIR/pyxis so we don't wipe the
+# DLAMI's pyxis source directory (if any); still create parent dirs (idempotent).
+if [[ "$DLAMI_PYXIS_INSTALLED" -eq 0 ]]; then
+    rm -fr $SLURM_INSTALL_DIR/pyxis
+fi
 mkdir -p $SLURM_INSTALL_DIR/enroot/ $SLURM_INSTALL_DIR/pyxis/ $PYXIS_TMP_DIR
 
 PYXIS_VERSION=v0.19.0
@@ -72,105 +124,129 @@ ENROOT_VERSION=3.4.1
 arch=$(dpkg --print-architecture)
 cd $PYXIS_TMP_DIR
 
-# Download enroot packages with retry
-retry_with_backoff 5 5 60 "curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${arch}.deb"
-retry_with_backoff 5 5 60 "curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_${arch}.deb"
+if [[ "$DLAMI_ENROOT_INSTALLED" -eq 0 ]]; then
+    # Download enroot packages with retry
+    retry_with_backoff 5 5 60 "curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${arch}.deb"
+    retry_with_backoff 5 5 60 "curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_VERSION}-1_${arch}.deb"
 
-# Install enroot packages with retry
-retry_with_backoff 5 5 60 "apt install -y -o DPkg::Lock::Timeout=120 ./enroot_${ENROOT_VERSION}-1_${arch}.deb"
-retry_with_backoff 5 5 60 "apt install -y -o DPkg::Lock::Timeout=120 ./enroot+caps_${ENROOT_VERSION}-1_${arch}.deb"
+    # Install enroot packages with retry
+    retry_with_backoff 5 5 60 "apt install -y -o DPkg::Lock::Timeout=120 ./enroot_${ENROOT_VERSION}-1_${arch}.deb"
+    retry_with_backoff 5 5 60 "apt install -y -o DPkg::Lock::Timeout=120 ./enroot+caps_${ENROOT_VERSION}-1_${arch}.deb"
+fi
+
+# Always overwrite enroot.conf: LCS ships broader flags (writable rootfs, no
+# home mount, unrestricted /dev, lzo squash, ENROOT_CONFIG_PATH=$HOME/enroot)
+# that customer container workloads depend on. Changing this default is a
+# breaking behavior change.
 cp $BIN_DIR/enroot.conf /etc/enroot/enroot.conf
 
-# Clone pyxis with retry
-retry_with_backoff 5 5 60 "git clone --depth 1 --branch $PYXIS_VERSION https://github.com/NVIDIA/pyxis.git $SLURM_INSTALL_DIR/pyxis"
-cd $SLURM_INSTALL_DIR/pyxis/
-CPPFLAGS='-I /opt/slurm/include/' make -j $(nproc)
-CPPFLAGS='-I /opt/slurm/include/' make install
-mkdir -p $SLURM_INSTALL_DIR/etc/plugstack.conf.d/
-# Check if the line exists before adding it to handle multi headnode conf
-if ! grep -q "include $SLURM_INSTALL_DIR/etc/plugstack.conf.d/pyxis.conf" "$SLURM_INSTALL_DIR/etc/plugstack.conf"; then
-    echo -e "include $SLURM_INSTALL_DIR/etc/plugstack.conf.d/pyxis.conf" >> $SLURM_INSTALL_DIR/etc/plugstack.conf
+if [[ "$DLAMI_PYXIS_INSTALLED" -eq 0 ]]; then
+    # Clone pyxis with retry
+    retry_with_backoff 5 5 60 "git clone --depth 1 --branch $PYXIS_VERSION https://github.com/NVIDIA/pyxis.git $SLURM_INSTALL_DIR/pyxis"
+    cd $SLURM_INSTALL_DIR/pyxis/
+    CPPFLAGS='-I /opt/slurm/include/' make -j $(nproc)
+    CPPFLAGS='-I /opt/slurm/include/' make install
+    mkdir -p $SLURM_INSTALL_DIR/etc/plugstack.conf.d/
+    # Idempotent + wildcard-aware guard: skip the include add if pyxis is already
+    # covered (either by an explicit `include .../pyxis.conf` or a wildcard
+    # `include .../plugstack.conf.d/*`), so LCS re-runs and older Packer-built
+    # AMIs that use the wildcard form don't produce a duplicate include.
+    if ! grep -qE "^[[:space:]]*include[[:space:]]+.*plugstack\.conf\.d/(pyxis\.conf|\*)[[:space:]]*$" \
+            "$SLURM_INSTALL_DIR/etc/plugstack.conf" 2>/dev/null; then
+        echo -e "include $SLURM_INSTALL_DIR/etc/plugstack.conf.d/pyxis.conf" >> $SLURM_INSTALL_DIR/etc/plugstack.conf
+    fi
+    ln -fs /usr/local/share/pyxis/pyxis.conf $SLURM_INSTALL_DIR/etc/plugstack.conf.d/pyxis.conf
 fi
-ln -fs /usr/local/share/pyxis/pyxis.conf $SLURM_INSTALL_DIR/etc/plugstack.conf.d/pyxis.conf
 
 mkdir -p /run/pyxis/ /tmp/enroot/data /opt/enroot/
 chmod 777 -R /tmp/enroot /opt/enroot
 
 ################################################################################
-# Below while loop instituted to combat race condition when mapping enroot path to /opt/dlami/nvme
-MAX_WAIT_TIME=120
-ELAPSED_TIME=0
-CHECK_INTERVAL=5
+# Mount-aware enroot.conf tuning.
+#
+# Skipped when the DLAMI already provisioned enroot (`DLAMI_ENROOT_INSTALLED=1`),
+#
+# On older AMIs / bare Ubuntu where LCS installed enroot itself, this block still
+# runs and does the mount-aware sed as before.
+################################################################################
+if [[ "$DLAMI_ENROOT_INSTALLED" -eq 0 ]]; then
+    # Below while loop instituted to combat race condition when mapping enroot path to /opt/dlami/nvme
+    MAX_WAIT_TIME=120
+    ELAPSED_TIME=0
+    CHECK_INTERVAL=5
 
-while true; do
-    # Check the ActiveState of the lib/systemd/system/dlami-nvme.service
-    ACTIVE_STATE=$(systemctl show dlami-nvme | grep "ActiveState" | cut -d '=' -f 2)
-    # Check the ExecMainStatus of the lib/systemd/system/dlami-nvme.service
-    RESULT_STATE=$(systemctl show dlami-nvme | grep "ExecMainStatus" | cut -d '=' -f 2)
+    while true; do
+        # Check the ActiveState of the lib/systemd/system/dlami-nvme.service
+        ACTIVE_STATE=$(systemctl show dlami-nvme | grep "ActiveState" | cut -d '=' -f 2)
+        # Check the ExecMainStatus of the lib/systemd/system/dlami-nvme.service
+        RESULT_STATE=$(systemctl show dlami-nvme | grep "ExecMainStatus" | cut -d '=' -f 2)
 
-    echo "dlami-nvme.service ActiveState: $ACTIVE_STATE"
-    echo "dlami-nvme.service ExecMainStatus: $RESULT_STATE"
+        echo "dlami-nvme.service ActiveState: $ACTIVE_STATE"
+        echo "dlami-nvme.service ExecMainStatus: $RESULT_STATE"
 
-    if [[ "$ACTIVE_STATE" == "active" && "$RESULT_STATE" == "0" ]]; then
-        echo "dlami-nvme.service is active and successful. Proceeding with Enroot configuration on /opt/dlami/nvme if available"
-        break
-    fi
+        if [[ "$ACTIVE_STATE" == "active" && "$RESULT_STATE" == "0" ]]; then
+            echo "dlami-nvme.service is active and successful. Proceeding with Enroot configuration on /opt/dlami/nvme if available"
+            break
+        fi
 
-    ELAPSED_TIME=$((ELAPSED_TIME + CHECK_INTERVAL))
+        ELAPSED_TIME=$((ELAPSED_TIME + CHECK_INTERVAL))
 
-    if [[ $ELAPSED_TIME -ge $MAX_WAIT_TIME ]]; then
-        echo "WARN: Timeout reached: dlami-nvme.service did not become active and successful, it is possible enroot default path is /opt/sagemaker. When training larger models, dragons be here. See https://github.com/awslabs/awsome-distributed-training/issues/427 for corrective actions"
-        break
-    fi
+        if [[ $ELAPSED_TIME -ge $MAX_WAIT_TIME ]]; then
+            echo "WARN: Timeout reached: dlami-nvme.service did not become active and successful, it is possible enroot default path is /opt/sagemaker. When training larger models, dragons be here. See https://github.com/awslabs/awsome-distributed-training/issues/427 for corrective actions"
+            break
+        fi
 
-    sleep $CHECK_INTERVAL
-done
+        sleep $CHECK_INTERVAL
+    done
 
 ####################################################################################################
 
-# Configure enroot paths based on available mounts
-if [[ $(mount | grep /opt/dlami/nvme) ]]; then
-    sed -i \
-        -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/user-$(id -u)|' \
-        -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/dlami/nvme/enroot|' \
-        -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/data/user-$(id -u)|' \
-        -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/dlami/nvme/tmp|' \
-        /etc/enroot/enroot.conf
+    # Configure enroot paths based on available mounts
+    if [[ $(mount | grep /opt/dlami/nvme) ]]; then
+        sed -i \
+            -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/user-$(id -u)|' \
+            -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/dlami/nvme/enroot|' \
+            -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/dlami/nvme/tmp/enroot/data/user-$(id -u)|' \
+            -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/dlami/nvme/tmp|' \
+            /etc/enroot/enroot.conf
 
-    mkdir -p /opt/dlami/nvme/tmp/enroot/
-    chmod 1777 /opt/dlami/nvme/tmp
-    chmod 1777 /opt/dlami/nvme/tmp/enroot/
+        mkdir -p /opt/dlami/nvme/tmp/enroot/
+        chmod 1777 /opt/dlami/nvme/tmp
+        chmod 1777 /opt/dlami/nvme/tmp/enroot/
 
-    mkdir -p /opt/dlami/nvme/tmp/enroot/data/
-    chmod 1777 /opt/dlami/nvme/tmp/enroot/data/
+        mkdir -p /opt/dlami/nvme/tmp/enroot/data/
+        chmod 1777 /opt/dlami/nvme/tmp/enroot/data/
 
-    mkdir -p /opt/dlami/nvme/enroot
-    chmod 1777 /opt/dlami/nvme/enroot
+        mkdir -p /opt/dlami/nvme/enroot
+        chmod 1777 /opt/dlami/nvme/enroot
 
-elif [[ $(mount | grep /opt/sagemaker) ]]; then
-    sed -i \
-        -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/sagemaker/tmp/enroot/user-$(id -u)|' \
-        -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/sagemaker/enroot|' \
-        -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/sagemaker/tmp/enroot/data/user-$(id -u)|' \
-        -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/sagemaker/tmp|' \
-        /etc/enroot/enroot.conf
+    elif [[ $(mount | grep /opt/sagemaker) ]]; then
+        sed -i \
+            -e 's|^\(ENROOT_RUNTIME_PATH  *\).*$|\1/opt/sagemaker/tmp/enroot/user-$(id -u)|' \
+            -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/opt/sagemaker/enroot|' \
+            -e 's|^\(ENROOT_DATA_PATH  *\).*$|\1/opt/sagemaker/tmp/enroot/data/user-$(id -u)|' \
+            -e 's|^#\(ENROOT_TEMP_PATH  *\).*$|\1/opt/sagemaker/tmp|' \
+            /etc/enroot/enroot.conf
 
-    mkdir -p /opt/sagemaker/tmp/enroot/
-    chmod 1777 /opt/sagemaker/tmp
-    chmod 1777 /opt/sagemaker/tmp/enroot/
+        mkdir -p /opt/sagemaker/tmp/enroot/
+        chmod 1777 /opt/sagemaker/tmp
+        chmod 1777 /opt/sagemaker/tmp/enroot/
 
-    mkdir -p /opt/sagemaker/tmp/enroot/data/
-    chmod 1777 /opt/sagemaker/tmp/enroot/data/
+        mkdir -p /opt/sagemaker/tmp/enroot/data/
+        chmod 1777 /opt/sagemaker/tmp/enroot/data/
 
-    mkdir -p /opt/sagemaker/enroot
-    chmod 1777 /opt/sagemaker/enroot
-fi
+        mkdir -p /opt/sagemaker/enroot
+        chmod 1777 /opt/sagemaker/enroot
+    fi
 
-# Configure FSX for enroot cache if available
-if [[ $(mount | grep /fsx) ]]; then
-    sed -i -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/fsx/enroot|' /etc/enroot/enroot.conf
-    mkdir -p /fsx/enroot
-    chmod 1777 /fsx/enroot
+    # Configure FSX for enroot cache if available
+    if [[ $(mount | grep /fsx) ]]; then
+        sed -i -e 's|^\(ENROOT_CACHE_PATH  *\).*$|\1/fsx/enroot|' /etc/enroot/enroot.conf
+        mkdir -p /fsx/enroot
+        chmod 1777 /fsx/enroot
+    fi
+else
+    echo "[INFO] Skipping mount-aware enroot.conf tuning (DLAMI HostAgent handles NVMe / /opt/sagemaker / /fsx)."
 fi
 
 # Restart Slurm services if they're running


### PR DESCRIPTION
## Symptom

On a HyperPod Slurm cluster created with **custom lifecycle scripts from this repo** on the current HyperPod DLAMI, every `srun`/`sbatch` job launch prints 14 duplicate-option warnings:

```
$ srun
srun: spank: option "container-image" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-mounts" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-workdir" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-name" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-save" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-mount-home" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "no-container-mount-home" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-remap-root" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "no-container-remap-root" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-entrypoint" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "no-container-entrypoint" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-writable" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-readonly" provided by both spank_pyxis.so and spank_pyxis.so
srun: spank: option "container-env" provided by both spank_pyxis.so and spank_pyxis.so
```

Clusters using **None** (AMI-based lifecycle) don't hit this because `install_enroot_pyxis.sh` never runs.

## Root cause

The current HyperPod DLAMI ships both pyxis and enroot pre-installed and pre-configured:

- **pyxis:** SPANK plugin at `/opt/slurm/lib/slurm/spank_pyxis.so`, pre-registered in `plugstack.conf` with a direct `required` line.
- **enroot:** installed as an apt package.
- **enroot.conf mount-aware tuning:** the DLAMI's on-boot HostAgent tunes `ENROOT_RUNTIME_PATH`, `ENROOT_CACHE_PATH`, `ENROOT_DATA_PATH`, and `ENROOT_TEMP_PATH` based on which of NVMe / `/opt/sagemaker` / `/fsx` is mounted (verified: with FSx attached, HostAgent sets `ENROOT_CACHE_PATH=/fsx/enroot`).

Meanwhile `install_enroot_pyxis.sh`:

1. Rebuilds pyxis from source into `/usr/local/lib/slurm/spank_pyxis.so` and appends `include /opt/slurm/etc/plugstack.conf.d/pyxis.conf` to `plugstack.conf` on top of the DLAMI's `required` line - producing two SPANK registrations from two different `.so` files.
2. Re-downloads and re-installs the same enroot version via `.deb`.
3. Re-runs the mount-aware `sed` on `enroot.conf`.

With current DLAMIs (1) causes the visible bug; (2) and (3) are silent waste.

## Fix

`install_enroot_pyxis.sh` now detects each DLAMI-provided component **independently** and skips only what's redundant. Detections:

- `DLAMI_PYXIS_INSTALLED=1` if and only if `/opt/slurm/lib/slurm/spank_pyxis.so` exists **and** `plugstack.conf` contains a `required …spank_pyxis.so` line.
- `DLAMI_ENROOT_INSTALLED=1` if and only if `command -v enroot` succeeds.

## Behavior matrix

| Environment | pyxis install | enroot deb install | enroot.conf overwrite | mount-aware sed | slurm restart |
|---|---|---|---|---|---|
| **DLAMI + LCS** (this bug) | **skip** | **skip** | run | **skip** | run |
| **DLAMI, no LCS (None)** | n/a | n/a | n/a | HostAgent | HostAgent |
| **Older AMI + LCS** | run | run | run | run | run |
| **LCS re-run on any** | skip (guard idempotent) | skip (already installed) | run (safe) | skip (already enroot present) | run |

## Why LCS `enroot.conf` is still copied on top of the DLAMI's

The DLAMI ships a conservative default `enroot.conf`. LCS `enroot.conf` deliberately differs in five settings:

| Setting | LCS | DLAMI (effective) | Effect if we let DLAMI's win |
|---|---|---|---|
| `ENROOT_CONFIG_PATH` | `${HOME}/enroot` | `${HOME}/.config/enroot` (default) | Users with existing per-user credentials/mount/env files under `~/enroot/` silently stop having them read; enroot looks in `~/.config/enroot/` instead. Low impact but breakage for power users. |
| `ENROOT_SQUASH_OPTIONS` | `-comp lzo -noI -noD -noF -noX -no-duplicates` | `-noI -noD -noF -noX -no-duplicates` (no compression) | Container image size on disk ~1.5–2× larger (no LZO compression). Slightly faster `enroot import`/`enroot start`. Storage impact on FSx cache. |
| `ENROOT_ROOTFS_WRITABLE` | `yes` | `no` (default) | **HIGH.** Container rootfs becomes read-only by default. `apt install`, `pip install`, `mkdir`, writes to `/root/…`, notebook writes - all fail unless users add `--container-writable` to every `srun`. Breaking change for typical HyperPod training workflows. |
| `ENROOT_MOUNT_HOME` | `no` | `yes` (LC-inverted default) | Container's `$HOME` becomes the host's `$HOME`. Container gains ambient access to `~/.aws/credentials`, `~/.ssh/id_rsa`, etc. Files written by root-in-container end up owned by root on host FS. Security + permissions impact. |
| `ENROOT_RESTRICT_DEV` | `no` | `yes` (default) | `/dev` inside container is restricted to a minimal safe set. GPU access still works via `--nvidia`. Breaks in-container Docker, raw NVMe, some MPI stacks. Low-to-medium impact. |

Everything else in the two configs is either identical or purely commented documentation.

Two of these (`ENROOT_ROOTFS_WRITABLE`, `ENROOT_MOUNT_HOME`) are behavior-visible flags customers have very likely built training workflows around today. Silently switching them by dropping the `cp enroot.conf` step would be a breaking behavior change for anyone upgrading to a new version of LC.

For that reason this PR **preserves LC's `enroot.conf` overwrite as-is**. Aligning LC and DLAMI defaults is a separate, deliberate product decision - if it happens, it should be a distinct PR with a clear `BREAKING CHANGE:` note, an upgrade guide, and customer communication about the flags that flipped. It does not belong inside a bug fix for a duplicate SPANK registration.
## Purpose

<!-- Link related issues using "Fixes #123" or "Relates to #123" -->

## Changes

<!-- Summarize the changes made in this PR -->

-

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:
- Instance type:
- Number of nodes:

**Test commands:**
```bash

```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
