### PR TITLE
Fix libnvidia-compute mock for latest Slurm AMI

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/hotfix/mock-gpu-driver-deb.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/hotfix/mock-gpu-driver-deb.sh
@@ -10,7 +10,7 @@ MOCK_PKG=libnvidia-compute-${DRV_VERSION_MAJOR}
 apt-get -y -o DPkg::Lock::Timeout=120 install equivs
 
 # 1) Try exact-patch match first (preferred: mock matches the running kmod exactly).
-for SUFFIX in "-1ubuntu1" "-0ubuntu1" ""; do
+for SUFFIX in "-0ubuntu0.22.04.1" "-1ubuntu1" "-0ubuntu1" ""; do
     if apt-cache show ${MOCK_PKG}=${DRV_VERSION}${SUFFIX} 2>/dev/null | egrep '^Package|^Version|^Provides' &> ${MOCK_PKG}; then
         echo "Found exact match for ${DRV_VERSION} with suffix: ${SUFFIX}"
         break


### PR DESCRIPTION
# Testing — Slurm AMI × LCS GPU-driver-mock fix

Validation for the `mock-gpu-driver-deb.sh` fix on the latest Slurm AMI

## Environment

| Item | Value |
|------|-------|
| Platform | SageMaker HyperPod (Slurm), Ubuntu 22.04 (jammy) |
| AMI driver (kmod) | Nvidia `595.71.05` |
| Script under test | `LifecycleScripts/base-config/hotfix/mock-gpu-driver-deb.sh` |

## Sad path — reproduce the failure (legacy LCS, pre-fallback)

- **Cluster:** `svnisar730test`
- **LCS source:** `s3://xx-zeus-slurm-lcs-bucket/src/` — pre-fallback version, exact-match suffixes only (`-1ubuntu1` / `-0ubuntu1` / `""`).
- **Result:** ❌ **FAILED on both nodes.** Exact-match loop missed → empty control file → `exit 1`.

**Evidence**

| Node | Time (UTC) | Log line |
|------|-----------|----------|
| `worker-group-1` `i-028d49d56c9bdbf1f` | 19:25:56 | `Error: Could not find package libnvidia-compute-595 with version 595.71.05 in apt-cache` |
| `controller-machine` `i-08d52129030dc75c8` | 19:26:33 | same error; LCS exits non-zero |

## Happy path — with patched LCS

- **Cluster:** `svnisar731test`
- **LCS source:** `s3://xx-slurm-hotfix-issue/base-config/` — patched script.
- **Result:** ✅ **SUCCEEDED** — mock `libnvidia-compute-595` built via `equivs` and installed on both nodes; LCS proceeded past the GPU step.

**Evidence**

| Node | Time (UTC) | Log line |
|------|-----------|----------|
| `worker-group-1` `i-0cd86d8d40185ca1b` | 19:37:40 | `Setting up libnvidia-compute-595 (595.71.05) ...` |
| `controller-machine` `i-024bfa53a215625c7` | 19:37:59 | `Setting up libnvidia-compute-595 (595.71.05) ...` |

- Package built: `libnvidia-compute-595_595.71.05_all.deb`
- Held afterward: `dpkg --set-selections … hold`

Successful cluster creation and operations
```
ubuntu@ip-10-2-149-192:~$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
dev*         up   infinite      1   idle ip-10-2-1-115
ubuntu@ip-10-2-149-192:~$ pwd
/home/ubuntu
```