### PR TITLE
Add KimiK3 code example

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/inference-operator/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/inference-operator/README.md
@@ -1,0 +1,9 @@
+# Inference Operator on Amazon SageMaker HyperPod EKS
+
+Deploy large language models using the [Inference Operator](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-model-deployment.html) on an **existing** [Amazon SageMaker HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-eks.html) EKS cluster.
+
+> **This guide assumes you already have a SageMaker HyperPod EKS cluster
+> in `InService` state with the Inference Operator installed.** It does not create VPC, EKS or SageMaker Hyperπod
+> infrastructure from scratch. You can confirm if it is installed with `kubectl get inferenceendointconfigs`
+
+The `models` directory contains folders for each model. Each model folder will contain a deployment YAML file alongside any additional instructions for deploying the model.

--- a/1.architectures/7.sagemaker-hyperpod-eks/inference-operator/models/kimi-k3/README.md
+++ b/1.architectures/7.sagemaker-hyperpod-eks/inference-operator/models/kimi-k3/README.md
@@ -1,0 +1,41 @@
+# Kimi K3 with SageMaker HyperPod Inference Operator
+
+To deploy Kimi K3 on HyperPod using the HyperPod Inference operator, you need an ml.p6-b300.48xlarge instance.
+
+Deploy using 
+```
+kubectl apply -f kimi-k3.yaml
+```
+
+This will download the model weights from Hugging Face and run on vLLM.
+
+To invoke, get the DNS name for the created `Ingress` object using `kubectl get ingress` and invoke using the OpenAI SDK such as:
+
+```python
+import time
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="<ALB DNS>/v1",
+)
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": "Introduce Kimi K3 in one sentence"
+            }
+        ]
+    }
+]
+
+start = time.time()
+response = client.chat.completions.create(
+    model="Kimi-K3",
+    messages=messages,
+    max_tokens=2048
+)
+```

--- a/1.architectures/7.sagemaker-hyperpod-eks/inference-operator/models/kimi-k3/kimi-k3.yaml
+++ b/1.architectures/7.sagemaker-hyperpod-eks/inference-operator/models/kimi-k3/kimi-k3.yaml
@@ -1,0 +1,48 @@
+apiVersion: inference.sagemaker.aws.amazon.com/v1
+kind: InferenceEndpointConfig
+metadata:
+  name: kimik3
+spec:
+  modelName: Kimi-K3
+  instanceType: ml.p6-b300.48xlarge
+  invocationEndpoint: v1/chat/completions
+  replicas: 1
+  modelSourceConfig:
+    huggingFaceModel:
+      modelId: moonshotai/Kimi-K3
+    modelSourceType: huggingface
+  worker:
+    image: vllm/vllm-openai:kimi-k3
+    modelInvocationPort:
+      containerPort: 8000
+      name: http
+    modelVolumeMount:
+      mountPath: /opt/ml/model
+      name: model-weights
+    resources:
+      limits:
+        nvidia.com/gpu: 8
+      requests:
+        nvidia.com/gpu: 8
+    args:
+      - "--model"
+      - "moonshotai/Kimi-K3"
+      - "--trust-remote-code"
+      - "--load-format"
+      - "fastsafetensors"
+      - "--enable-prefix-caching"
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "kimi_k3"
+      - "--reasoning-parser"
+      - "kimi_k3"
+      - "--served-model-name"
+      - "Kimi-K3"
+      - "--moe-backend"
+      - "auto"
+      - "--tensor-parallel-size"
+      - "8"
+      - "--no-enable-flashinfer-autotune"
+    environmentVariables:
+      - name: "VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION"
+        value: "1"


### PR DESCRIPTION
## Purpose

Add a Kimi K3 deployment using SageMaker HyperPod Inference Operator for HyperPod EKS

## Changes

- Add a new folder for inference operator. Include kimi-k3 as a model in the folder

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service: HyperPod EKS
- Instance type: ml.p6-b300.48xlarge
- Number of nodes: 1

**Test commands:**
```bash
kubectl apply -f kimi-k3.yaml
```

then run sample curl command against the model

## Test Results

Model responds successfully

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [X] I am working against the latest `main` branch.
- [X] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [X] The contribution is self-contained with documentation and scripts.
- [X] External dependencies are pinned to a specific version or tag (no `latest`).
- [X] A README is included or updated with prerequisites, instructions, and known issues.
- [X] New test cases follow the [expected directory structure](#directory-structure).
