### PR TITLE
docs(aws-pcs): improve JUPYTER + USER-MANAGEMENT + IAM walkthroughs (verbatim-verified)

### DIFF
--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -778,6 +778,7 @@ In this repo:
 - [Jupyter on a compute node](./docs/JUPYTER.md) — run Jupyter as a Slurm job, browser access via SSM port forwarding
 - [IAM permissions guide](./docs/IAM.md) — cluster admin / cluster user roles, policy deploy, security considerations
 - [Deploy & testing procedures](./docs/DEPLOY-TESTING.md) — development deploy workflow with test S3 bucket
+- [PCS-Ready DLAMI version history](./docs/PCS-READY-DLAMI.md) — PCS Agent / Slurm / driver / CUDA / EFA / DCGM per published build
 - [Test & Validation Guide](./tests/README.md) — reproducible matrix with measured numbers
 - [GPU Cluster Health Check](../../4.validation_and_observability/2.gpu-cluster-healthcheck) — comprehensive GPU/EFA/NVLink validation suite (lightweight + intensive modes, Slurm prolog integration)
 - [Roadmap / TODO](./docs/ROADMAP.md)

--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -337,6 +337,10 @@ lines.) To submit it as a batch job instead:
 sbatch --partition=cpu1 --nodes=2 --wrap='srun bash -c "hostname"'
 ```
 
+> With `AccountingPolicyEnforcement` set, the submitter must be registered
+> in Slurm accounting or the job is rejected — see
+> [docs/USER-MANAGEMENT.md §4](./docs/USER-MANAGEMENT.md#4-slurm-accounting).
+
 ### Example B — multi-node GPU NCCL test (needs a GPU queue)
 
 A 2-node `all_reduce_perf` is the quickest GPU end-to-end check (GPU queue + Pyxis

--- a/architectures/aws-pcs/assets/cluster.yaml
+++ b/architectures/aws-pcs/assets/cluster.yaml
@@ -31,7 +31,7 @@ Parameters:
   ClusterName:
     Type: String
     Description: Name of the PCS cluster
-    Default: "ml-cluster"
+    Default: "pcs-ml-cluster"
     AllowedPattern: '^[a-zA-Z][a-zA-Z0-9-]{0,39}$'
     ConstraintDescription: Must start with a letter, contain only alphanumeric characters and hyphens, and be 1-40 characters long
 

--- a/architectures/aws-pcs/assets/scripts/ldap-add-user.sh
+++ b/architectures/aws-pcs/assets/scripts/ldap-add-user.sh
@@ -49,6 +49,27 @@ if [ -z "${LDAP_ADMIN_PASSWORD:-}" ]; then
     echo
 fi
 
+# Refuse a uidNumber that another entry already owns. LDAP itself won't reject
+# this — uidNumber is not part of the DN — so two users would silently share
+# the same POSIX UID and, on the shared /home + /fsx, become the same principal.
+# Same check for the username (its DN would be unique, but shadowing an
+# existing account is still a mistake). ldapsearch here is unauthenticated
+# and read-only; a lookup failure (LDAP down) still lets us continue and
+# surface the real error at ldapadd time.
+if command -v ldapsearch >/dev/null 2>&1; then
+    if OWNER=$(ldapsearch -x -LLL -H ldap://localhost -b "${LDAP_DOMAIN_SUFFIX}" \
+                 "(uidNumber=${USER_UID})" uid 2>/dev/null | sed -n 's/^uid: //p' | head -1) \
+       && [ -n "${OWNER}" ]; then
+        echo "uidNumber ${USER_UID} is already used by '${OWNER}'. Pick a different uid." >&2
+        exit 1
+    fi
+    if ldapsearch -x -LLL -H ldap://localhost -b "${LDAP_DOMAIN_SUFFIX}" \
+         "(uid=${USERNAME})" dn 2>/dev/null | grep -q .; then
+        echo "Username '${USERNAME}' already exists in the directory." >&2
+        exit 1
+    fi
+fi
+
 # Create user entry
 LDIF=$(cat <<EOF
 dn: uid=${USERNAME},ou=People,${LDAP_DOMAIN_SUFFIX}

--- a/architectures/aws-pcs/assets/scripts/ldap-add-user.sh
+++ b/architectures/aws-pcs/assets/scripts/ldap-add-user.sh
@@ -35,6 +35,32 @@ if [[ ! "${USER_GID}" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
+# Refuse UIDs outside the range this cluster reserves for LDAP users
+# (10001-59999). The DLAMI's local accounts sit at 1000 (ubuntu) and other
+# system UIDs live below 10000; a shadowing LDAP entry at those UIDs would
+# `chown -R "${USER_UID}:${USER_GID}" /home/<local-name>` and destroy the
+# local user's HOME on the shared /home (documented lower bound in
+# USER-MANAGEMENT.md §3.1).
+if [ "${USER_UID}" -lt 10001 ] || [ "${USER_UID}" -gt 59999 ]; then
+    echo "uid '${USER_UID}' is outside the LDAP-user range 10001-59999 (see USER-MANAGEMENT.md §3.1)." >&2
+    exit 1
+fi
+
+# Reject any username/UID that already resolves via NSS (local /etc/passwd,
+# SSSD/LDAP, or any other configured source). LDAP-only checks below miss
+# local shadowing: e.g. `ubuntu` has UID 1000 in /etc/passwd, and adding an
+# LDAP `ubuntu` would append the pubkey to /home/ubuntu/.ssh/authorized_keys
+# and chown /home/ubuntu to the new numeric UID — breaking the DLAMI account.
+if getent passwd "${USERNAME}" >/dev/null; then
+    echo "Username '${USERNAME}' already exists (local passwd or LDAP via NSS)." >&2
+    exit 1
+fi
+if getent passwd "${USER_UID}" >/dev/null; then
+    EXISTING=$(getent passwd "${USER_UID}" | cut -d: -f1)
+    echo "uid ${USER_UID} is already used by '${EXISTING}' (local passwd or LDAP via NSS)." >&2
+    exit 1
+fi
+
 # Auto-detect LDAP config from sssd.conf or environment
 LDAP_DOMAIN_SUFFIX="${LDAP_DOMAIN_SUFFIX:-$(sed -n 's/^ldap_search_base[[:space:]]*=[[:space:]]*//p' /etc/sssd/sssd.conf 2>/dev/null || echo 'dc=cluster,dc=internal')}"
 LDAP_DOMAIN_SUFFIX="${LDAP_DOMAIN_SUFFIX:-dc=cluster,dc=internal}"

--- a/architectures/aws-pcs/docs/IAM.md
+++ b/architectures/aws-pcs/docs/IAM.md
@@ -30,17 +30,6 @@ plus the extra permissions the all-in-one template needs because it provisions
 VPC + FSx + IAM roles itself (the AWS reference policy assumes those already
 exist). Review and tighten before production use.
 
-**Login-node access is scoped to one stack.** The user policy conditions
-`ssm:StartSession` on `ssm:resourceTag/Name` equalling
-`<ClusterStackName>-login` (exact match, no wildcards) — the Name tag every
-login node carries by default. The tag is operator-mutable; if you re-tag
-the login node, update the policy condition to match.
-
-**The admin policy is split into core + Image Builder** because the combined
-document exceeds IAM's 6,144-character per-policy limit. The core covers a
-normal deploy; the Image Builder add-on is only needed for the standalone
-DLAMI builder.
-
 **Pairing with AWS-managed policies.** For a smaller customer-managed
 surface, attach AWS-managed policies for parts of the stack and trim the
 matching statements: `AWSCloudFormationFullAccess`, `AmazonFSxFullAccess`,
@@ -49,11 +38,6 @@ matching statements: `AWSCloudFormationFullAccess`, `AmazonFSxFullAccess`,
 public-share); prefer the customer-managed EC2 statements in the template.
 There is no `AmazonPCSFullAccess`, so the PCS portion has to stay
 customer-managed.
-
-**Private template bucket.** The admin policy grants no `s3:GetObject`
-because the production templates live in the public `awsome-distributed-ai`
-bucket (CFN fetches `--template-url` anonymously). If you host the templates
-in a private bucket, grant `s3:GetObject` on that bucket separately.
 
 **Not covered by these policies:**
 - The compute instance role (passed to EC2 by `cluster.yaml`) — use the

--- a/architectures/aws-pcs/docs/IAM.md
+++ b/architectures/aws-pcs/docs/IAM.md
@@ -8,7 +8,7 @@ adding existing IAM users at deploy time).
 | Role | Launch |
 |---|---|
 | **Cluster admin** — deploys/updates/deletes clusters. Full CRUD on CloudFormation, PCS, EC2 (VPC/SG/launch templates/placement groups/NAT/EIP), FSx, scoped IAM, SSM Parameter Store, KMS, Secrets Manager, and (optionally) Image Builder. **Broad — do not hand to every engineer.** | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
-| **Cluster user** — engineers running jobs on an existing cluster. SSM session to the **login node only**, port-forward Grafana, read the Grafana password, read PCS cluster/queue status. Cannot create, modify, or delete anything, and cannot shell into compute nodes. **Safe to hand out widely.** | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
+| **Cluster user** — engineers running jobs on an existing cluster. SSM session to the **login node only**, port-forward Grafana, read the Grafana password, read PCS cluster/queue status. **No AWS-API mutations** (cannot create, modify, or delete cluster resources) and **no compute-node sessions**. The login-node SSM shell it grants runs as `ssm-user` with passwordless sudo (SSM default), so on the login node it is effectively root — meaning read access to shared `/home`, Slurm accounting, and the instance role's `/pcs/<id>/ldap/*` SSM secret; treat it as trusted-operator-scope, not arbitrary-viewer-scope. | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
 
 Both templates take an optional `AttachUsers` parameter (comma-separated
 existing IAM user names) so you can wire up group membership at deploy time,
@@ -17,7 +17,12 @@ or add users later via the IAM console. The cluster-admin template's
 admin will also deploy the standalone DLAMI builder
 (`pcs-ready-dlami-with-enroot-pyxis.yaml`). The cluster-user template
 requires `ClusterStackName` and scopes SSM session access to that one
-cluster's login node — deploy one stack of it per cluster.
+cluster's login node — deploy one stack of it per cluster. That scoping
+keys on the EC2 `Name` tag (`ssm:resourceTag/Name = <ClusterStackName>-login`),
+which is operator-mutable: re-tagging a login node changes who can reach it,
+and if another instance in the account happens to carry a matching `Name`
+tag it would also satisfy the condition. Treat `Name` as part of this
+policy's trust surface.
 
 ---
 

--- a/architectures/aws-pcs/docs/IAM.md
+++ b/architectures/aws-pcs/docs/IAM.md
@@ -5,68 +5,19 @@ responsibilities. Each ships a CloudFormation template that creates the
 customer-managed IAM policy and an IAM group with it attached (optionally
 adding existing IAM users at deploy time).
 
-| Role | Can do | Template · Launch |
-|---|---|---|
-| **Cluster admin** — deploys/updates/deletes clusters | Full CRUD on CloudFormation, PCS, EC2 (VPC/SG/launch templates/placement groups/NAT/EIP), FSx, scoped IAM, SSM Parameter Store, KMS, Secrets Manager, and (optionally) Image Builder. **Broad — do not hand to every engineer.** | [`cluster-admin-iam.yaml`](../assets/cluster-admin-iam.yaml) · [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
-| **Cluster user** — engineers running jobs on an existing cluster | SSM session to the **login node only**, port-forward Grafana, read the Grafana password, read PCS cluster/queue status. Cannot create, modify, or delete anything, and cannot shell into compute nodes. **Safe to hand out widely.** | [`cluster-user-iam.yaml`](../assets/cluster-user-iam.yaml) · [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
+| Role | Launch |
+|---|---|
+| **Cluster admin** — deploys/updates/deletes clusters. Full CRUD on CloudFormation, PCS, EC2 (VPC/SG/launch templates/placement groups/NAT/EIP), FSx, scoped IAM, SSM Parameter Store, KMS, Secrets Manager, and (optionally) Image Builder. **Broad — do not hand to every engineer.** | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
+| **Cluster user** — engineers running jobs on an existing cluster. SSM session to the **login node only**, port-forward Grafana, read the Grafana password, read PCS cluster/queue status. Cannot create, modify, or delete anything, and cannot shell into compute nodes. **Safe to hand out widely.** | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
 
----
-
-## Deploying the policies
-
-From the CLI (use `--template-body` against a local checkout for a pre-merge
-sandbox test):
-
-```bash
-# Admin: create the policies + group, attach existing users, include Image Builder perms
-aws cloudformation create-stack \
-  --stack-name pcs-cluster-admins \
-  --template-body file://architectures/aws-pcs/assets/cluster-admin-iam.yaml \
-  --parameters ParameterKey=AttachUsers,ParameterValue=alice,bob \
-               ParameterKey=AttachImageBuilderPolicy,ParameterValue=true \
-  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
-
-# User: create the policy + group, attach existing users
-# ClusterStackName scopes SSM session access to that one cluster's login node —
-# deploy one stack of this template per cluster.
-aws cloudformation create-stack \
-  --stack-name pcs-cluster-users-pcs-ml-cluster \
-  --template-body file://architectures/aws-pcs/assets/cluster-user-iam.yaml \
-  --parameters ParameterKey=ClusterStackName,ParameterValue=pcs-ml-cluster \
-               ParameterKey=AttachUsers,ParameterValue=carol,dave \
-  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
-```
-
-`AttachUsers` is optional — leave it empty and add users to the group later
-via IAM console/CLI. `AttachImageBuilderPolicy` defaults to `false`; enable
-it only if the admin will also deploy the standalone DLAMI builder
-(`pcs-ready-dlami-with-enroot-pyxis.yaml`).
-
-### What the cluster user can do once attached
-
-```bash
-STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
-AWS_REGION=us-east-1             # your region
-
-# Find the login node's instance ID via the PCS API — no dependency on tag naming
-CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
-[ -n "$CLUSTER_ID" ] && [ "$CLUSTER_ID" != "None" ] || { echo "No ClusterId — check STACK_NAME/AWS_REGION"; return 1; }
-
-LOGIN_CNG_ID=$(aws pcs list-compute-node-groups --cluster-identifier "$CLUSTER_ID" --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)
-LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$LOGIN_CNG_ID" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
-
-# Open a session
-aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION"
-
-# Port-forward Grafana (443 -> 8443), then open https://localhost:8443/grafana/
-aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION" \
-  --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["443"],"localPortNumber":["8443"]}'
-
-# Read the Grafana admin password
-aws ssm get-parameter --name "/pcs/${CLUSTER_ID}/grafana/admin-password" --region "$AWS_REGION" \
-  --with-decryption --query 'Parameter.Value' --output text
-```
+Both templates take an optional `AttachUsers` parameter (comma-separated
+existing IAM user names) so you can wire up group membership at deploy time,
+or add users later via the IAM console. The cluster-admin template's
+`AttachImageBuilderPolicy` defaults to `false`; set it `true` only if the
+admin will also deploy the standalone DLAMI builder
+(`pcs-ready-dlami-with-enroot-pyxis.yaml`). The cluster-user template
+requires `ClusterStackName` and scopes SSM session access to that one
+cluster's login node — deploy one stack of it per cluster.
 
 ---
 
@@ -85,13 +36,6 @@ exist). Review and tighten before production use.
 login node carries by default. The tag is operator-mutable; if you re-tag
 the login node, update the policy condition to match.
 
-**Combined CRUD is intentional, not a mistake.** The admin policy covers
-create + update + delete in one policy because (1) CFN rollback on a failed
-Create requires Delete actions, (2) UpdateStack is operationally a superset of
-Create (it may replace resources), and (3) drift detection during Update calls
-Describe across every service. If you want a read-only variant, reduce the same
-actions to `*:Describe*` / `*:Get*` / `*:List*` for an auditor role.
-
 **The admin policy is split into core + Image Builder** because the combined
 document exceeds IAM's 6,144-character per-policy limit. The core covers a
 normal deploy; the Image Builder add-on is only needed for the standalone
@@ -106,44 +50,17 @@ public-share); prefer the customer-managed EC2 statements in the template.
 There is no `AmazonPCSFullAccess`, so the PCS portion has to stay
 customer-managed.
 
-### Not covered by these policies
+**Private template bucket.** The admin policy grants no `s3:GetObject`
+because the production templates live in the public `awsome-distributed-ai`
+bucket (CFN fetches `--template-url` anonymously). If you host the templates
+in a private bucket, grant `s3:GetObject` on that bucket separately.
 
-- **The compute instance role** (passed to EC2 by `cluster.yaml`) — provisioned
-  by the templates themselves; use the AWS-managed `AWSPCSComputeNodePolicy`.
-- **The Image Builder build instance role** — use the AWS-managed
+**Not covered by these policies:**
+- The compute instance role (passed to EC2 by `cluster.yaml`) — use the
+  AWS-managed `AWSPCSComputeNodePolicy`.
+- The Image Builder build instance role — use the AWS-managed
   `EC2InstanceProfileForImageBuilder` /
   `EC2InstanceProfileForImageBuilderECRContainerBuilds`.
-- **Fine-grained per-cluster scoping** — both policies use `Resource: "*"` for
-  many EC2/VPC actions because resource-level scoping there is limited. This is
-  a deliberate sample-grade choice.
-
-### Refining to least-privilege via CloudTrail
-
-To generate a tighter policy from real usage:
-
-1. Deploy a representative cluster in a sandbox account with broad permissions on
-   the deploying principal (so nothing fails for spurious IAM reasons).
-2. Let the full lifecycle run — deploy, then `delete-stack` — so CloudTrail
-   captures every API call.
-3. Generate a policy from CloudTrail with IAM Access Analyzer
-   (`aws accessanalyzer start-policy-generation` → `get-generated-policy`), then
-   diff against the template's statements. Access Analyzer output is usually
-   *narrower* on actions but leaves `Resource: "*"`; the template's resource ARNs
-   are usually the keepers.
-
-The same approach works for the user policy — exercise the user workflows
-(start a session, port-forward Grafana, terminate it) in a sandbox, then narrow.
-
----
-
-## Verifying the policies
-
-To confirm the admin policy can deploy a cluster end-to-end and the user
-policy is correctly constrained (login-only SSM, no LDAP-password access),
-see the reproducible procedure in [tests/iam-test.md](../tests/iam-test.md).
-
-> **Private template bucket:** the admin policy grants no `s3:GetObject`
-> because the production templates live in the public
-> `awsome-distributed-ai` bucket (CFN fetches `--template-url`
-> anonymously). If you host the templates in a private bucket, grant
-> `s3:GetObject` on that bucket separately.
+- Fine-grained per-cluster scoping — both policies use `Resource: "*"` for
+  many EC2/VPC actions where resource-level scoping is limited. Sample-grade,
+  deliberate.

--- a/architectures/aws-pcs/docs/IAM.md
+++ b/architectures/aws-pcs/docs/IAM.md
@@ -1,32 +1,20 @@
 # IAM Permissions Guide
 
 The cluster distinguishes **two human roles** with very different
-responsibilities, and ships a ready-to-deploy IAM policy stack for each:
+responsibilities. Each ships a CloudFormation template that creates the
+customer-managed IAM policy and an IAM group with it attached (optionally
+adding existing IAM users at deploy time).
 
-| Role | Who | What they can do | Template |
-|---|---|---|---|
-| **Cluster admin** | The person who deploys/updates/deletes the cluster | Full CRUD on the infrastructure: CloudFormation, PCS, EC2 (VPC/SG/launch templates/placement groups/NAT/EIP), FSx, scoped IAM, SSM Parameter Store, KMS, Secrets Manager, and (optionally) Image Builder | [`cluster-admin-iam.yaml`](../assets/cluster-admin-iam.yaml) |
-| **Cluster user** | Engineers who just run jobs on an existing cluster | SSM session **to the login node only**, port-forward Grafana, read the Grafana password, read PCS cluster/queue status. **Cannot create, modify, or delete anything**, and cannot open shells on compute nodes | [`cluster-user-iam.yaml`](../assets/cluster-user-iam.yaml) |
-
-Splitting the roles means the deployer's broad permissions never have to be
-handed to every engineer who just wants to `srun`, and the user role can be
-given out widely — it can't accidentally delete the cluster or get a shell on a
-compute node.
+| Role | Can do | Template · Launch |
+|---|---|---|
+| **Cluster admin** — deploys/updates/deletes clusters | Full CRUD on CloudFormation, PCS, EC2 (VPC/SG/launch templates/placement groups/NAT/EIP), FSx, scoped IAM, SSM Parameter Store, KMS, Secrets Manager, and (optionally) Image Builder. **Broad — do not hand to every engineer.** | [`cluster-admin-iam.yaml`](../assets/cluster-admin-iam.yaml) · [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
+| **Cluster user** — engineers running jobs on an existing cluster | SSM session to the **login node only**, port-forward Grafana, read the Grafana password, read PCS cluster/queue status. Cannot create, modify, or delete anything, and cannot shell into compute nodes. **Safe to hand out widely.** | [`cluster-user-iam.yaml`](../assets/cluster-user-iam.yaml) · [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
 
 ---
 
 ## Deploying the policies
 
-Each template creates the customer-managed IAM policies, an IAM group with them
-attached, and (optionally) adds existing IAM users to that group. Deploy both
-as CloudFormation stacks:
-
-| Stack | Creates | Deploy |
-|---|---|---|
-| **Cluster admin** | `<stack>-PCSClusterAdmin-core` (always) + `<stack>-PCSClusterAdmin-imagebuilder` (if opted in) managed policies + an IAM group | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-admin-iam.yaml&stackName=pcs-cluster-admins) |
-| **Cluster user** | `<stack>-PCSClusterUser` managed policy + an IAM group | [![Launch](../images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster-user-iam.yaml&stackName=pcs-cluster-users) |
-
-Or from the CLI (use `--template-body` against a local checkout for a pre-merge
+From the CLI (use `--template-body` against a local checkout for a pre-merge
 sandbox test):
 
 ```bash
@@ -49,11 +37,9 @@ aws cloudformation create-stack \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
 ```
 
-Both templates take an `AttachUsers` parameter (comma-separated existing IAM
-user names) so you can wire up group membership at deploy time, or leave it
-empty and add users to the group later. The admin template's
-`AttachImageBuilderPolicy` defaults to `false`; set it `true` only when the
-admin will also deploy the standalone DLAMI builder
+`AttachUsers` is optional — leave it empty and add users to the group later
+via IAM console/CLI. `AttachImageBuilderPolicy` defaults to `false`; enable
+it only if the admin will also deploy the standalone DLAMI builder
 (`pcs-ready-dlami-with-enroot-pyxis.yaml`).
 
 ### What the cluster user can do once attached
@@ -77,9 +63,7 @@ aws ssm start-session --target "$LOGIN_INSTANCE_ID" --region "$AWS_REGION" \
   --document-name AWS-StartPortForwardingSession \
   --parameters '{"portNumber":["443"],"localPortNumber":["8443"]}'
 
-# Read the Grafana admin password (CLUSTER_ID is resolved by CFN Outputs above; look it up if needed)
-CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" \
-  --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+# Read the Grafana admin password
 aws ssm get-parameter --name "/pcs/${CLUSTER_ID}/grafana/admin-password" --region "$AWS_REGION" \
   --with-decryption --query 'Parameter.Value' --output text
 ```
@@ -95,19 +79,11 @@ plus the extra permissions the all-in-one template needs because it provisions
 VPC + FSx + IAM roles itself (the AWS reference policy assumes those already
 exist). Review and tighten before production use.
 
-**Login-node access is scoped by the `Name` tag, to one stack.** The user
-policy conditions `ssm:StartSession` on `ssm:resourceTag/Name` **equalling**
-`<ClusterStackName>-login` (exact match, no wildcards). PCS does not emit a
-dedicated "is this a login node" tag, so the templates set
-`Name=<ClusterName>-<cng-name>` on every instance — the deploy-all template
-passes `${AWS::StackName}` as ClusterName, so the login CNG's default
-`CngName=login` yields `Name=<StackName>-login`, and compute CNGs get
-`<StackName>-cpu1`, `<StackName>-gpu-p5`, etc. That means one deploy of
-`cluster-user-iam.yaml` grants access to **exactly one cluster**; deploy the
-template again with a different `ClusterStackName` for each additional
-cluster you want the group to reach. **The `Name` tag is operator-mutable**:
-if you re-tag a login node, update the policy condition to match (or fork
-the templates to add a dedicated `IsLoginNode=true` tag and key off that).
+**Login-node access is scoped to one stack.** The user policy conditions
+`ssm:StartSession` on `ssm:resourceTag/Name` equalling
+`<ClusterStackName>-login` (exact match, no wildcards) — the Name tag every
+login node carries by default. The tag is operator-mutable; if you re-tag
+the login node, update the policy condition to match.
 
 **Combined CRUD is intentional, not a mistake.** The admin policy covers
 create + update + delete in one policy because (1) CFN rollback on a failed
@@ -117,22 +93,18 @@ Describe across every service. If you want a read-only variant, reduce the same
 actions to `*:Describe*` / `*:Get*` / `*:List*` for an auditor role.
 
 **The admin policy is split into core + Image Builder** because the combined
-document (~7.4 KB) exceeds the IAM 6,144-character per-policy limit. The
-~5.8 KB core covers a normal deploy; the ~1.7 KB Image Builder add-on is only
-needed for the standalone DLAMI builder. The CFN template attaches both to the
-group when `AttachImageBuilderPolicy=true`.
+document exceeds IAM's 6,144-character per-policy limit. The core covers a
+normal deploy; the Image Builder add-on is only needed for the standalone
+DLAMI builder.
 
-**There is no `AmazonPCSFullAccess` managed policy** as of January 2026 — AWS
-publishes only `AWSPCSComputeNodePolicy` (for compute instances) and
-`AWSPCSServiceRolePolicy` (the service-linked role). The PCS portion of the
-admin policy must therefore be customer-managed.
-
-**Pairing with AWS-managed policies.** For a smaller customer-managed surface
-you can attach AWS-managed policies for parts of the stack and trim the matching
-statements: `AWSCloudFormationFullAccess`, `AmazonFSxFullAccess`,
-`AWSImageBuilderFullAccess` are reasonable fits. Avoid `AmazonEC2FullAccess` —
-it is materially overprivileged (e.g. EBS public-share); prefer the
-customer-managed EC2 statements in the template.
+**Pairing with AWS-managed policies.** For a smaller customer-managed
+surface, attach AWS-managed policies for parts of the stack and trim the
+matching statements: `AWSCloudFormationFullAccess`, `AmazonFSxFullAccess`,
+`AWSImageBuilderFullAccess` are reasonable fits. Avoid
+`AmazonEC2FullAccess` — it is materially overprivileged (e.g. EBS
+public-share); prefer the customer-managed EC2 statements in the template.
+There is no `AmazonPCSFullAccess`, so the PCS portion has to stay
+customer-managed.
 
 ### Not covered by these policies
 
@@ -166,13 +138,12 @@ The same approach works for the user policy — exercise the user workflows
 
 ## Verifying the policies
 
-To confirm the admin policy can deploy a cluster end-to-end and the user policy is
-correctly constrained (login-only SSM, no LDAP-password access), see the reproducible
-procedure in [tests/iam-test.md](../tests/iam-test.md).
+To confirm the admin policy can deploy a cluster end-to-end and the user
+policy is correctly constrained (login-only SSM, no LDAP-password access),
+see the reproducible procedure in [tests/iam-test.md](../tests/iam-test.md).
 
-> **Note on the template-source bucket.** The admin policy grants no `s3:GetObject`,
-> because the production templates live in the public `awsome-distributed-ai`
-> bucket (CFN fetches `--template-url` anonymously). If you host the templates in
-> a **private** bucket, the deploying principal additionally needs `s3:GetObject`
-> on that bucket — grant it separately; it is intentionally out of the
-> cluster-admin policy.
+> **Private template bucket:** the admin policy grants no `s3:GetObject`
+> because the production templates live in the public
+> `awsome-distributed-ai` bucket (CFN fetches `--template-url`
+> anonymously). If you host the templates in a private bucket, grant
+> `s3:GetObject` on that bucket separately.

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -56,9 +56,9 @@ python3 -m venv $HOME/jupyter-env
 $HOME/jupyter-env/bin/pip install --upgrade pip jupyterlab
 ```
 
-**For GPU work, also install PyTorch now** so the kernel can `import torch`
-without another install roundtrip inside the notebook. The PCS-Ready DLAMI
-ships CUDA 12.x, so pin the matching wheel:
+**To run the GPU-visibility verify cell below**, also install PyTorch here so
+the kernel can `import torch` without another install roundtrip. The
+PCS-Ready DLAMI ships CUDA 12.x, so pin the matching wheel:
 
 ```bash
 $HOME/jupyter-env/bin/pip install torch --index-url https://download.pytorch.org/whl/cu124
@@ -129,8 +129,7 @@ sbatch -p cpu1 jupyter.sbatch
 sbatch -p gpu-g6 --gres=gpu:1 jupyter.sbatch
 ```
 
-For GPU work, the venv already has `torch` from Step 1; the GPU
-allocation behaviour is detailed in [Using GPUs](#using-gpus) below.
+GPU allocation behaviour is detailed in [Using GPUs](#using-gpus) below.
 
 The first submission on an idle queue waits ~2–3 minutes for the node to
 scale up (8–12 minutes if the node is also running its first-boot

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -45,6 +45,9 @@ Compute node — Jupyter server, launched as an sbatch job
 - **Multi-user clusters:** your `$HOME` must exist before the first job — log
   in to the login node (SSH or SSM) once so `pam_mkhomedir` creates it. Slurm
   jobs do not create home directories.
+- **Do not run Jupyter on the login node.** It has no GPUs and is shared with
+  the monitoring stack; always launch the server as a Slurm job on a compute
+  node, as Step 2 does.
 
 ## Step 1 — one-time: create a Jupyter environment on `/home`
 
@@ -223,6 +226,24 @@ costs nothing.
 You launch a GPU session with the same script and the `sbatch -p <gpu-queue>
 --gres=gpu:N` form shown in Step 2 — nothing else changes.
 
+### How the GPU allocation behaves
+
+- **`--gres=gpu:N` is the only knob.** Slurm sets `CUDA_VISIBLE_DEVICES`
+  accordingly and PyTorch sees exactly those GPUs. Request only what you
+  need — the remaining GPUs on a multi-GPU node stay available for other
+  jobs.
+- **Multi-GPU works inside one notebook.** All allocated GPUs are visible
+  to the kernel, so `DataParallel` / FSDP / `accelerate` run as usual.
+- **Sizing.** `--gres=gpu:1` is plenty for most interactive exploration.
+  Keep `--time` tight — an idle notebook holds its GPUs until the job
+  ends; prefer a batch job for multi-hour training.
+- **Multi-NIC GPU nodes (P5/P6) work as-is.** `hostname -I` returns one
+  address per EFA NIC; the script binds to the first, which is
+  same-VPC-reachable from the login node.
+- **Containerized kernels (optional).** Wrap `jupyter lab` in
+  `srun --container-image=<sqsh> --container-mounts=/fsx,$HOME …` to run
+  the notebook inside a Pyxis-imported image (see [README §7](../README.md#7-running-a-job)).
+
 ### Verify GPU visibility from the notebook
 
 Paste this into a new notebook cell after the kernel comes up. It confirms
@@ -250,56 +271,7 @@ if torch.cuda.is_available():
 ```
 
 Expected: `torch.cuda.device_count()` **equals the `--gres=gpu:N` you
-requested**. If the `nvidia-smi` in a shell cell shows more devices than
+requested**. If `nvidia-smi` shows more devices than
 `torch.cuda.device_count()`, Slurm's cgroup isolation is not restricting
 them — file a bug against the CNG configuration.
 
-### How the GPU allocation behaves
-
-- **Slurm enforces the `--gres` count** (the verify cell above proves it):
-  the job gets `CUDA_VISIBLE_DEVICES` set to its allocated GPUs (e.g. `0,1`
-  for `--gres=gpu:2` on a 4-GPU g6.12xlarge), so PyTorch sees exactly the
-  requested GPUs. GPU node groups configure gres automatically (e.g.
-  `Gres=gpu:L4:4`; check with `scontrol show node <node>`).
-- **Multi-GPU works inside one notebook.** All allocated GPUs are visible to
-  the kernel, so `DataParallel` / FSDP / `accelerate` with
-  `num_processes=<gres count>` run as usual. Leave GPUs you don't need
-  unrequested — on multi-GPU nodes Slurm can schedule other jobs (another
-  user's Jupyter, batch training) onto the remaining GPUs.
-- **Sizing:** request only what you interactively need (`--gres=gpu:1` is
-  plenty for most exploration) and keep `--time` tight — an idle notebook
-  holds its GPUs until the job ends. For multi-hour *training*, prefer a
-  batch job over a notebook so the GPUs free up when the run finishes.
-  (Remember `HF_HOME=/fsx/$USER/.hf-cache` from Step 1 for model downloads.)
-- **Multi-NIC GPU nodes (P5/P6) work as-is.** On these instances `hostname -I`
-  returns dozens of addresses (one per EFA NIC). The script binds Jupyter to
-  the first entry, which in practice is the primary interface's IP (verified
-  on p5.48xlarge, 32 NICs) — and any entry is same-VPC-reachable from the
-  login node, so the port-forward path works regardless. The kernel saw all
-  8 H100s with `--gres=gpu:8`.
-- **Containerized kernels (optional):** to use an NGC image as the notebook
-  environment instead of a venv, wrap the server in Pyxis:
-  `srun --container-image=<image> --container-mounts=/fsx,$HOME …` around the
-  `jupyter lab` command inside the job. Import large images once to
-  `/fsx/*.sqsh` (see the [README §7](../README.md#7-running-a-job) enroot
-  note) and pass the `.sqsh` path as the image.
-
-## Notes
-
-- **Multi-user:** each user runs their own server job under their own UID; the
-  job-ID-derived port makes same-node collisions unlikely (see the comment in
-  the script). Keep tokens in `$HOME` (created mode 600 by the script) — treat
-  the token like a password to your account, since the SSM/IAM layer alone
-  does not distinguish cluster users.
-- **Multiple clusters in one account:** the `Name=*login` tag filter in the
-  connect snippet matches the login node of *every* PCS cluster that follows
-  the naming convention — add a `"Name=tag:ClusterName,Values=<your-stack>"`
-  filter to pin it when you run more than one.
-- **Alternative when `SSHAccessCidr` is set:** a plain SSH tunnel also works —
-  `ssh -L 8888:<compute-node-ip>:<port> <user>@<login-public-ip>` — useful for
-  users who cannot install the Session Manager plugin.
-- **Do not run Jupyter on the login node.** It has no GPUs, and it is shared
-  by every user (and hosts the monitoring stack).
-- **Scripts on `/fsx` can't be exec'd directly** (Lustre blocks `execve` on
-  some paths) — keep the sbatch file under `$HOME`, or invoke via
-  `bash /fsx/script.sh`.

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -61,10 +61,12 @@ $HOME/jupyter-env/bin/pip install --upgrade pip jupyterlab
 
 **To run the GPU-visibility verify cell below**, also install PyTorch here so
 the kernel can `import torch` without another install roundtrip. The
-PCS-Ready DLAMI ships CUDA 12.x, so pin the matching wheel:
+PCS-Ready DLAMI's NVIDIA driver (595.x) supports current CUDA wheels; the
+`cu130` build matches the image's CUDA 13.2 stack (see
+[PCS-READY-DLAMI.md](./PCS-READY-DLAMI.md)):
 
 ```bash
-$HOME/jupyter-env/bin/pip install torch --index-url https://download.pytorch.org/whl/cu124
+$HOME/jupyter-env/bin/pip install torch --index-url https://download.pytorch.org/whl/cu130
 ```
 
 > For ML work, also set `HF_HOME=/fsx/$USER/.hf-cache` in your notebooks/jobs —
@@ -193,23 +195,31 @@ with the disabled-auth form:
 ```bash
 exec jupyter lab --no-browser --ip="$NODE_IP" --port="$PORT" \
   --ServerApp.token='' --ServerApp.password='' \
-  --ServerApp.disable_check_xsrf=True \
   --notebook-dir="$HOME"
 ```
 
-The token file (and the `openssl rand` line above it) is no longer needed
-and can be dropped. Connect to `http://localhost:8888/lab` — no token
-required. Nothing else in Step 3 changes.
+The token file (and the `openssl rand` line above it) are no longer
+needed and can be dropped; you can also drop the `token   = ...` line
+from the sbatch banner heredoc. Steps 1 and 3 of Step 3 are unchanged —
+skip sub-step 2 (there is no token to read). Connect to
+`http://localhost:8888/lab` — no token required.
+
+Jupyter's default XSRF protection is left **enabled** (this recipe does
+not set `--ServerApp.disable_check_xsrf`); the Lab UI's own cookie+header
+flow works fine with it on, and it is the one browser-side guard that
+still prevents a random webpage open in your browser from POSTing to
+`http://localhost:8888` and executing code on the compute node.
 
 > **Do NOT do this on a multi-user cluster.** Jupyter binds to the compute
 > node's private IP; any other cluster user's job on any other node in the
 > same VPC subnet can reach that IP:port. The token is what separates one
 > user's notebook (with your `$HOME` and credentials) from another user's.
-> Removing it means anyone with a shell on any compute node can attach to
-> your kernel. On a single-`ubuntu`-user cluster there's only one identity,
-> so the token adds no separation and disabling it is fine; on a cluster
-> with `DirectoryService=OpenLDAP-LoginNode` (or any shared multi-user
-> setup) always keep the token.
+> Removing it means anyone who can run a job on this cluster can attach to
+> your kernel. Only use the token-less form when **every IAM principal who
+> can reach the VPC or submit jobs is trusted as the same person** — the
+> single-`ubuntu`-user default cluster is that case by construction;
+> `DirectoryService=OpenLDAP-LoginNode` (or any shared multi-user setup)
+> is not, so always keep the token there.
 
 ## Stopping
 
@@ -271,7 +281,8 @@ if torch.cuda.is_available():
 ```
 
 Expected: `torch.cuda.device_count()` **equals the `--gres=gpu:N` you
-requested**. If `nvidia-smi` shows more devices than
-`torch.cuda.device_count()`, Slurm's cgroup isolation is not restricting
-them — file a bug against the CNG configuration.
+requested**. Note that `nvidia-smi` from inside the job may still show
+all physical GPUs on the node — that's expected on these clusters;
+allocation is enforced per-process via `CUDA_VISIBLE_DEVICES`, which
+`torch.cuda.device_count()` respects.
 

--- a/architectures/aws-pcs/docs/JUPYTER.md
+++ b/architectures/aws-pcs/docs/JUPYTER.md
@@ -56,6 +56,14 @@ python3 -m venv $HOME/jupyter-env
 $HOME/jupyter-env/bin/pip install --upgrade pip jupyterlab
 ```
 
+**For GPU work, also install PyTorch now** so the kernel can `import torch`
+without another install roundtrip inside the notebook. The PCS-Ready DLAMI
+ships CUDA 12.x, so pin the matching wheel:
+
+```bash
+$HOME/jupyter-env/bin/pip install torch --index-url https://download.pytorch.org/whl/cu124
+```
+
 > For ML work, also set `HF_HOME=/fsx/$USER/.hf-cache` in your notebooks/jobs —
 > the HuggingFace cache must not live on NFS `/home` (file-locking errors under
 > concurrent access), and a per-user path avoids ownership clashes on
@@ -103,11 +111,17 @@ exec jupyter lab --no-browser --ip="$NODE_IP" --port="$PORT" \
   --notebook-dir="$HOME"
 ```
 
-Then submit it with `sbatch`. **`-p <queue>` is required** — Slurm has no
-default partition, so a bare `sbatch jupyter.sbatch` is rejected with
+Then submit it with `sbatch` **from `$HOME`** — Slurm's default working
+directory for a job is the submitter's CWD, and the `--output=%u-jupyter-%j.log`
+line above resolves relative to that. Submitting from anywhere else (e.g. an
+SSM shell that lands in `/var/…`) drops the log there instead of `$HOME`, and
+the connect step in Step 3 won't find it. **`-p <queue>` is required** — Slurm
+has no default partition, so a bare `sbatch jupyter.sbatch` is rejected with
 *"invalid partition specified"*. Run `sinfo` to list your queues, then:
 
 ```bash
+cd $HOME
+
 # CPU session — pick a CPU queue (e.g. cpu1)
 sbatch -p cpu1 jupyter.sbatch
 
@@ -115,8 +129,7 @@ sbatch -p cpu1 jupyter.sbatch
 sbatch -p gpu-g6 --gres=gpu:1 jupyter.sbatch
 ```
 
-For GPU work, add the ML stack to the venv from Step 1 once
-(`$HOME/jupyter-env/bin/pip install torch  # + transformers, etc.`); the GPU
+For GPU work, the venv already has `torch` from Step 1; the GPU
 allocation behaviour is detailed in [Using GPUs](#using-gpus) below.
 
 The first submission on an idle queue waits ~2–3 minutes for the node to
@@ -128,16 +141,23 @@ Enroot/Pyxis install).
 The job log (`~/<user>-jupyter-<jobid>.log`, printed by the running job) gives
 you the compute node's `NODE_IP` and `PORT`. With those two values:
 
-**1. On your workstation** — open the SSM tunnel (fill in your Region and the
-`NODE_IP` / `PORT` from the log):
+**1. On your workstation** — open the SSM tunnel (fill in the `NODE_IP` /
+`PORT` from the job log). The login instance ID is resolved from the
+CloudFormation stack via the PCS API — same recipe used in
+[README §6](../README.md#6-accessing-the-cluster), so it works across
+multi-cluster VPCs without accidentally targeting another cluster's login:
 
 ```bash
-LOGIN_ID=$(aws ec2 describe-instances --region <region> \
-  --filters "Name=tag:Name,Values=*login" \
-            "Name=instance-state-name,Values=running" \
-  --query 'Reservations[0].Instances[0].InstanceId' --output text)
+STACK_NAME=pcs-ml-cluster        # your CloudFormation stack name
+AWS_REGION=us-east-1             # your region
 
-aws ssm start-session --region <region> --target "$LOGIN_ID" \
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+[ -n "$CLUSTER_ID" ] && [ "$CLUSTER_ID" != "None" ] || { echo "No ClusterId — check STACK_NAME/AWS_REGION"; return 1; }
+
+LOGIN_CNG_ID=$(aws pcs list-compute-node-groups --cluster-identifier "$CLUSTER_ID" --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)
+LOGIN_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$LOGIN_CNG_ID" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+aws ssm start-session --region "$AWS_REGION" --target "$LOGIN_ID" \
   --document-name AWS-StartPortForwardingSessionToRemoteHost \
   --parameters "host=<NODE_IP>,portNumber=<PORT>,localPortNumber=8888"
 ```
@@ -153,13 +173,41 @@ cat ~/.jupyter-token-<jobid>
 
 **3. In your browser** — open `http://localhost:8888/?token=<token>`.
 
-> **Required IAM.** The two CLI calls above are already permitted by the stock
+> **Required IAM.** The CLI calls above are already permitted by the stock
 > [`cluster-user-iam.yaml`](../assets/cluster-user-iam.yaml) policy (and by any
 > broader admin credentials). Under a restricted role, ensure it grants:
+> `cloudformation:DescribeStacks`, `pcs:ListComputeNodeGroups`,
 > `ec2:DescribeInstances` (find the login node); `ssm:StartSession` on the
-> login instance (`ssm:resourceTag/Name = PCS-login*`) and on the
-> `AWS-StartPortForwardingSessionToRemoteHost` document; and
+> login instance (`ssm:resourceTag/Name = <ClusterStackName>-login`) and on
+> the `AWS-StartPortForwardingSessionToRemoteHost` document; and
 > `ssm:TerminateSession` / `ssm:DescribeSessions` to end the tunnel.
+
+### Running without a token (single-user clusters only)
+
+If you're the only user on the cluster and want to skip the token
+copy-paste, swap the `--ServerApp.token=…` line in the sbatch script
+with the disabled-auth form:
+
+```bash
+exec jupyter lab --no-browser --ip="$NODE_IP" --port="$PORT" \
+  --ServerApp.token='' --ServerApp.password='' \
+  --ServerApp.disable_check_xsrf=True \
+  --notebook-dir="$HOME"
+```
+
+The token file (and the `openssl rand` line above it) is no longer needed
+and can be dropped. Connect to `http://localhost:8888/lab` — no token
+required. Nothing else in Step 3 changes.
+
+> **Do NOT do this on a multi-user cluster.** Jupyter binds to the compute
+> node's private IP; any other cluster user's job on any other node in the
+> same VPC subnet can reach that IP:port. The token is what separates one
+> user's notebook (with your `$HOME` and credentials) from another user's.
+> Removing it means anyone with a shell on any compute node can attach to
+> your kernel. On a single-`ubuntu`-user cluster there's only one identity,
+> so the token adds no separation and disabling it is fine; on a cluster
+> with `DirectoryService=OpenLDAP-LoginNode` (or any shared multi-user
+> setup) always keep the token.
 
 ## Stopping
 
@@ -174,15 +222,46 @@ costs nothing.
 ## Using GPUs
 
 You launch a GPU session with the same script and the `sbatch -p <gpu-queue>
---gres=gpu:N` form shown in Step 2 — nothing else changes. How the GPU
-allocation behaves:
+--gres=gpu:N` form shown in Step 2 — nothing else changes.
 
-- **Slurm enforces the `--gres` count.** The job gets `CUDA_VISIBLE_DEVICES`
-  set to its allocated GPUs (e.g. `0,1` for `--gres=gpu:2` on a 4-GPU
-  g6.12xlarge), so frameworks like PyTorch see exactly the requested GPUs —
-  `torch.cuda.device_count()` matches the `--gres` count. GPU node groups
-  configure gres automatically (e.g. `Gres=gpu:L4:4`; check with
-  `scontrol show node <node>`).
+### Verify GPU visibility from the notebook
+
+Paste this into a new notebook cell after the kernel comes up. It confirms
+Slurm's `--gres` count, that PyTorch sees the same set of GPUs, and that a
+kernel actually runs on the allocated device:
+
+```python
+import os, torch
+
+# 1. What Slurm handed us
+print("CUDA_VISIBLE_DEVICES =", os.environ.get("CUDA_VISIBLE_DEVICES"))
+print("SLURM_JOB_GPUS       =", os.environ.get("SLURM_JOB_GPUS"))
+
+# 2. What PyTorch actually sees
+print("torch.cuda.is_available:", torch.cuda.is_available())
+print("torch.cuda.device_count:", torch.cuda.device_count())
+for i in range(torch.cuda.device_count()):
+    p = torch.cuda.get_device_properties(i)
+    print(f"  [{i}] {p.name}  {p.total_memory/1024**3:.1f} GiB  SM {p.major}.{p.minor}")
+
+# 3. Prove compute runs on the allocated GPU (raises if the kernel can't launch)
+if torch.cuda.is_available():
+    x = torch.randn(4096, 4096, device="cuda:0")
+    print("matmul on cuda:0 -> sum =", float((x @ x).sum()))
+```
+
+Expected: `torch.cuda.device_count()` **equals the `--gres=gpu:N` you
+requested**. If the `nvidia-smi` in a shell cell shows more devices than
+`torch.cuda.device_count()`, Slurm's cgroup isolation is not restricting
+them — file a bug against the CNG configuration.
+
+### How the GPU allocation behaves
+
+- **Slurm enforces the `--gres` count** (the verify cell above proves it):
+  the job gets `CUDA_VISIBLE_DEVICES` set to its allocated GPUs (e.g. `0,1`
+  for `--gres=gpu:2` on a 4-GPU g6.12xlarge), so PyTorch sees exactly the
+  requested GPUs. GPU node groups configure gres automatically (e.g.
+  `Gres=gpu:L4:4`; check with `scontrol show node <node>`).
 - **Multi-GPU works inside one notebook.** All allocated GPUs are visible to
   the kernel, so `DataParallel` / FSDP / `accelerate` with
   `num_processes=<gres count>` run as usual. Leave GPUs you don't need

--- a/architectures/aws-pcs/docs/PCS-READY-DLAMI.md
+++ b/architectures/aws-pcs/docs/PCS-READY-DLAMI.md
@@ -27,9 +27,11 @@ New builds are announced through the SNS topic
 
 ## PCS-Ready DLAMI x86\_64
 
-Every published x86\_64 PCS-Ready DLAMI, newest first. AMI IDs are region-scoped
-and shown for **us-east-2**; use the `describe-images` command below the table
-to look up the same build in another region.
+Snapshot (as of 2026-08-05) of the published x86\_64 PCS-Ready DLAMIs, newest
+first. AMI IDs are region-scoped and shown for **us-east-2** — the SSM
+parameter above resolves to the newest build in each region, so leaving
+`AmiId` empty in the templates is the region-portable path; refer here only
+when pinning to a specific build.
 
 Base-DLAMI component versions (kernel, NVIDIA driver, CUDA, DCGM, EFA,
 OFI-NCCL, containerd) come from the DLAMI release notes for the build named in

--- a/architectures/aws-pcs/docs/PCS-READY-DLAMI.md
+++ b/architectures/aws-pcs/docs/PCS-READY-DLAMI.md
@@ -1,0 +1,56 @@
+# PCS-Ready DLAMI version history
+
+AWS publishes the **PCS-Ready DLAMI Base GPU AMI (Ubuntu 24.04)** as the default
+compute-node image for AWS PCS. Every deploy-all / add-cng template in this repo
+resolves it through the public SSM parameter
+`/aws/service/pcs/ami/dlami-base-ubuntu2404/x86_64/latest/ami-id` when `AmiId`
+is left empty.
+
+The image is a two-layer stack:
+
+1. **Base DLAMI** — Ubuntu 24.04, kernel, NVIDIA driver, CUDA stack, EFA, DCGM,
+   containerd, OFI-NCCL. Maintained on the DLAMI release cadence.
+2. **PCS layer** — PCS Agent, one or more Slurm builds, EFS utils. Added on top
+   by the PCS team.
+
+The AMI `Description` embeds every PCS-layer version and the base DLAMI build
+date, for example:
+
+```
+PCS-Ready DLAMI based on Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04) 20260724.
+PCS Agent: 1.5.0-1. Slurm: 24.11.7-2, 25.05.8-2, 25.11.6-2. EFS Utils: 2.4.2
+```
+
+New builds are announced through the SNS topic
+`arn:aws:sns:us-west-2:265886551188:pcs-ready-dlami-release-notifications`
+(see the [PCS-Ready DLAMI user guide](https://docs.aws.amazon.com/pcs/latest/userguide/working-with_ami_pcs-ready-dlami.html)).
+
+## PCS-Ready DLAMI x86\_64
+
+Every published x86\_64 PCS-Ready DLAMI, newest first. AMI IDs are region-scoped
+and shown for **us-east-2**; use the `describe-images` command below the table
+to look up the same build in another region.
+
+Base-DLAMI component versions (kernel, NVIDIA driver, CUDA, DCGM, EFA,
+OFI-NCCL, containerd) come from the DLAMI release notes for the build named in
+the "Base DLAMI" column. Intermediate base builds without their own release
+notes inherit values from the nearest previous published build.
+
+| PCS build | AMI ID (us-east-2) | Base DLAMI | PCS Agent | Slurm | EFS Utils | Kernel | NVIDIA driver | Default CUDA | CUDA stack | DCGM | EFA | OFI-NCCL | containerd |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-07-27 | `ami-0631f0a4211880f98` | 20260724 | 1.5.0-1 | 24.11.7-2, 25.05.8-2, 25.11.6-2 | 2.4.2 | 6.17.0-1019 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.6.0 | 1.47.0 | 1.18.0 | v2.2.6 |
+| 2026-07-22 | `ami-045669174d015d92c` | 20260721 | 1.5.0-1 | 24.11.7-2, 25.05.8-2, 25.11.6-2 | 2.4.2 | 6.17.0-1019 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.6.0 | 1.47.0 | 1.18.0 | v2.2.6 |
+| 2026-07-20 | `ami-0c91bfa1d3999dfea` | 20260717 | 1.5.0-1 | 24.11.7-2, 25.05.8-2, 25.11.6-2 | 2.4.2 | 6.17.0-1019 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.6.0 | 1.47.0 | 1.18.0 | v2.2.6 |
+| 2026-07-13 | `ami-0c1b2f4317de42125` | 20260710 | 1.4.0-1 | 24.11.7-1, 25.05.8-2, 25.11.6-2 | 2.4.2 | 6.17.0-1019 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.6.0 | 1.47.0 | 1.18.0 | v2.2.5 |
+| 2026-07-08 | `ami-01b64e972d350b317` | 20260707 | 1.4.0-1 | 24.11.7-1, 25.05.8-2, 25.11.6-2 | 2.4.2 | 6.17.0-1019 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.6.0 | 1.47.0 | 1.18.0 | v2.2.5 |
+| 2026-07-06 | `ami-04e4916942b70bf64` | 20260703 | 1.4.0-1 | 24.11.7-1, 25.05.8-2, 25.11.6-2 | 2.4.2 | 6.17.0-1019 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.6.0 | 1.47.0 | 1.18.0 | v2.2.5 |
+| 2026-06-29 | `ami-03ef51e588e1864db` | 20260626 | 1.4.0-1 | 24.11.7-1, 25.05.7-1, 25.11.2-1 | 2.4.2 | 6.17.0-1019 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.6.0 | 1.47.0 | 1.18.0 | v2.2.5 |
+| 2026-06-22 | `ami-039d4de58ea181e3d` | 20260619 | 1.4.0-1 | 24.11.7-1, 25.05.7-1, 25.11.2-1 | 2.4.2 | 6.17.0-1017 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.5.3 | 1.47.0 | 1.18.0 | v2.2.4 |
+| 2026-06-09 | `ami-08a86ee651999836e` | 20260609 | 1.4.0-1 | 24.11.7-1, 25.05.7-1, 25.11.2-1 | 2.4.2 | 6.17.0-1017 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.5.3 | 1.47.0 | 1.18.0 | v2.2.4 |
+| 2026-06-07 | `ami-08ab1cf913f168f31` | 20260605 | 1.4.0-1 | 24.11.7-1, 25.05.7-1, 25.11.2-1 | 2.4.2 | 6.17.0-1017 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.5.3 | 1.47.0 | 1.18.0 | v2.2.4 |
+| 2026-06-02 | `ami-0da9c0741ad44f950` | 20260602 | 1.4.0-1 | 24.11.7-1, 25.05.7-1, 25.11.2-1 | 2.4.2 | 6.17.0-1015 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.5.3 | 1.47.0 | 1.18.0 | v2.2.4 |
+| 2026-05-30 | `ami-0ddf60cecde4935de` | 20260529 | 1.4.0-1 | 24.11.7-1, 25.05.7-1, 25.11.2-1 | 2.4.2 | 6.17.0-1015 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.5.3 | 1.47.0 | 1.18.0 | v2.2.4 |
+| 2026-05-23 | `ami-0b0605bcf9ffffa63` | 20260522 | 1.4.0-1 | 24.11.7-1, 25.05.7-1, 25.11.2-1 | 2.4.2 | 6.17.0-1015 | 595.71.05 | 13.2 | 12.8, 12.9, 13.0, 13.2 | 4.5.3 | 1.47.0 | 1.18.0 | v2.2.4 |
+
+Full base DLAMI release notes:
+<https://docs.aws.amazon.com/dlami/latest/devguide/aws-deep-learning-x86-base-gpu-ami-ubuntu-24-04.html>

--- a/architectures/aws-pcs/docs/USER-MANAGEMENT.md
+++ b/architectures/aws-pcs/docs/USER-MANAGEMENT.md
@@ -23,7 +23,7 @@ CLI — pick one.
 ### deploy-all — from the CloudFormation console (Quick Create)
 
 1. Open the deploy-all template's **Launch Stack** link in the
-   [README](../README.md#quick-start) (or navigate to CloudFormation
+   [README](../README.md#3-quick-start) (or navigate to CloudFormation
    → *Create stack* → *Upload* `pcs-ml-cluster-deploy-all.yaml`).
 2. On the *Specify stack details* page, set:
    - **`DirectoryService`** → `OpenLDAP-LoginNode` (default is `none`
@@ -380,8 +380,11 @@ see the blog for pricing detail.
 
 Registering users in accounting is optional unless the cluster was
 deployed with `AccountingPolicyEnforcement=associations,limits,safe`
-(or the stricter `associations,limits`) — with either enforcement on,
-jobs from unregistered users are rejected.
+— with enforcement on, jobs from unregistered users are rejected.
+(Slurm also supports a stricter `associations,limits` mode that rejects
+over-quota work at submit time rather than holding it pending, but
+these templates only offer `none` and `associations,limits,safe`; the
+sections below use the latter.)
 
 > **`sacctmgr` add / modify / remove must run as root.** In PCS
 > managed accounting the Administrator is `root`; the default
@@ -390,13 +393,8 @@ jobs from unregistered users are rejected.
 > accounts"*. Read-only forms (`sacctmgr show …`, `sacct`, `sreport`)
 > work as any user.
 
-Ubuntu's `sudo` resets `PATH` (`secure_path`), so `sudo sacctmgr` from
-a shell where you only `export PATH=…` still fails to find the binary.
-Bind the absolute path to a variable and use it throughout:
-
 ```bash
-S=/opt/aws/pcs/scheduler/slurm-25.11/bin/sacctmgr   # 25.05 if SlurmVersion=25.05
-export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH  # for the read-only sacct / sreport below
+S=/opt/aws/pcs/scheduler/slurm-25.11/bin/sacctmgr   # slurm-25.05 for SlurmVersion=25.05
 ```
 
 ### 4.1 Register users to accounts
@@ -435,24 +433,54 @@ With `AccountingPolicyEnforcement=associations,limits,safe` a job
 that would put alice over her running-minutes budget is **accepted
 at submit time but held pending** with reason
 `AssocGrpCPURunMinutesLimit`; it starts only once earlier work drains
-the budget. A job that fits proceeds normally:
+the budget. To see this, first tighten the cap so a modest job trips
+it (8 CPUs × 30 min = 240 CPU-min > 60):
 
 ```bash
-# As alice
-sbatch --account=proj_physics --nodes=1 --ntasks-per-node=8 --time=30:00 myjob.sh
+sudo $S -i modify user alice set GrpTRESRunMins=cpu=60
+```
+
+As alice, in her login shell (`sudo su - alice`) — `sbatch` is on the
+login-shell `PATH`, no export needed. `--ntasks-per-node` here must not
+exceed what `sinfo -N -o %c` reports for the queue (4 on the default
+`cpu1` / `c6i.2xlarge`); at 4 tasks × 30 min = 120 CPU-min > 60 the
+limit still trips:
+
+```bash
+sudo su - alice
+# now inside alice's login shell:
+printf '#!/bin/bash\nsleep 1000\n' > ~/myjob.sh && chmod +x ~/myjob.sh
+sbatch --account=proj_physics --partition=cpu1 --nodes=1 --ntasks-per-node=4 --time=30:00 ~/myjob.sh
+exit
+# back in the ubuntu shell:
 squeue -u alice -o "%.6i %.10P %.8u %.2t %r"
 #   6      cpu1     alice PD AssocGrpCPURunMinutesLimit
-sbatch --account=proj_physics --nodes=1 --ntasks=1 --time=2:00 smalljob.sh
+```
+
+A job that fits proceeds normally (2 CPUs × 2 min = 4 CPU-min < 60):
+
+```bash
+sudo su - alice
+printf '#!/bin/bash\nhostname\n' > ~/smalljob.sh && chmod +x ~/smalljob.sh
+sbatch --account=proj_physics --partition=cpu1 --nodes=1 --ntasks=1 --time=2:00 ~/smalljob.sh
+exit
 #   -> Submitted batch job <n> (runs when a node is available)
+```
+
+Restore the original cap once done:
+
+```bash
+sudo $S -i modify user alice set GrpTRESRunMins=cpu=6000
 ```
 
 > **`safe` accepts, doesn't `sbatch: error` — even over-quota.** The
 > blog's *"Job violates accounting/QOS policy"* message would come from
-> the stricter `AccountingPolicyEnforcement=associations,limits` (no
-> `safe`). With `safe` the scheduler still accepts the submission so
-> the user can leave work queued; only *starting* it is deferred until
-> the running-minutes budget frees up. Watch `squeue`'s Reason column,
-> not `sbatch`'s exit status, to see the limit taking effect.
+> Slurm's stricter `associations,limits` mode (no `safe`), which these
+> templates don't offer. With `safe` the scheduler still accepts the
+> submission so the user can leave work queued; only *starting* it is
+> deferred until the running-minutes budget frees up. Watch `squeue`'s
+> Reason column, not `sbatch`'s exit status, to see the limit taking
+> effect.
 
 ### 4.3 Reporting
 
@@ -465,11 +493,11 @@ sacct --starttime=$(date -d "7 days ago" +%Y-%m-%d) \
 
 # Monthly cluster utilization by account/user
 sreport cluster AccountUtilizationByUser \
-  start=2026-04-01 end=2026-04-30 -t percent \
+  start=2026-04-01 end=2026-05-01 -t percent \
   format="Accounts,Login,Proper,Used"
 
 # Monthly top users
-sreport user topusage start=2026-03-01 end=2026-03-31
+sreport user topusage start=2026-03-01 end=2026-04-01
 
 # Per-user weekly failure diagnostic
 sacct -u alice --starttime=$(date -d "7 days ago" +%Y-%m-%d) \

--- a/architectures/aws-pcs/docs/USER-MANAGEMENT.md
+++ b/architectures/aws-pcs/docs/USER-MANAGEMENT.md
@@ -112,6 +112,10 @@ aws ssm get-parameter --region "$AWS_REGION" --with-decryption --name "/pcs/$CLU
 > ```bash
 > sudo cat /home/ldap-db/.admin-password
 > ```
+>
+> If a later `ldap*` command replies *"Invalid credentials"*, the password
+> was typed wrong at the `-W` prompt — re-run the command to re-prompt,
+> and re-fetch from SSM here if you've lost it.
 
 ### 2.2 Add your first user
 
@@ -270,17 +274,26 @@ prompt).
 
 ### 3.1 Add a user
 
-Same `ldap-add-user.sh` invocation as in [§2.2](#22-add-your-first-user);
-pick the next unused `uidNumber` (see [§3.2 List users](#32-list-users)
-for what's in use, or [§8 UID / GID conventions](#8-uid--gid-conventions)
-for the allocation policy). The script refuses a `uidNumber` or username
-that already exists — two users sharing a UID would collapse into the
-same POSIX principal on the shared `/home` and `/fsx`.
+Same `ldap-add-user.sh` invocation as in [§2.2](#22-add-your-first-user).
+Pick the next unused `uidNumber`; [§3.2 List users](#32-list-users) shows
+what's already in use. The script refuses a `uidNumber` or username that
+already exists — two users sharing a UID would collapse into the same
+POSIX principal on the shared `/home` and `/fsx`.
 
 ```bash
 sudo /usr/local/bin/ldap-add-user.sh <username> <uid> 3000 "<ssh-pub-key>"
 # LDAP admin password: <paste from SSM — input is hidden>
 ```
+
+UID / GID allocation policy for this cluster:
+
+| Range | Purpose |
+|---|---|
+| 0–999 | System users (do not use) |
+| 1000 | `ubuntu` (DLAMI default user) |
+| 3000 | `clusterusers` group (default GID for new users) |
+| 3001+ | Additional groups |
+| 10001–59999 | LDAP user UIDs |
 
 ### 3.2 List users
 
@@ -504,14 +517,7 @@ sudo journalctl -u slapd -n 20
 cat /var/log/directory-setup.log
 ```
 
-### 5.3 "Invalid credentials" from `ldap*` commands
-
-You typed the wrong admin password at the `-W` prompt. Re-run the
-command; it will prompt again. Re-fetch the password with the recipe in
-[§2.1](#21-recover-the-ldap-admin-password) — SSM is the source of truth
-and `/home/ldap-db/.admin-password` is the fallback.
-
-### 5.4 Home directory not created
+### 5.3 Home directory not created
 
 `/home/<user>` is auto-created by `pam_mkhomedir` on first **interactive
 login** (SSH or `su -`). Slurm jobs do not create it, so a user who has
@@ -525,7 +531,7 @@ sudo chown alice:clusterusers /home/alice
 sudo chmod 700 /home/alice
 ```
 
-### 5.5 New compute node doesn't resolve users
+### 5.4 New compute node doesn't resolve users
 
 If the node was launched **before** `DirectoryService` was enabled
 (e.g. before a stack update), its LaunchTemplate has no SSSD client
@@ -535,81 +541,35 @@ setup. Terminate the node; PCS replaces it with a new one that has SSSD.
 
 ## 6. How it works
 
+- **`slapd` runs on the login node**, DB on shared `/home/ldap-db/`
+  (OpenZFS NFS) so it survives login-node restart or replacement.
+- **Every node runs SSSD** (server-side on login, client on compute) and
+  caches LDAP replies. `sudo sss_cache -E` refreshes.
+- **Compute nodes discover the login IP by EC2 tag** at first boot,
+  filtering on `pcs-cluster-id=<this cluster>` + `directory-role=server`,
+  then set `ldap_uri` in `/etc/sssd/sssd.conf`. Requires
+  `ec2:DescribeInstances` on the compute instance role (the cluster
+  IAM role grants it).
+- **Home directories are on shared `/home`**, auto-created by
+  `pam_mkhomedir` at first interactive login.
+- **Slurm launches jobs by numeric UID**, so a job runs even if a
+  compute node can't currently name-resolve the user (SSSD cold cache,
+  brief LDAP outage).
+
+> ⚠️ **Single login node only.** `OpenLDAP-LoginNode` runs slapd on one
+> node; keep the login CNG at `MinCount=MaxCount=1` while the directory
+> is enabled. Two login nodes would open the same MDB from two
+> processes (corruption risk). If HA is needed, plan for AWS Simple AD /
+> Managed AD — see [ROADMAP.md](./ROADMAP.md).
+
+**After a login-node replacement**, the new instance re-tags itself
+`directory-role=server` and re-attaches the same MDB. Newly-booting
+compute nodes discover the new IP; already-running compute nodes still
+hold the old `ldap_uri` and need a one-shot fix:
+
+```bash
+srun -N <n> -n <n> bash -c 'sudo sed -i "s#ldap_uri = .*#ldap_uri = ldap://<new-login-ip>#" /etc/sssd/sssd.conf && sudo sss_cache -E && sudo systemctl restart sssd'
 ```
-┌─────────────────────────────────────────────────────────┐
-│  Login Node                                              │
-│  ┌──────────┐     ┌──────────┐     ┌──────────────┐    │
-│  │  slapd   │────►│  SSSD    │────►│  NSS / PAM   │    │
-│  │ (OpenLDAP│     │  (cache) │     │  (getent,    │    │
-│  │  server) │     │          │     │   login, su) │    │
-│  └──────────┘     └──────────┘     └──────────────┘    │
-│  DB: /home/ldap-db/ (shared OpenZFS)                    │
-└───────┼──────────────────────────────────────────────────┘
-        │ ldap://login-ip:389
-        ▼
-┌─────────────────────────────────────────────────────────┐
-│  Compute Node                                            │
-│  ┌──────────┐     ┌──────────────┐                      │
-│  │  SSSD    │────►│  NSS / PAM   │                      │
-│  │ (client) │     │              │                      │
-│  └──────────┘     └──────────────┘                      │
-└─────────────────────────────────────────────────────────┘
-```
-
-- Users live in LDAP on the login node.
-- The DB is on shared `/home` (OpenZFS NFS) — survives login-node
-  restart or replacement.
-- Every node runs SSSD, which caches LDAP replies. `sss_cache -E`
-  refreshes.
-- Home directories are on shared `/home` (auto-created on first
-  interactive login).
-- Slurm sees LDAP users transparently — no Slurm-side config needed for
-  user resolution.
-
-> ⚠️ **Single login node only.** `OpenLDAP-LoginNode` runs slapd on
-> **one** node; keep the login CNG at `MinCount=MaxCount=1` while the
-> directory is enabled. Two login nodes would give clients an ambiguous
-> server and open the same MDB from two processes (corruption risk).
-> Use the planned `SimpleAD` / `ManagedAD` `DirectoryService` options
-> for HA — see [§10 Upgrading](#10-upgrading-to-aws-simple-ad-future).
-
-### How a compute node finds the LDAP server (tag-based discovery)
-
-Not obvious — spelled out here because it drives several operational
-edge cases.
-
-1. Login CNG tags itself `directory-role=server` + `pcs-cluster-id=<id>`;
-   compute CNGs tag themselves `directory-role=client`. This
-   `directory-role` tag is dedicated to the directory feature —
-   deliberately separate from the monitoring stack's `monitoring-role`.
-2. On first boot each compute node runs `setup-directory.sh client`,
-   which calls `aws ec2 describe-instances` filtering for
-   `pcs-cluster-id=<my cluster>` + `directory-role=server` +
-   `instance-state=running`, and reads the matching instance's
-   private IP. `pcs-cluster-id` scopes lookup to **this** cluster only.
-3. The private IP becomes SSSD's `ldap_uri` (`ldap://<login-ip>`); SSSD
-   on the compute node resolves users from the login's slapd.
-
-Implications:
-
-- **Compute nodes need `ec2:DescribeInstances`** in their instance role
-  (the cluster IAM role grants it). Without it, discovery fails silently
-  — check `/var/log/directory-setup.log` for
-  `could not discover directory server IP`.
-- **Login must be running before a compute node boots.** Normal deploy
-  order gives you this; a compute node that scales up later simply
-  queries the already-running server.
-- **After a login-node replacement**, the new instance re-tags itself
-  `directory-role=server` and re-attaches to the same `/home/ldap-db`.
-  The admin password is preserved (SSM). **Already-running compute
-  nodes**, though, keep the old cached `ldap_uri`; cached users still
-  resolve, but new/uncached lookups degrade. Fix by rebooting SSSD:
-  ```bash
-  srun -N <n> -n <n> bash -c 'sudo sed -i "s#ldap_uri = .*#ldap_uri = ldap://<new-login-ip>#" /etc/sssd/sssd.conf && sudo sss_cache -E && sudo systemctl restart sssd'
-  ```
-  A stable endpoint that removes this step is in
-  [ROADMAP.md](./ROADMAP.md) ("Stable LDAP endpoint across login-node
-  replacement").
 
 ---
 
@@ -637,51 +597,3 @@ sudo chown -R openldap:openldap /home/ldap-db
 sudo systemctl start slapd
 ```
 
----
-
-## 8. UID / GID conventions
-
-| Range | Purpose |
-|---|---|
-| 0–999 | System users (do not use) |
-| 1000 | `ubuntu` (DLAMI default user) |
-| 3000 | `clusterusers` group (default GID for new users) |
-| 3001+ | Additional groups |
-| 10001–59999 | LDAP user UIDs |
-
-Always specify UIDs explicitly (as [§2.2](#22-add-your-first-user)
-shows). This keeps ownership consistent across all nodes and shared
-filesystems.
-
----
-
-## 9. Template structure
-
-```
-deploy-all.yaml
-├─► cluster.yaml         (IAM role with ssm:PutParameter for /pcs/<id>/ldap/*)
-├─► add-cng.yaml (login) → DirectoryRole=server → setup-directory.sh server
-│                           (installs slapd, configures local SSSD)
-└─► add-cng.yaml (compute) → DirectoryRole=client → setup-directory.sh client
-                              (installs SSSD, discovers login IP via tags)
-```
-
----
-
-## 10. Upgrading to AWS Simple AD (future)
-
-If you outgrow OpenLDAP (need HA, >50 users, Kerberos), the
-`DirectoryService` parameter is designed to extend:
-
-```yaml
-DirectoryService: SimpleAD    # future AllowedValue
-```
-
-Migration path (planned):
-1. Export users: `slapcat > users.ldif`
-2. Deploy Simple AD (separate stack, 2 AZs)
-3. Import users
-4. Redeploy cluster with `DirectoryService=SimpleAD`
-5. Decommission slapd
-
-Tracked in [ROADMAP.md](./ROADMAP.md).

--- a/architectures/aws-pcs/docs/USER-MANAGEMENT.md
+++ b/architectures/aws-pcs/docs/USER-MANAGEMENT.md
@@ -1,363 +1,336 @@
 # User Management Guide
 
-This guide is written for **cluster administrators who may not be familiar with
-LDAP**. It covers the day-to-day operations of managing users on a PCS
-reference architecture cluster with `DirectoryService=OpenLDAP-LoginNode`.
+**By default a cluster runs as a single `ubuntu` user** — the PCS-Ready
+DLAMI default account, shared across the login and every compute node.
+Nothing further is needed for single-operator workflows.
 
-By default, the cluster runs as a single `ubuntu` user. When multi-user is
-enabled, an OpenLDAP directory runs on the login node and provides centralized
-POSIX user accounts visible on all nodes via SSSD.
-
----
-
-## Quick reference (common tasks)
-
-Run on the login node. `$ADMIN_PW` is the LDAP admin password from SSM (see
-[Getting the admin password](#getting-the-admin-password)); the `LDAP_*` env
-vars must be passed **inline to `sudo`** (`sudo VAR=... cmd`) — `sudo -E` alone
-drops them under the default `env_reset`/`secure_path`.
-
-> **Slurm path matches `SlurmVersion`.** The `sacctmgr` / `sbatch` paths below use
-> `slurm-25.11` (the default). If you deployed with `SlurmVersion=25.05`, replace
-> `slurm-25.11` with `slurm-25.05` in every path (or just run `export
-> PATH=/opt/aws/pcs/scheduler/slurm-$(ls /opt/aws/pcs/scheduler | sed 's/slurm-//')/bin:$PATH`
-> once and drop the absolute path).
-
-| Task | Command (run on the login node) |
-|---|---|
-| Add a user | `sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user.sh alice 10001 3000` |
-| Add a user + SSH key | `sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user.sh alice 10001 3000 "ssh-ed25519 AAAA..."` |
-| List all users | `ldapsearch -x -H ldap://localhost -b ou=People,dc=cluster,dc=internal uid` |
-| Delete a user | `ldapdelete -x -H ldap://localhost -D cn=admin,dc=cluster,dc=internal -w "$ADMIN_PW" uid=alice,ou=People,dc=cluster,dc=internal` then `sudo sss_cache -E` |
-| Reset a user's password | `ldappasswd -x -H ldap://localhost -D cn=admin,dc=cluster,dc=internal -w "$ADMIN_PW" -s NEWPASS uid=alice,ou=People,dc=cluster,dc=internal` |
-| Add user to Slurm accounting | `sudo /opt/aws/pcs/scheduler/slurm-25.11/bin/sacctmgr -i add user alice Account=ml-team` (root = accounting admin) |
-| Verify user on compute node | `srun -N1 -n1 -p cpu1 id alice` |
-
-`ldap-add-user.sh` is a helper script installed on the login node at
-`/usr/local/bin/` (it wraps `ldapadd`+`ldappasswd` so you don't need the LDAP
-syntax). List/delete/reset use the raw `ldap*` tools directly — the full
-commands are documented in each section below.
+**Read on only if you need multi-user access** (multiple engineers with
+their own POSIX accounts, home directories, and Slurm job ownership).
+This guide covers the day-to-day operations of a cluster deployed with
+`DirectoryService=OpenLDAP-LoginNode`, in which an OpenLDAP directory
+runs on the login node and provides centralized POSIX accounts visible
+on every node via SSSD. Written for cluster admins who may not be
+familiar with LDAP.
 
 ---
 
-## How it works (overview)
+## 1. Enabling multi-user
 
-```
-┌─────────────────────────────────────────────────────────┐
-│  Login Node                                              │
-│                                                          │
-│  ┌──────────┐     ┌──────────┐     ┌──────────────┐    │
-│  │  slapd   │────►│  SSSD    │────►│  NSS / PAM   │    │
-│  │ (OpenLDAP│     │  (cache) │     │  (getent,    │    │
-│  │  server) │     │          │     │   login, su) │    │
-│  └──────────┘     └──────────┘     └──────────────┘    │
-│       │                                                  │
-│  DB: /home/ldap-db/ (shared OpenZFS)                    │
-└───────┼──────────────────────────────────────────────────┘
-        │ ldap://login-ip:389
-        ▼
-┌─────────────────────────────────────────────────────────┐
-│  Compute Node                                            │
-│                                                          │
-│  ┌──────────┐     ┌──────────────┐                      │
-│  │  SSSD    │────►│  NSS / PAM   │                      │
-│  │  (client)│     │  (getent,    │                      │
-│  │          │     │   srun user) │                      │
-│  └──────────┘     └──────────────┘                      │
-└─────────────────────────────────────────────────────────┘
-```
+Multi-user is a **deploy-time parameter**, not something you can flip
+on after the stack exists. Set it via either the AWS console or the
+CLI — pick one.
 
-**Key points:**
-- Users are stored in the LDAP database on the login node
-- The database lives on shared `/home` (OpenZFS NFS) — it survives login node restart/replacement
-- Every node (login + compute) runs SSSD which queries LDAP for user info
-- When you add a user in LDAP, they become visible on all nodes within seconds
-- Home directories are auto-created at first login (shared `/home` on OpenZFS)
-- Slurm sees LDAP users transparently — no Slurm configuration needed for user resolution
+### deploy-all — from the CloudFormation console (Quick Create)
 
-> ⚠️ **Single login node only.** `OpenLDAP-LoginNode` runs the directory server
-> on **one** login node, so keep the login node group at `MinCount=MaxCount=1`
-> while the directory is enabled. Compute clients discover the server by its
-> `directory-role=server` tag and the slapd database is a single MDB on shared
-> `/home`; running two login nodes would give clients an ambiguous server and
-> have two `slapd` processes open the same database files concurrently
-> (corruption risk). If you need multiple login nodes or a highly-available
-> directory, use a managed backend (the planned `SimpleAD` / `ManagedAD`
-> `DirectoryService` options) rather than the login-node OpenLDAP.
+1. Open the deploy-all template's **Launch Stack** link in the
+   [README](../README.md#quick-start) (or navigate to CloudFormation
+   → *Create stack* → *Upload* `pcs-ml-cluster-deploy-all.yaml`).
+2. On the *Specify stack details* page, set:
+   - **`DirectoryService`** → `OpenLDAP-LoginNode` (default is `none`
+     → single-user; **must be changed here** to get multi-user)
+   - **`SSHAccessCidr`** → your office CIDR (e.g. `203.0.113.10/32`),
+     because LDAP users log in over SSH — see
+     [§2.3 Log in as that user](#23-log-in-as-that-user). Leave empty
+     to disable direct SSH; users then log in only via SSH-over-SSM.
+3. The other parameters (VPC/CIDR, instance types, monitoring, etc.)
+   have sensible defaults — see [PARAMETERS.md](./PARAMETERS.md).
+4. Acknowledge the two IAM capabilities and *Create stack*.
 
-### How a compute node finds the LDAP server (tag-based discovery)
-
-This part is **not obvious**, so it's worth spelling out. A compute node does
-**not** receive the login node's IP as a parameter — PCS launches the login and
-compute node groups independently, and the login node's private IP isn't known
-at template-synthesis time (and it changes if the login node is replaced).
-Instead, discovery happens **at compute-node boot**, by EC2 tag lookup:
-
-1. When the directory is enabled, the login node group tags its instance
-   `directory-role=server` (alongside `pcs-cluster-id=<this cluster>`). The
-   compute node groups tag themselves `directory-role=client`. This
-   `directory-role` tag is **dedicated to the directory feature** — it is
-   deliberately *separate* from the monitoring stack's `monitoring-role` tag, so
-   the two features don't depend on each other.
-2. On first boot, each compute node runs `setup-directory.sh client`, which
-   calls `aws ec2 describe-instances` filtering for
-   `tag:pcs-cluster-id=<my cluster>` + `tag:directory-role=server` +
-   `instance-state-name=running`, and reads the matching instance's
-   `PrivateIpAddress`. The `pcs-cluster-id` filter scopes the lookup to **this
-   cluster only**, so multiple PCS clusters can share one VPC without their
-   compute nodes finding the wrong cluster's LDAP server. (`CLUSTER_ID` is
-   passed from `${ClusterId}` in UserData; the script aborts client setup if it
-   is empty, rather than risk matching another cluster's server.)
-3. That IP becomes the SSSD `ldap_uri` (`ldap://<login-ip>`). SSSD on the
-   compute node then resolves users from the login node's slapd.
-
-Implications to be aware of:
-
-- **Compute nodes need `ec2:DescribeInstances`** in their instance role (the
-  cluster IAM role already grants it). Without it, discovery fails and the node
-  boots without LDAP (check `/var/log/directory-setup.log` for
-  `could not discover directory server IP`).
-- **The login (server) node must be running before a compute node boots** for
-  discovery to succeed. In normal deploy order the login node group comes up
-  first; a compute node that scales up later simply queries the
-  already-running server.
-- **If the login node is replaced**, its new instance re-tags itself
-  `directory-role=server` and re-attaches to the same `/home/ldap-db`, so newly
-  booting compute nodes discover the new IP automatically. The admin password is
-  **preserved** across replacement (the new login node reuses the existing
-  `/pcs/<id>/ldap/admin-password` from SSM rather than regenerating it), so cached
-  admin passwords keep working and the DB stays accessible.
-  **Already-running compute nodes, however, keep their cached `ldap_uri`** (the
-  old login node's private IP, which the replacement no longer has). Cached users
-  still resolve via SSSD, but **name resolution for uncached/new users and group
-  expansion degrades** on those nodes until you refresh them. (Jobs already
-  submitted by such users still *run* — Slurm uses numeric UIDs, so a name-
-  resolution gap is a degradation, not a hard job failure — but `id`/`getent`,
-  `pam_mkhomedir`, and anything that looks the user up by name can misbehave.)
-  After a login-node replacement, run on every running compute node:
-  ```bash
-  srun -N <nodes> -n <nodes> bash -c 'sudo sed -i "s#ldap_uri = .*#ldap_uri = ldap://<new-login-ip>#" /etc/sssd/sssd.conf && sudo sss_cache -E && sudo systemctl restart sssd'
-  ```
-  or simply let PCS replace the compute nodes (terminate them; the replacements
-  discover the new IP on boot). A stable endpoint that removes this manual step is
-  tracked in [ROADMAP.md](./ROADMAP.md) ("Stable LDAP endpoint across login-node
-  replacement").
-- **An explicit override exists**: set `LDAP_SERVER_URI` (or `DIRECTORY_DNS_IPS`,
-  for the future managed-directory path) in the client's environment to skip the
-  tag lookup entirely — used by the SimpleAD/ManagedAD extension and handy for
-  debugging.
-
----
-
-## Enabling multi-user
-
-### Option 1: deploy-all (recommended)
+### deploy-all — from the CLI
 
 ```bash
 aws cloudformation create-stack \
-  --stack-name my-cluster \
+  --stack-name pcs-ml-cluster \
   --template-url https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ml-cluster-deploy-all.yaml \
   --parameters \
     ParameterKey=PrimarySubnetAZ,ParameterValue=us-east-2b \
     ParameterKey=DirectoryService,ParameterValue=OpenLDAP-LoginNode \
+    ParameterKey=SSHAccessCidr,ParameterValue=<your-office-cidr>/32 \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM
 ```
 
-That's it. The login node will have slapd running and compute nodes will be
-configured as LDAP clients automatically at first boot.
+Both paths produce the same stack — the console *Quick Create* form
+just fills in the same `--parameters` for you. Use whichever fits
+your workflow.
 
-### Option 2: modular deployment
+### modular deployment
 
-Pass these to your `add-cng.yaml` stacks:
-- Login CNG: `DirectoryRole=server`, `DirectoryDomainSuffix=dc=cluster,dc=internal`
-- Compute CNG: `DirectoryRole=client`, `DirectoryDomainSuffix=dc=cluster,dc=internal`
+Pass to your `add-cng.yaml` stacks:
+- Login CNG: `DirectoryRole=server`, `IamProfileArn=<LoginInstanceProfileArn>`
+- Compute CNG: `DirectoryRole=client`, `IamProfileArn=<InstanceProfileArn>`
 
-> **IAM profile — give the login CNG the login profile.** `cluster.yaml` outputs two
-> instance profiles: `InstanceProfileArn` (compute) and `LoginInstanceProfileArn` (login,
-> which additionally grants read+decrypt of the OpenLDAP admin secret). When deploying
-> modularly with multi-user enabled, pass `IamProfileArn=<LoginInstanceProfileArn>` to the
-> **login** CNG and `IamProfileArn=<InstanceProfileArn>` to the **compute** CNGs. Giving
-> the login node the plain compute profile makes its OpenLDAP setup fail (it can't write
-> the admin password to SSM). `deploy-all` wires this automatically.
+Both share `DirectoryDomainSuffix=dc=cluster,dc=internal` (default).
 
-### Parameters
+> **IAM profile matters.** `cluster.yaml` outputs `LoginInstanceProfileArn`
+> (login-only, grants SSM write of the OpenLDAP admin secret) and
+> `InstanceProfileArn` (compute). Give the login CNG the login profile;
+> otherwise OpenLDAP setup fails silently. deploy-all wires this
+> automatically.
 
-| Parameter | Default | Description |
+| Parameter | Default | Purpose |
 |---|---|---|
-| `DirectoryService` | `none` | (deploy-all only) Set to `OpenLDAP-LoginNode` to enable multi-user; deploy-all derives each CNG's `DirectoryRole` from it |
-| `DirectoryRole` | `none` | (add-cng) `server` for the login CNG, `client` for compute CNGs |
-| `DirectoryDomainSuffix` | `dc=cluster,dc=internal` | LDAP base DN (change only if you need a different domain) |
+| `DirectoryService` (deploy-all) | `none` | `OpenLDAP-LoginNode` enables the flow |
+| `DirectoryRole` (add-cng) | `none` | `server` on the login CNG, `client` on compute CNGs |
+| `DirectoryDomainSuffix` | `dc=cluster,dc=internal` | LDAP base DN |
 
 ---
 
-## Day-to-day operations
+## 2. Adding your first LDAP user
 
-All commands below run on the **login node** as root (`sudo`).
+Walkthrough for the first LDAP user on a fresh cluster — recover the
+admin password, add the user with an SSH key, log them in, and prove
+their Slurm jobs actually run on a compute node. Once you've done this
+once, subsequent users go through the shorter recipes in
+[§3 Detailed operations](#3-detailed-operations).
 
-### Getting the admin password
+§2.1–§2.2 run on the login node (SSM session or SSH as `ubuntu`);
+§2.3–§2.4 are the LDAP user's own login and job submission from their
+workstation.
 
-The LDAP admin password is auto-generated at cluster creation and stored in
-AWS Systems Manager Parameter Store:
+### 2.1 Recover the LDAP admin password
+
+The source of truth is SSM Parameter Store, populated by the login node
+at first boot. Print it once at the start of your session — every raw
+`ldap*` command below uses `-W` and every `ldap-add-user.sh` call reads
+an env var or prompts, so the value never has to land on the command
+line or in shell history.
+
+The login node reads its own cluster ID and region from IMDS, and its
+instance role is already granted `ssm:GetParameter` on
+`/pcs/<id>/ldap/*`:
 
 ```bash
-CLUSTER_ID=<from stack output, e.g. pcs_abc123>
+TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+CLUSTER_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/aws:pcs:cluster-id)
+AWS_REGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
 
-aws ssm get-parameter \
-  --name "/pcs/${CLUSTER_ID}/ldap/admin-password" \
-  --with-decryption \
-  --query 'Parameter.Value' \
-  --output text
+aws ssm get-parameter --region "$AWS_REGION" --with-decryption --name "/pcs/$CLUSTER_ID/ldap/admin-password" --query 'Parameter.Value' --output text
 ```
 
-> **If SSM is empty** (instance role lacked the permission at first boot):
+> **If SSM has no password** (rare — instance role lacked permission at
+> first boot), fall back to the copy on shared storage:
 > ```bash
 > sudo cat /home/ldap-db/.admin-password
 > ```
 
-Store this password somewhere safe — you'll need it for all user management
-operations.
+### 2.2 Add your first user
 
----
+The `ldap-add-user.sh` helper takes `<username> <uid> <gid>
+[ssh-public-key]`. For the very first user, `10001` is safe — that's the
+bottom of the LDAP UID range. For subsequent users pick 10002, 10003,
+etc.; the helper refuses a duplicate `uidNumber` or username, so a
+collision fails loudly instead of silently sharing a POSIX principal on
+the shared `/home` + `/fsx`.
 
-### Adding a user
-
-**Using the helper script** (recommended):
+Get the user's SSH public key. If they don't have one yet, they can
+generate a keypair on their own workstation:
 
 ```bash
-# Usage: ldap-add-user.sh <username> <uid> <gid> [ssh-public-key]
-sudo LDAP_ADMIN_PASSWORD="<password>" ldap-add-user.sh alice 10001 3000
+# On the user's workstation
+ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -C "alice@laptop"
+# Then send you the *public* half (~/.ssh/id_ed25519.pub, one line).
 ```
 
-This creates the user with:
-- Username: `alice`
-- UID: `10001` (pick a unique number in range 10001–59999)
-- GID: `3000` (= `clusterusers` group, the default)
-- Home directory: `/home/alice` (auto-created on first login)
-- Shell: `/bin/bash`
-- A random initial password (printed to stdout)
-
-**With an SSH key** (user can log in immediately):
+Back on the login node, add the user. The helper prompts for the admin
+password if it isn't already in the environment:
 
 ```bash
-sudo LDAP_ADMIN_PASSWORD="<password>" ldap-add-user.sh alice 10001 3000 "ssh-ed25519 AAAA... alice@laptop"
+sudo /usr/local/bin/ldap-add-user.sh alice 10001 3000 "ssh-ed25519 AAAA... alice@laptop"
+# LDAP admin password: <paste the value from §2.1 — input is hidden>
 ```
 
-The quoted key is installed into `/home/alice/.ssh/authorized_keys` (home
-directory created on the spot; `/home` is shared, so it works cluster-wide).
-To add or rotate a key later, append to that file — LDAP doesn't store keys.
+The script prints the user's initial password. Hand it to the user if
+they need to set their own later ([§3.4](#34-reset-a-password));
+otherwise they can log in with the SSH key you added and change it
+themselves.
 
-**Verifying the user was created:**
-
+Verify:
 ```bash
-# On login node
 getent passwd alice
-# Expected: alice:*:10001:3000:alice:/home/alice:/bin/bash
-
-id alice
-# Expected: uid=10001(alice) gid=3000(clusterusers) groups=3000(clusterusers)
+# alice:*:10001:3000:alice:/home/alice:/bin/bash
 ```
 
----
+### 2.3 Log in as that user
 
-### Adding multiple users (batch)
+Pick one of these two paths depending on how the user reaches AWS. If
+`SSHAccessCidr` was set at deploy time, direct SSH is simpler; otherwise
+use SSH-over-SSM which needs no inbound port 22.
 
-Create a file `users.txt`:
+**Direct SSH** — from the user's workstation, using the private key that
+matches the public key above. Get the login node's **public IP** first
+(the stock `cluster-user-iam` policy grants the AWS CLI calls used
+here):
+
+```bash
+STACK_NAME=pcs-ml-cluster                 # your deploy-all CloudFormation stack name
+AWS_REGION=us-east-2                      # your region
+
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+LOGIN_CNG_ID=$(aws pcs list-compute-node-groups --cluster-identifier "$CLUSTER_ID" --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)
+aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$LOGIN_CNG_ID" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text
 ```
-alice 10001 3000 ssh-ed25519 AAAA...
-bob   10002 3000 ssh-ed25519 BBBB...
-carol 10003 3000
+
+Then, from the user's workstation:
+```bash
+# alice@laptop
+ssh -i ~/.ssh/id_ed25519 alice@<login-node-public-ip>
+```
+
+> **After a login-node replacement the public IP and SSH host key both
+> change.** The login node has no Elastic IP; a replacement gets a fresh
+> IP and a new host key, so users see
+> `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!` — clear the old
+> entry (`ssh-keygen -R <old-ip>`) and reconnect. SSH-over-SSM avoids
+> this because it targets the instance ID, not an IP.
+
+**SSH over SSM** — no inbound port 22 needed. Requires the AWS CLI +
+the Session Manager plugin on the user's workstation and IAM
+credentials scoped to `ssm:StartSession` (the stock `cluster-user-iam`
+policy grants exactly that on the login node).
+
+Quick one-liner to verify connectivity without editing any config
+files — the login instance ID is resolved from the PCS API, so no
+hard-coded `i-0abc…` and no dependency on tag naming:
+
+```bash
+STACK_NAME=pcs-ml-cluster                 # your deploy-all CloudFormation stack name
+AWS_REGION=us-east-2                      # your region
+
+CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text)
+LOGIN_CNG_ID=$(aws pcs list-compute-node-groups --cluster-identifier "$CLUSTER_ID" --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)
+LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$LOGIN_CNG_ID" "Name=instance-state-name,Values=running" --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+ssh -i ~/.ssh/id_ed25519 -o ProxyCommand="aws ssm start-session --target $LOGIN_INSTANCE_ID --document-name AWS-StartSSHSession --parameters portNumber=%p --region $AWS_REGION" alice@"$LOGIN_INSTANCE_ID"
+```
+
+For day-to-day use, put the instance ID in `~/.ssh/config` so `ssh
+pcs-login` just works. The ID changes if the login node is replaced;
+re-run the resolver above and update `HostName`.
+
+```
+# ~/.ssh/config on the user's workstation
+Host pcs-login
+  HostName <paste-LOGIN_INSTANCE_ID-here>
+  User alice
+  IdentityFile ~/.ssh/id_ed25519
+  ProxyCommand aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p --region us-east-2
 ```
 
 Then:
 ```bash
-while read name uid gid key; do
-  sudo LDAP_ADMIN_PASSWORD="<password>" ldap-add-user.sh "$name" "$uid" "$gid" "$key"
-done < users.txt
+ssh pcs-login
 ```
+
+Either way, on first login `pam_mkhomedir` creates `/home/alice` from
+`/etc/skel`. The home directory lives on shared OpenZFS and is visible
+from every compute node.
+
+### 2.4 Verify on a compute node — as the user
+
+Confirm the end-to-end path: **the user themselves** submits a job and
+it runs on a compute node under their own UID / home directory. This
+is what a real workflow looks like, so it exercises name resolution,
+`$HOME` mounting, and Slurm's numeric-UID launch in one shot.
+
+> **If the cluster was deployed with
+> `AccountingPolicyEnforcement=associations,limits,safe`**, this srun
+> will fail with *"Invalid account or account/partition combination
+> specified"* until you (1) register alice in Slurm accounting —
+> jump to [§4 Slurm accounting](#4-slurm-accounting) first — and
+> (2) add `--account=<account>` to the srun below. On the default
+> (`enforcement=none`) accounting registration is optional and this
+> step works as-is with no `--account` argument.
+
+Still logged in as alice from [§2.3](#23-log-in-as-that-user):
+```bash
+# alice@login
+srun -N 1 -n 1 -p cpu1 --time=2:00 bash -c 'id; hostname; touch $HOME/.pcs-verify-ok && ls -l $HOME/.pcs-verify-ok'
+# uid=10001(alice) gid=3000(clusterusers) groups=3000(clusterusers)
+# cpu1-1
+# -rw-rw-r-- 1 alice clusterusers 0 ... /home/alice/.pcs-verify-ok
+```
+
+> **`--time=<mm>`** is required on clusters with a `GrpTRESRunMins`
+> quota. Without it Slurm estimates the job's TRES-minutes as
+> UNLIMITED × 1 CPU and holds it pending with
+> `AssocGrpCPURunMinutesLimit`. PCS partitions ship with no
+> `DefaultTime`; keep `--time=<mm>` on every submission.
+
+If the user does not resolve immediately, see
+[§5 Troubleshooting](#51-user-not-found-on-compute).
 
 ---
 
-### Listing all users
+## 3. Detailed operations
+
+Every raw `ldap*` command uses `-W` to be prompted for the admin
+password interactively — nothing sensitive lands on the command line
+or in shell history. `ldap-add-user.sh` does the same (env var or
+prompt).
+
+### 3.1 Add a user
+
+Same `ldap-add-user.sh` invocation as in [§2.2](#22-add-your-first-user);
+pick the next unused `uidNumber` (see [§3.2 List users](#32-list-users)
+for what's in use, or [§8 UID / GID conventions](#8-uid--gid-conventions)
+for the allocation policy). The script refuses a `uidNumber` or username
+that already exists — two users sharing a UID would collapse into the
+same POSIX principal on the shared `/home` and `/fsx`.
 
 ```bash
-# Simple list
+sudo /usr/local/bin/ldap-add-user.sh <username> <uid> 3000 "<ssh-pub-key>"
+# LDAP admin password: <paste from SSM — input is hidden>
+```
+
+### 3.2 List users
+
+```bash
 ldapsearch -x -H ldap://localhost -b "ou=People,dc=cluster,dc=internal" \
-  "(objectClass=posixAccount)" uid uidNumber | grep -E "^uid:|^uidNumber:"
-
-# Or just use getent (shows all LDAP users + system users)
-getent passwd | awk -F: '$3 >= 10000 {print $1, $3, $6}'
+  "(objectClass=posixAccount)" uid uidNumber | grep -E '^(uid|uidNumber):'
 ```
 
----
-
-### Deleting a user
+### 3.3 Delete a user
 
 ```bash
-ADMIN_PW="<password>"
-ldapdelete -x -H ldap://localhost \
-  -D "cn=admin,dc=cluster,dc=internal" \
-  -w "$ADMIN_PW" \
+ldapdelete -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -W \
   "uid=alice,ou=People,dc=cluster,dc=internal"
-```
 
-**Invalidate the SSSD cache** so the deletion takes effect immediately instead
-of lingering until the cache entry's TTL expires. SSSD caches lookups (so users
-still resolve during a brief LDAP outage), which means a freshly-deleted user
-keeps resolving via `getent` until the cache is cleared. Run on the login node
-**and** any running compute node:
-```bash
-sudo sss_cache -E      # invalidate all cached entries (needs the sssd-tools package, pre-installed)
-# across compute nodes:
-srun -N <nodes> -n <nodes> bash -c 'sudo sss_cache -E'
-```
+# Invalidate the SSSD cache so the deletion is visible immediately.
+sudo sss_cache -E
+srun -N <compute-nodes> -n <compute-nodes> bash -c 'sudo sss_cache -E'
 
-Also remove from Slurm accounting:
-```bash
+# Also remove from Slurm accounting if you registered them there.
 sudo /opt/aws/pcs/scheduler/slurm-25.11/bin/sacctmgr -i remove user alice
-```
 
-The user's home directory (`/home/alice`) is NOT deleted automatically.
-Remove it manually if needed:
-```bash
+# The user's home directory is NOT deleted automatically.
+# Remove it if you want to reclaim the space:
 sudo rm -rf /home/alice
 ```
 
----
+### 3.4 Reset a password
 
-### Resetting a user's password
+`-W` prompts for the admin password; `-S` prompts for the new user
+password. Neither appears on the command line or in shell history.
 
 ```bash
-ADMIN_PW="<password>"
-NEW_PW="temporary-password-123"
-
-ldappasswd -x -H ldap://localhost \
-  -D "cn=admin,dc=cluster,dc=internal" \
-  -w "$ADMIN_PW" \
-  -s "$NEW_PW" \
+ldappasswd -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -W -S \
   "uid=alice,ou=People,dc=cluster,dc=internal"
-
-echo "New password for alice: $NEW_PW"
+# Enter LDAP Password:              (admin password, hidden)
+# New password:                     (new password for alice, hidden)
+# Re-enter new password:
 ```
 
-Tell the user to change it after login:
+The user can change their own password after logging in:
 ```bash
-# User runs this after logging in
-ldappasswd -x -H ldap://localhost \
-  -D "uid=alice,ou=People,dc=cluster,dc=internal" \
-  -W -s "my-new-password" \
+# Run by the user themselves
+ldappasswd -x -H ldap://localhost -D "uid=alice,ou=People,dc=cluster,dc=internal" -W -S \
   "uid=alice,ou=People,dc=cluster,dc=internal"
 ```
 
----
-
-### Creating groups
+### 3.5 Create a group
 
 ```bash
-ADMIN_PW="<password>"
-
-ldapadd -x -H ldap://localhost \
-  -D "cn=admin,dc=cluster,dc=internal" \
-  -w "$ADMIN_PW" << EOF
+ldapadd -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -W <<EOF
 dn: cn=ml-team,ou=Groups,dc=cluster,dc=internal
 objectClass: posixGroup
 cn: ml-team
@@ -367,12 +340,10 @@ memberUid: bob
 EOF
 ```
 
-### Adding a user to a group
+### 3.6 Add a user to an existing group
 
 ```bash
-ldapmodify -x -H ldap://localhost \
-  -D "cn=admin,dc=cluster,dc=internal" \
-  -w "$ADMIN_PW" << EOF
+ldapmodify -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -W <<EOF
 dn: cn=ml-team,ou=Groups,dc=cluster,dc=internal
 changetype: modify
 add: memberUid
@@ -382,184 +353,282 @@ EOF
 
 ---
 
-## Slurm accounting
+## 4. Slurm accounting
 
 PCS manages the Slurm accounting database internally (enable it with
-`ManagedAccounting=enabled` at deploy time). You just need to register users and
-accounts.
+`ManagedAccounting=enabled` at deploy time). This section walks
+through the flow demonstrated in the AWS blog
+[Introducing managed accounting for AWS Parallel Computing Service](https://aws.amazon.com/blogs/hpc/introducing-managed-accounting-for-aws-parallel-computing-service/):
+register users under project accounts, cap their usage, and read
+back utilization. Extra managed-accounting charges (an hourly fee
+tied to the controller size + per-GB-month storage governed by the
+cluster's Default Purge Time) apply on top of the base cluster —
+see the blog for pricing detail.
 
-> **Run `sacctmgr` add/modify/remove as `root`.** In PCS managed accounting the
-> Administrator is `root` — the default `ubuntu` user is not an accounting admin,
-> so `sacctmgr -i add ...` as `ubuntu` fails with *"Only
-> admins/operators/coordinators can add accounts"*. Use `sudo` with the full
-> path (the Slurm bin dir isn't on root's `PATH` by default):
+Registering users in accounting is optional unless the cluster was
+deployed with `AccountingPolicyEnforcement=associations,limits,safe`
+(or the stricter `associations,limits`) — with either enforcement on,
+jobs from unregistered users are rejected.
+
+> **`sacctmgr` add / modify / remove must run as root.** In PCS
+> managed accounting the Administrator is `root`; the default
+> `ubuntu` user is not an accounting admin, so `sacctmgr -i add …` as
+> `ubuntu` fails with *"Only admins/operators/coordinators can add
+> accounts"*. Read-only forms (`sacctmgr show …`, `sacct`, `sreport`)
+> work as any user.
+
+Ubuntu's `sudo` resets `PATH` (`secure_path`), so `sudo sacctmgr` from
+a shell where you only `export PATH=…` still fails to find the binary.
+Bind the absolute path to a variable and use it throughout:
 
 ```bash
-SACCTMGR=/opt/aws/pcs/scheduler/slurm-25.11/bin/sacctmgr
-
-# Create a Slurm account (typically one per team or project)
-sudo $SACCTMGR -i add account ml-team Description="ML Team"
-
-# Add LDAP users to the account
-sudo $SACCTMGR -i add user alice Account=ml-team
-sudo $SACCTMGR -i add user bob Account=ml-team
-
-# Verify (read-only — works as any user with the Slurm bin on PATH)
-sudo $SACCTMGR show user alice bob format=User,Account,DefaultAccount
+S=/opt/aws/pcs/scheduler/slurm-25.11/bin/sacctmgr   # 25.05 if SlurmVersion=25.05
+export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH  # for the read-only sacct / sreport below
 ```
 
-Read-only `sacct` / `sreport` / `sacctmgr show ...` work as `ubuntu`; only the
-mutating `sacctmgr` verbs need `root`.
+### 4.1 Register users to accounts
 
-> **Two reporting gotchas (verified in testing — they are tool behaviour, not bugs):**
+Reproducing the blog's two-project layout — physics and chemistry
+groups sharing one cluster:
+
+```bash
+sudo $S -i add account proj_physics   Description="Physics group"
+sudo $S -i add account proj_chemistry Description="Chemistry group"
+
+sudo $S -i add user alice Account=proj_physics
+sudo $S -i add user bob   Account=proj_physics
+sudo $S -i add user carol Account=proj_chemistry
+
+sacctmgr show user alice bob carol WithAssoc \
+  format=User,Account,DefaultAccount
+```
+
+`WithAssoc` joins the user's association row so per-account
+attributes actually appear in the output. Attribute a job to a
+project at submit time with `--account=<name>` (see §4.2).
+
+### 4.2 Limits and enforcement
+
+Cap alice at 100 CPU-hours of concurrently-running work
+(6000 CPU-minutes):
+
+```bash
+sudo $S -i modify user alice set GrpTRESRunMins=cpu=6000
+
+sacctmgr show user alice WithAssoc format=User,Account,GrpTRESRunMins%30
+```
+
+With `AccountingPolicyEnforcement=associations,limits,safe` a job
+that would put alice over her running-minutes budget is **accepted
+at submit time but held pending** with reason
+`AssocGrpCPURunMinutesLimit`; it starts only once earlier work drains
+the budget. A job that fits proceeds normally:
+
+```bash
+# As alice
+sbatch --account=proj_physics --nodes=1 --ntasks-per-node=8 --time=30:00 myjob.sh
+squeue -u alice -o "%.6i %.10P %.8u %.2t %r"
+#   6      cpu1     alice PD AssocGrpCPURunMinutesLimit
+sbatch --account=proj_physics --nodes=1 --ntasks=1 --time=2:00 smalljob.sh
+#   -> Submitted batch job <n> (runs when a node is available)
+```
+
+> **`safe` accepts, doesn't `sbatch: error` — even over-quota.** The
+> blog's *"Job violates accounting/QOS policy"* message would come from
+> the stricter `AccountingPolicyEnforcement=associations,limits` (no
+> `safe`). With `safe` the scheduler still accepts the submission so
+> the user can leave work queued; only *starting* it is deferred until
+> the running-minutes budget frees up. Watch `squeue`'s Reason column,
+> not `sbatch`'s exit status, to see the limit taking effect.
+
+### 4.3 Reporting
+
+Same recipes as in the blog:
+
+```bash
+# Weekly all-user job listing
+sacct --starttime=$(date -d "7 days ago" +%Y-%m-%d) \
+  --format="JobID,User,JobName,Partition,Account,AllocCPUS,State,ExitCode"
+
+# Monthly cluster utilization by account/user
+sreport cluster AccountUtilizationByUser \
+  start=2026-04-01 end=2026-04-30 -t percent \
+  format="Accounts,Login,Proper,Used"
+
+# Monthly top users
+sreport user topusage start=2026-03-01 end=2026-03-31
+
+# Per-user weekly failure diagnostic
+sacct -u alice --starttime=$(date -d "7 days ago" +%Y-%m-%d) \
+  --format="JobID,JobName,State,ExitCode,Start,End,MaxRSS,MaxVMSize,Comment"
+```
+
+> **Two reporting notes (tool behaviour, not bugs):**
 >
-> 1. **`sacct --state=...` needs an explicit end time.** A state filter without
->    `-E now` (or `--endtime`) silently returns **nothing** — e.g.
->    `sacct -X --state=FAILED -S 2026-01-01` shows no rows even when failed jobs
->    exist. Always pair it: `sacct -X -a --state=FAILED -S <start> -E now`.
->    (`sacct -j <id>` always shows the true state, useful to cross-check.)
-> 2. **`sreport` usage lags behind `sacct` by up to an hour.** `sreport`
->    (`AccountUtilizationByUser`, `topusage`, cluster `Utilization`) reads
->    slurmdbd's **periodic usage rollup**, which runs hourly — so right after jobs
->    finish, `sreport ... Used` reads **zero** (even at `-t Seconds`) until the next
->    rollup boundary. `sacct` reads the live job table and is immediate. For
->    up-to-the-second per-job/-user accounting use `sacct`; use `sreport` for
->    settled historical utilization.
-
-> **Note:** if `AccountingPolicyEnforcement=none` (the default), users can
-> submit jobs even without being registered in `sacctmgr`. Registration is
-> needed for fairshare/priority and for `sacct` history to show the user name.
+> 1. **`sacct --state=…` needs an explicit `-E now`.** A state filter
+>    without `-E now` (or `--endtime`) silently returns nothing —
+>    `sacct -X --state=FAILED -S 2026-01-01` shows no rows even when
+>    failed jobs exist. Always pair it: `sacct -X -a --state=FAILED
+>    -S <start> -E now`.
+> 2. **`sreport` lags `sacct` by up to an hour.** `sreport` reads
+>    slurmdbd's periodic (hourly) usage rollup, so right after jobs
+>    finish, `sreport … Used` reads zero until the next rollup boundary.
+>    Use `sacct` for up-to-the-second data; use `sreport` for settled
+>    historical utilization.
 
 ---
 
-## Verifying users on compute nodes
+## 5. Troubleshooting
 
-After adding a user, verify they're visible on compute nodes:
+### 5.1 "User not found" on compute
 
-```bash
-export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH
-
-# Single node
-srun -N 1 -n 1 -p cpu1 bash -c 'getent passwd alice; id alice'
-
-# All nodes
-srun -N 4 -n 4 -p cpu1 bash -c 'echo "$(hostname): $(id alice)"'
-```
-
-If a user isn't visible yet (SSSD cache delay, typically <5 sec):
-```bash
-srun -N 1 -n 1 -p cpu1 bash -c 'sudo sss_cache -E; sleep 2; getent passwd alice'
-```
-
----
-
-## Running jobs as a specific user
-
-Users log in to the login node and submit jobs normally:
-
-```bash
-# User 'alice' logs in via SSH and runs:
-srun -p cpu1 -N 1 -n 1 bash -c 'whoami; hostname'
-sbatch --partition=cpu1 my-training.sbatch
-```
-
-The job runs as `alice` (uid=10001) on the compute node. The user's home
-directory `/home/alice` is visible on the compute node (shared OpenZFS).
-
----
-
-## Troubleshooting
-
-### "User not found" on compute node
-
-> **Expected right after a node boots.** SSSD is configured with `enumerate = true`,
-> so on first start it runs a full enumeration of all users/groups in the
-> background. Until that completes (seconds to a minute, depending on directory
-> size), an individual `getent passwd <user>` / `id <user>` can briefly return
-> "not found" even though LDAP is healthy. It resolves on its own; only
-> investigate further if it persists. (Note also that a job submitted by such a
-> user still **runs** — Slurm uses numeric UIDs — so this is a name-resolution
-> delay, not a job failure.)
+> Expected right after a fresh compute node boot. SSSD runs a full
+> enumeration in the background on first start; individual lookups can
+> briefly return "not found" until it completes (seconds to a minute).
+> Jobs still **run** because Slurm launches by numeric UID — this is a
+> name-resolution delay, not a job failure.
 
 If it persists:
 
 ```bash
-# Check SSSD is running on compute
 srun -N 1 -n 1 bash -c 'systemctl status sssd | head -3'
-
-# Check LDAP connectivity from compute
 srun -N 1 -n 1 bash -c 'ldapsearch -x -H ldap://<login-ip> -b dc=cluster,dc=internal uid=alice'
-
-# Force cache refresh
 srun -N 1 -n 1 bash -c 'sudo sss_cache -E; sudo systemctl restart sssd'
 ```
 
-### slapd not running on login node
+### 5.2 `slapd` not running on the login node
 
 ```bash
 sudo systemctl status slapd
 sudo journalctl -u slapd -n 20
-# Check install log
 cat /var/log/directory-setup.log
 ```
 
-### "Invalid credentials" when running ldap commands
+### 5.3 "Invalid credentials" from `ldap*` commands
 
-You're using the wrong admin password. Retrieve it from SSM or the fallback
-file (see [Getting the admin password](#getting-the-admin-password)).
+You typed the wrong admin password at the `-W` prompt. Re-run the
+command; it will prompt again. Re-fetch the password with the recipe in
+[§2.1](#21-recover-the-ldap-admin-password) — SSM is the source of truth
+and `/home/ldap-db/.admin-password` is the fallback.
 
-### Home directory not created
+### 5.4 Home directory not created
 
+`/home/<user>` is auto-created by `pam_mkhomedir` on first **interactive
+login** (SSH or `su -`). Slurm jobs do not create it, so a user who has
+never logged in and immediately runs `sbatch` will hit `chdir: No such
+file or directory`.
+
+Fix by logging in once as the user, or create it manually:
 ```bash
-# Check pam_mkhomedir is configured
-grep pam_mkhomedir /etc/pam.d/common-session
-# Expected: session optional pam_mkhomedir.so skel=/etc/skel umask=0022
-
-# Manually create (should auto-create on next login)
 sudo mkdir -p /home/alice
 sudo chown alice:clusterusers /home/alice
+sudo chmod 700 /home/alice
 ```
 
-### New compute node doesn't resolve users
+### 5.5 New compute node doesn't resolve users
 
-New compute nodes boot with the latest LaunchTemplate version, which includes
-SSSD client setup. If a node was launched before `DirectoryService` was enabled
-(e.g. during a stack update), it won't have SSSD. Terminate the node and let
-PCS replace it with a new one.
-
----
-
-## UID/GID conventions
-
-| Range | Purpose |
-|---|---|
-| 0–999 | System users (do not use) |
-| 1000 | `ubuntu` (DLAMI default user) |
-| 3000 | `clusterusers` group (default GID for new users) |
-| 3001+ | Additional groups (create as needed) |
-| 10001–59999 | LDAP user UIDs |
-
-**Always specify UIDs explicitly** when creating users. This ensures
-consistency across all nodes and NFS mounts. Do not rely on auto-increment.
+If the node was launched **before** `DirectoryService` was enabled
+(e.g. before a stack update), its LaunchTemplate has no SSSD client
+setup. Terminate the node; PCS replaces it with a new one that has SSSD.
 
 ---
 
-## Data persistence and backup
+## 6. How it works
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Login Node                                              │
+│  ┌──────────┐     ┌──────────┐     ┌──────────────┐    │
+│  │  slapd   │────►│  SSSD    │────►│  NSS / PAM   │    │
+│  │ (OpenLDAP│     │  (cache) │     │  (getent,    │    │
+│  │  server) │     │          │     │   login, su) │    │
+│  └──────────┘     └──────────┘     └──────────────┘    │
+│  DB: /home/ldap-db/ (shared OpenZFS)                    │
+└───────┼──────────────────────────────────────────────────┘
+        │ ldap://login-ip:389
+        ▼
+┌─────────────────────────────────────────────────────────┐
+│  Compute Node                                            │
+│  ┌──────────┐     ┌──────────────┐                      │
+│  │  SSSD    │────►│  NSS / PAM   │                      │
+│  │ (client) │     │              │                      │
+│  └──────────┘     └──────────────┘                      │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Users live in LDAP on the login node.
+- The DB is on shared `/home` (OpenZFS NFS) — survives login-node
+  restart or replacement.
+- Every node runs SSSD, which caches LDAP replies. `sss_cache -E`
+  refreshes.
+- Home directories are on shared `/home` (auto-created on first
+  interactive login).
+- Slurm sees LDAP users transparently — no Slurm-side config needed for
+  user resolution.
+
+> ⚠️ **Single login node only.** `OpenLDAP-LoginNode` runs slapd on
+> **one** node; keep the login CNG at `MinCount=MaxCount=1` while the
+> directory is enabled. Two login nodes would give clients an ambiguous
+> server and open the same MDB from two processes (corruption risk).
+> Use the planned `SimpleAD` / `ManagedAD` `DirectoryService` options
+> for HA — see [§10 Upgrading](#10-upgrading-to-aws-simple-ad-future).
+
+### How a compute node finds the LDAP server (tag-based discovery)
+
+Not obvious — spelled out here because it drives several operational
+edge cases.
+
+1. Login CNG tags itself `directory-role=server` + `pcs-cluster-id=<id>`;
+   compute CNGs tag themselves `directory-role=client`. This
+   `directory-role` tag is dedicated to the directory feature —
+   deliberately separate from the monitoring stack's `monitoring-role`.
+2. On first boot each compute node runs `setup-directory.sh client`,
+   which calls `aws ec2 describe-instances` filtering for
+   `pcs-cluster-id=<my cluster>` + `directory-role=server` +
+   `instance-state=running`, and reads the matching instance's
+   private IP. `pcs-cluster-id` scopes lookup to **this** cluster only.
+3. The private IP becomes SSSD's `ldap_uri` (`ldap://<login-ip>`); SSSD
+   on the compute node resolves users from the login's slapd.
+
+Implications:
+
+- **Compute nodes need `ec2:DescribeInstances`** in their instance role
+  (the cluster IAM role grants it). Without it, discovery fails silently
+  — check `/var/log/directory-setup.log` for
+  `could not discover directory server IP`.
+- **Login must be running before a compute node boots.** Normal deploy
+  order gives you this; a compute node that scales up later simply
+  queries the already-running server.
+- **After a login-node replacement**, the new instance re-tags itself
+  `directory-role=server` and re-attaches to the same `/home/ldap-db`.
+  The admin password is preserved (SSM). **Already-running compute
+  nodes**, though, keep the old cached `ldap_uri`; cached users still
+  resolve, but new/uncached lookups degrade. Fix by rebooting SSSD:
+  ```bash
+  srun -N <n> -n <n> bash -c 'sudo sed -i "s#ldap_uri = .*#ldap_uri = ldap://<new-login-ip>#" /etc/sssd/sssd.conf && sudo sss_cache -E && sudo systemctl restart sssd'
+  ```
+  A stable endpoint that removes this step is in
+  [ROADMAP.md](./ROADMAP.md) ("Stable LDAP endpoint across login-node
+  replacement").
+
+---
+
+## 7. Data persistence and backup
 
 | Data | Location | Survives node replacement? | Survives stack delete? |
 |---|---|---|---|
-| LDAP database | `/home/ldap-db/` (shared OpenZFS) | ✅ | ❌ (FSx deleted) |
-| User home directories | `/home/<user>/` (shared OpenZFS) | ✅ | ❌ (FSx deleted) |
+| LDAP database | `/home/ldap-db/` (OpenZFS) | ✅ | ❌ (FSx deleted) |
+| Home directories | `/home/<user>/` (OpenZFS) | ✅ | ❌ (FSx deleted) |
 | Admin password | SSM Parameter Store | ✅ | ✅ |
 
-### Backup
+### Back up
 
 ```bash
-# Export LDAP database to a file (run periodically via cron)
-sudo slapcat -l /home/ldap-backup-$(date +%Y%m%d).ldif
+# Periodically (e.g. from cron)
+sudo slapcat -l "/home/ldap-backup-$(date +%Y%m%d).ldif"
 ```
 
-### Restore (on a fresh login node)
+### Restore on a fresh login node
 
 ```bash
 sudo systemctl stop slapd
@@ -570,60 +639,49 @@ sudo systemctl start slapd
 
 ---
 
-## Access methods
+## 8. UID / GID conventions
 
-| Method | Best for | Setup required |
-|---|---|---|
-| **Direct SSH** (port 22) | Multi-user teams, VS Code/JupyterLab | SG rule opening port 22 to a CIDR |
-| **SSH over SSM** | Security-sensitive environments | IAM credentials + SSM plugin per user |
-| **SSM Session Manager** | Admin-only access | IAM credentials only |
+| Range | Purpose |
+|---|---|
+| 0–999 | System users (do not use) |
+| 1000 | `ubuntu` (DLAMI default user) |
+| 3000 | `clusterusers` group (default GID for new users) |
+| 3001+ | Additional groups |
+| 10001–59999 | LDAP user UIDs |
 
-For multi-user clusters, **Direct SSH** is recommended. Users connect with
-their SSH key that was added during user creation:
-
-```bash
-ssh alice@<login-node-public-ip>
-```
-
-> **After a login-node replacement, the public IP and SSH host key change.**
-> The login node has no Elastic IP, so a replacement (or stop/start) gives it a
-> **new public IP** — re-fetch it from the EC2 console or
-> `aws ec2 describe-instances`. A *replacement* (not a stop/start) is a brand-new
-> instance, so its **SSH host key also changes**: users will see
-> `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!` and must clear the old key
-> (`ssh-keygen -R <old-ip-or-hostname>`) before reconnecting. Tell users to expect
-> this whenever the login node is replaced. (SSH-over-SSM avoids the IP problem
-> since it targets the instance ID, not an IP.)
+Always specify UIDs explicitly (as [§2.2](#22-add-your-first-user)
+shows). This keeps ownership consistent across all nodes and shared
+filesystems.
 
 ---
 
-## Template structure
+## 9. Template structure
 
 ```
 deploy-all.yaml
 ├─► cluster.yaml         (IAM role with ssm:PutParameter for /pcs/<id>/ldap/*)
 ├─► add-cng.yaml (login) → DirectoryRole=server → setup-directory.sh server
-│                           (installs slapd + configures SSSD locally)
+│                           (installs slapd, configures local SSSD)
 └─► add-cng.yaml (compute) → DirectoryRole=client → setup-directory.sh client
-                              (installs SSSD, discovers login node IP)
+                              (installs SSSD, discovers login IP via tags)
 ```
 
 ---
 
-## Upgrading to AWS Simple AD (future)
+## 10. Upgrading to AWS Simple AD (future)
 
 If you outgrow OpenLDAP (need HA, >50 users, Kerberos), the
-`DirectoryService` parameter is designed for extension:
+`DirectoryService` parameter is designed to extend:
 
 ```yaml
-DirectoryService: SimpleAD   # future AllowedValue
+DirectoryService: SimpleAD    # future AllowedValue
 ```
 
-Migration path:
+Migration path (planned):
 1. Export users: `slapcat > users.ldif`
-2. Deploy Simple AD (separate stack, requires 2 AZs)
+2. Deploy Simple AD (separate stack, 2 AZs)
 3. Import users
 4. Redeploy cluster with `DirectoryService=SimpleAD`
 5. Decommission slapd
 
-See [docs/ROADMAP.md](./ROADMAP.md) for tracking.
+Tracked in [ROADMAP.md](./ROADMAP.md).

--- a/architectures/aws-pcs/tests/multi-user-test.md
+++ b/architectures/aws-pcs/tests/multi-user-test.md
@@ -144,22 +144,7 @@ ldapsearch -x -H ldap://localhost -b "ou=People,dc=cluster,dc=internal" \
 # Expected: no matching entries.
 ```
 
-### B6. Delete a user
-
-```bash
-ldapdelete -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" \
-  -w "$LDAP_ADMIN_PASSWORD" "uid=testuser2,ou=People,dc=cluster,dc=internal"
-
-# Verify deleted
-getent passwd testuser2    # should return nothing
-```
-
-Verify on compute (after cache expires or forced refresh):
-```bash
-srun -N 1 -n 1 -p cpu1 bash -c 'sudo sss_cache -E; sleep 2; getent passwd testuser2 || echo "user not found (correct)"'
-```
-
-### B7. Reset a password (`-W -S` prompt path)
+### B6. Reset a password (`-W -S` prompt path)
 
 ```bash
 ldappasswd -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -W -S \
@@ -176,10 +161,10 @@ ldapwhoami -x -H ldap://localhost -D "uid=testuser1,ou=People,dc=cluster,dc=inte
 # Expected: dn:uid=testuser1,ou=People,dc=cluster,dc=internal
 ```
 
-### B8. Group create and member add (`-W` prompt path)
+### B7. Group create and member add (`-W` prompt path)
 
 ```bash
-# Create group
+# Create group with testuser1 as an initial member
 cat > /tmp/g.ldif <<EOF
 dn: cn=ml-team,ou=Groups,dc=cluster,dc=internal
 objectClass: posixGroup
@@ -193,7 +178,7 @@ sudo sss_cache -E && sleep 2
 getent group ml-team
 # Expected: ml-team:*:3001:testuser1
 
-# Add existing user to the group
+# Add testuser2 (still present at this point — B9 deletes it later) to the group
 cat > /tmp/m.ldif <<EOF
 dn: cn=ml-team,ou=Groups,dc=cluster,dc=internal
 changetype: modify
@@ -209,19 +194,35 @@ id testuser2
 rm -f /tmp/g.ldif /tmp/m.ldif
 ```
 
-### B9. SSH-over-SSM login as LDAP user (end-to-end user flow)
+### B8. SSH-over-SSM login as LDAP user (end-to-end user flow)
 
-From an operator laptop that has AWS CLI + IAM permissions but no direct
-SSH access to the VPC. Uses the PCS API to derive the login instance ID
-(no reliance on the mutable `Name` tag).
+End-to-end path from an operator laptop that has AWS CLI + IAM permissions
+but no direct SSH access to the VPC.
+
+**1. On the laptop — generate a keypair:**
 
 ```bash
-# Generate a keypair and install its public key on user creation:
 ssh-keygen -t ed25519 -N "" -f ~/.ssh/pcs-testuser1 -C "testuser1@laptop"
-sudo -E ldap-add-user.sh testuser1 10001 3000 "$(cat ~/.ssh/pcs-testuser1.pub)"
-# (Skip if B1 already created testuser1 without a key — add it with:
-#  ldapmodify or re-run the helper on a fresh directory.)
+cat ~/.ssh/pcs-testuser1.pub
+```
 
+**2. On the login node — install the public key for testuser1.** B1
+already created testuser1 without a key, so append the pubkey to the
+existing shared-home `authorized_keys` (this is where the helper would
+put it too — it does not store keys in LDAP):
+
+```bash
+PUBKEY='<paste the ssh-ed25519 line from step 1>'
+sudo install -d -m 700 -o testuser1 -g 3000 /home/testuser1/.ssh
+echo "$PUBKEY" | sudo tee -a /home/testuser1/.ssh/authorized_keys >/dev/null
+sudo chown testuser1:3000 /home/testuser1/.ssh/authorized_keys
+sudo chmod 600 /home/testuser1/.ssh/authorized_keys
+```
+
+**3. Back on the laptop — resolve the login instance ID and connect over
+SSM.** Uses the PCS API (no reliance on the mutable `Name` tag):
+
+```bash
 STACK_NAME=<cluster-stack>
 AWS_REGION=<region>
 LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
@@ -235,13 +236,28 @@ ssh -i ~/.ssh/pcs-testuser1 \
     "id; hostname"
 # Expected: uid=10001(testuser1) ..., login-node hostname.
 
-# Then from that session, submit a job and confirm the shared /home write:
+# Submit a job and confirm the shared /home write:
 ssh -tt -i ~/.ssh/pcs-testuser1 \
     -o ProxyCommand="aws ssm start-session --target $LOGIN_INSTANCE_ID --document-name AWS-StartSSHSession --parameters portNumber=%p --region $AWS_REGION" \
     testuser1@"$LOGIN_INSTANCE_ID" \
     "bash -lc 'srun -N 1 -n 1 -p cpu1 bash -c \"id; hostname; touch \\\$HOME/.pcs-verify-ok\"; ls -l \$HOME/.pcs-verify-ok'"
 # Expected: compute reports uid=10001, and .pcs-verify-ok is visible back on the
 # login home (shared OpenZFS).
+```
+
+### B9. Delete a user
+
+```bash
+ldapdelete -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" \
+  -w "$LDAP_ADMIN_PASSWORD" "uid=testuser2,ou=People,dc=cluster,dc=internal"
+
+# Verify deleted
+getent passwd testuser2    # should return nothing
+```
+
+Verify on compute (after cache expires or forced refresh):
+```bash
+srun -N 1 -n 1 -p cpu1 bash -c 'sudo sss_cache -E; sleep 2; getent passwd testuser2 || echo "user not found (correct)"'
 ```
 
 ---
@@ -606,7 +622,7 @@ on top of the existing LDAP users, exercising the customer-facing flow
 the blog demonstrates: two project accounts, a per-user cap, `--account=`
 job attribution, quota-based rejection, and the blog's own reporting
 commands. Regression guard for the walkthrough in
-[USER-MANAGEMENT.md §4.1](../docs/USER-MANAGEMENT.md#41-worked-example-project-accounts--per-user-quota--reports).
+[USER-MANAGEMENT.md §4.1](../docs/USER-MANAGEMENT.md#41-register-users-to-accounts).
 
 **Prerequisites**: same as the accounting test (`ManagedAccounting=enabled`
 + `DirectoryService=OpenLDAP-LoginNode`); alice / bob / carol as LDAP
@@ -615,17 +631,19 @@ users (add carol here if only alice/bob exist).
 ### F1. Project accounts and quota
 
 ```bash
-sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user.sh carol 10003 3000
+S=/opt/aws/pcs/scheduler/slurm-25.11/bin/sacctmgr   # slurm-25.05 for SlurmVersion=25.05
 
-sudo sacctmgr -i add account proj_physics   Description="Physics group"
-sudo sacctmgr -i add account proj_chemistry Description="Chemistry group"
-sudo sacctmgr -i add user alice Account=proj_physics
-sudo sacctmgr -i add user bob   Account=proj_physics
-sudo sacctmgr -i add user carol Account=proj_chemistry
+sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user.sh carol 10004 3000
 
-sudo sacctmgr -i modify user alice set GrpTRESRunMins=cpu=6000
+sudo $S -i add account proj_physics   Description="Physics group"
+sudo $S -i add account proj_chemistry Description="Chemistry group"
+sudo $S -i add user alice Account=proj_physics
+sudo $S -i add user bob   Account=proj_physics
+sudo $S -i add user carol Account=proj_chemistry
 
-sacctmgr show user alice bob carol format=User,Account,DefaultAccount,GrpTRESRunMins
+sudo $S -i modify user alice set GrpTRESRunMins=cpu=6000
+
+sacctmgr show user alice bob carol WithAssoc format=User,Account,DefaultAccount,GrpTRESRunMins
 ```
 
 Expected: three users listed under the two project accounts; alice's
@@ -633,38 +651,47 @@ Expected: three users listed under the two project accounts; alice's
 
 ### F2. Blog-style job submission with `--account=`
 
+Run as alice in her login shell (`sudo su - alice`; exit back to the
+`ubuntu` shell when done):
+
 ```bash
-sudo su - alice -c 'export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH; \
-  echo "hostname; id" > /home/alice/smalljob.sh && chmod +x /home/alice/smalljob.sh; \
-  sbatch --account=proj_physics --partition=cpu1 --cpus-per-task=2 --time=2:00 /home/alice/smalljob.sh'
+sudo su - alice
+printf '#!/bin/bash\nhostname\nid\n' > ~/smalljob.sh && chmod +x ~/smalljob.sh
+sbatch --account=proj_physics --partition=cpu1 --cpus-per-task=2 --time=2:00 ~/smalljob.sh
+exit
 ```
 
 Expected: `Submitted batch job <n>`; `sacct -j <n> -X --format=JobID,User,Account,State` reports `alice / proj_physics / COMPLETED`.
 
 ### F3. Quota hold with `safe` enforcement
 
-Only meaningful with `AccountingPolicyEnforcement=associations,limits,safe`.
-Note the `safe` variant *accepts* the submission and holds it pending
-instead of returning `sbatch: error …`; the strict variant
-(`associations,limits` without `safe`) rejects at submit time.
+Only meaningful with `AccountingPolicyEnforcement=associations,limits,safe`
+(the enforcement mode these templates offer). Note the `safe` variant
+*accepts* the submission and holds it pending instead of returning
+`sbatch: error …`.
 
-Tighten alice's limit first so a modest job triggers it:
+Tighten alice's limit first so a modest job triggers it (reusing `$S`
+from F1):
 
 ```bash
-sudo sacctmgr -i modify user alice set GrpTRESRunMins=cpu=60
+sudo $S -i modify user alice set GrpTRESRunMins=cpu=60
 ```
 
-Submit an over-quota job (8 CPUs × 30 min = 240 CPU-min > 60):
+Submit an over-quota job (4 CPUs × 30 min = 120 CPU-min > 60). Slurm
+counts CPUs from what `sinfo -N -o %c` reports for the queue's nodes
+(not the EC2 vCPU count), so cap `--ntasks-per-node` at that value —
+the default `cpu1` on `c6i.2xlarge` reports 4:
 
 ```bash
-sudo su - alice -c 'export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH; \
-  sbatch --account=proj_physics --partition=cpu1 --nodes=1 --ntasks-per-node=8 --time=30:00 --wrap="sleep 1000"'
+sudo su - alice
+sbatch --account=proj_physics --partition=cpu1 --nodes=1 --ntasks-per-node=4 --time=30:00 --wrap='sleep 1000'
+exit
 squeue -u alice -o "%.6i %.10P %.8u %.2t %r"
 ```
 
 Expected: `sbatch: Submitted batch job N`, then `squeue` shows the job
 in state `PD` with Reason `AssocGrpCPURunMinutesLimit`. Restore the
-original limit when done: `sudo sacctmgr -i modify user alice set GrpTRESRunMins=cpu=6000`.
+original limit when done: `sudo $S -i modify user alice set GrpTRESRunMins=cpu=6000`.
 
 ### F4. Blog reporting recipes
 
@@ -673,10 +700,10 @@ sacct --starttime=$(date -d "7 days ago" +%Y-%m-%d) \
   --format="JobID,User,JobName,Partition,Account,AllocCPUS,State,ExitCode"
 
 sreport cluster AccountUtilizationByUser \
-  start=$(date -d "30 days ago" +%Y-%m-%d) end=$(date +%Y-%m-%d) \
+  start=$(date -d "30 days ago" +%Y-%m-%d) end=now \
   -t percent format="Accounts,Login,Proper,Used"
 
-sreport user topusage start=$(date -d "30 days ago" +%Y-%m-%d) end=$(date +%Y-%m-%d)
+sreport user topusage start=$(date -d "30 days ago" +%Y-%m-%d) end=now
 
 sacct -u alice --starttime=$(date -d "7 days ago" +%Y-%m-%d) \
   --format="JobID,JobName,State,ExitCode,Start,End,MaxRSS,MaxVMSize,Comment"
@@ -689,9 +716,9 @@ slurmdbd rollup lag, not a failure (see USER-MANAGEMENT §4 note #2).
 ### F5. Cleanup
 
 ```bash
-sudo sacctmgr -i remove user       where User=alice   Account=proj_physics
-sudo sacctmgr -i remove user       where User=bob     Account=proj_physics
-sudo sacctmgr -i remove user       where User=carol   Account=proj_chemistry
-sudo sacctmgr -i remove account    where Account=proj_physics
-sudo sacctmgr -i remove account    where Account=proj_chemistry
+sudo $S -i remove user       where User=alice   Account=proj_physics
+sudo $S -i remove user       where User=bob     Account=proj_physics
+sudo $S -i remove user       where User=carol   Account=proj_chemistry
+sudo $S -i remove account    where Account=proj_physics
+sudo $S -i remove account    where Account=proj_chemistry
 ```

--- a/architectures/aws-pcs/tests/multi-user-test.md
+++ b/architectures/aws-pcs/tests/multi-user-test.md
@@ -121,6 +121,29 @@ srun -N 1 -n 1 -p cpu1 bash -c 'ls -la /home/testuser1'
 sudo -E ldap-add-user.sh testuser2 10002 3000
 ```
 
+### B5a. Duplicate UID / username is rejected
+
+The helper pre-checks the directory and refuses to add a user that
+would share a `uidNumber` with an existing entry (LDAP itself would
+happily allow this — two POSIX users with the same UID become the
+same principal on the shared `/home` and `/fsx`). Same check for the
+username. Regression guard for `ldap-add-user.sh`.
+
+```bash
+# Duplicate uidNumber
+sudo -E ldap-add-user.sh testuser3 10001 3000; echo "EXIT=$?"
+# Expected: EXIT=1, stderr: "uidNumber 10001 is already used by 'testuser1'. Pick a different uid."
+
+# Duplicate username
+sudo -E ldap-add-user.sh testuser1 10099 3000; echo "EXIT=$?"
+# Expected: EXIT=1, stderr: "Username 'testuser1' already exists in the directory."
+
+# Confirm neither survived
+ldapsearch -x -H ldap://localhost -b "ou=People,dc=cluster,dc=internal" \
+  "(|(uid=testuser3)(uidNumber=10099))" uid uidNumber
+# Expected: no matching entries.
+```
+
 ### B6. Delete a user
 
 ```bash
@@ -134,6 +157,91 @@ getent passwd testuser2    # should return nothing
 Verify on compute (after cache expires or forced refresh):
 ```bash
 srun -N 1 -n 1 -p cpu1 bash -c 'sudo sss_cache -E; sleep 2; getent passwd testuser2 || echo "user not found (correct)"'
+```
+
+### B7. Reset a password (`-W -S` prompt path)
+
+```bash
+ldappasswd -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -W -S \
+  "uid=testuser1,ou=People,dc=cluster,dc=internal"
+# Enter LDAP Password:              (admin password, hidden)
+# New password:                     (new password for testuser1, hidden)
+# Re-enter new password:
+```
+
+Then verify the user can bind with the new password (still on the login
+node):
+```bash
+ldapwhoami -x -H ldap://localhost -D "uid=testuser1,ou=People,dc=cluster,dc=internal" -W
+# Expected: dn:uid=testuser1,ou=People,dc=cluster,dc=internal
+```
+
+### B8. Group create and member add (`-W` prompt path)
+
+```bash
+# Create group
+cat > /tmp/g.ldif <<EOF
+dn: cn=ml-team,ou=Groups,dc=cluster,dc=internal
+objectClass: posixGroup
+cn: ml-team
+gidNumber: 3001
+memberUid: testuser1
+EOF
+ldapadd -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -W -f /tmp/g.ldif
+
+sudo sss_cache -E && sleep 2
+getent group ml-team
+# Expected: ml-team:*:3001:testuser1
+
+# Add existing user to the group
+cat > /tmp/m.ldif <<EOF
+dn: cn=ml-team,ou=Groups,dc=cluster,dc=internal
+changetype: modify
+add: memberUid
+memberUid: testuser2
+EOF
+ldapmodify -x -H ldap://localhost -D "cn=admin,dc=cluster,dc=internal" -W -f /tmp/m.ldif
+
+sudo sss_cache -E && sleep 2
+id testuser2
+# Expected: uid=10002(testuser2) gid=3000(clusterusers) groups=3000(clusterusers),3001(ml-team)
+
+rm -f /tmp/g.ldif /tmp/m.ldif
+```
+
+### B9. SSH-over-SSM login as LDAP user (end-to-end user flow)
+
+From an operator laptop that has AWS CLI + IAM permissions but no direct
+SSH access to the VPC. Uses the PCS API to derive the login instance ID
+(no reliance on the mutable `Name` tag).
+
+```bash
+# Generate a keypair and install its public key on user creation:
+ssh-keygen -t ed25519 -N "" -f ~/.ssh/pcs-testuser1 -C "testuser1@laptop"
+sudo -E ldap-add-user.sh testuser1 10001 3000 "$(cat ~/.ssh/pcs-testuser1.pub)"
+# (Skip if B1 already created testuser1 without a key — add it with:
+#  ldapmodify or re-run the helper on a fresh directory.)
+
+STACK_NAME=<cluster-stack>
+AWS_REGION=<region>
+LOGIN_INSTANCE_ID=$(aws ec2 describe-instances --region "$AWS_REGION" \
+  --filters "Name=tag:aws:pcs:compute-node-group-id,Values=$(aws pcs list-compute-node-groups --cluster-identifier $(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$AWS_REGION" --query 'Stacks[0].Outputs[?OutputKey==`ClusterId`].OutputValue' --output text) --region "$AWS_REGION" --query 'computeNodeGroups[?name==`login`].id' --output text)" \
+              "Name=instance-state-name,Values=running" \
+  --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+ssh -i ~/.ssh/pcs-testuser1 \
+    -o ProxyCommand="aws ssm start-session --target $LOGIN_INSTANCE_ID --document-name AWS-StartSSHSession --parameters portNumber=%p --region $AWS_REGION" \
+    testuser1@"$LOGIN_INSTANCE_ID" \
+    "id; hostname"
+# Expected: uid=10001(testuser1) ..., login-node hostname.
+
+# Then from that session, submit a job and confirm the shared /home write:
+ssh -tt -i ~/.ssh/pcs-testuser1 \
+    -o ProxyCommand="aws ssm start-session --target $LOGIN_INSTANCE_ID --document-name AWS-StartSSHSession --parameters portNumber=%p --region $AWS_REGION" \
+    testuser1@"$LOGIN_INSTANCE_ID" \
+    "bash -lc 'srun -N 1 -n 1 -p cpu1 bash -c \"id; hostname; touch \\\$HOME/.pcs-verify-ok\"; ls -l \$HOME/.pcs-verify-ok'"
+# Expected: compute reports uid=10001, and .pcs-verify-ok is visible back on the
+# login home (shared OpenZFS).
 ```
 
 ---
@@ -488,3 +596,102 @@ sudo su - charlie -c 'export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH; 
 
 Expected: `error: Unable to allocate resources: Invalid account or account/partition combination specified`
 
+---
+
+## Part F — Blog scenario end-to-end
+
+Reproduces [Introducing managed accounting for AWS Parallel Computing
+Service](https://aws.amazon.com/blogs/hpc/introducing-managed-accounting-for-aws-parallel-computing-service/)
+on top of the existing LDAP users, exercising the customer-facing flow
+the blog demonstrates: two project accounts, a per-user cap, `--account=`
+job attribution, quota-based rejection, and the blog's own reporting
+commands. Regression guard for the walkthrough in
+[USER-MANAGEMENT.md §4.1](../docs/USER-MANAGEMENT.md#41-worked-example-project-accounts--per-user-quota--reports).
+
+**Prerequisites**: same as the accounting test (`ManagedAccounting=enabled`
++ `DirectoryService=OpenLDAP-LoginNode`); alice / bob / carol as LDAP
+users (add carol here if only alice/bob exist).
+
+### F1. Project accounts and quota
+
+```bash
+sudo LDAP_ADMIN_PASSWORD="$ADMIN_PW" ldap-add-user.sh carol 10003 3000
+
+sudo sacctmgr -i add account proj_physics   Description="Physics group"
+sudo sacctmgr -i add account proj_chemistry Description="Chemistry group"
+sudo sacctmgr -i add user alice Account=proj_physics
+sudo sacctmgr -i add user bob   Account=proj_physics
+sudo sacctmgr -i add user carol Account=proj_chemistry
+
+sudo sacctmgr -i modify user alice set GrpTRESRunMins=cpu=6000
+
+sacctmgr show user alice bob carol format=User,Account,DefaultAccount,GrpTRESRunMins
+```
+
+Expected: three users listed under the two project accounts; alice's
+`GrpTRESRunMins` column shows `cpu=6000`.
+
+### F2. Blog-style job submission with `--account=`
+
+```bash
+sudo su - alice -c 'export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH; \
+  echo "hostname; id" > /home/alice/smalljob.sh && chmod +x /home/alice/smalljob.sh; \
+  sbatch --account=proj_physics --partition=cpu1 --cpus-per-task=2 --time=2:00 /home/alice/smalljob.sh'
+```
+
+Expected: `Submitted batch job <n>`; `sacct -j <n> -X --format=JobID,User,Account,State` reports `alice / proj_physics / COMPLETED`.
+
+### F3. Quota hold with `safe` enforcement
+
+Only meaningful with `AccountingPolicyEnforcement=associations,limits,safe`.
+Note the `safe` variant *accepts* the submission and holds it pending
+instead of returning `sbatch: error …`; the strict variant
+(`associations,limits` without `safe`) rejects at submit time.
+
+Tighten alice's limit first so a modest job triggers it:
+
+```bash
+sudo sacctmgr -i modify user alice set GrpTRESRunMins=cpu=60
+```
+
+Submit an over-quota job (8 CPUs × 30 min = 240 CPU-min > 60):
+
+```bash
+sudo su - alice -c 'export PATH=/opt/aws/pcs/scheduler/slurm-25.11/bin:$PATH; \
+  sbatch --account=proj_physics --partition=cpu1 --nodes=1 --ntasks-per-node=8 --time=30:00 --wrap="sleep 1000"'
+squeue -u alice -o "%.6i %.10P %.8u %.2t %r"
+```
+
+Expected: `sbatch: Submitted batch job N`, then `squeue` shows the job
+in state `PD` with Reason `AssocGrpCPURunMinutesLimit`. Restore the
+original limit when done: `sudo sacctmgr -i modify user alice set GrpTRESRunMins=cpu=6000`.
+
+### F4. Blog reporting recipes
+
+```bash
+sacct --starttime=$(date -d "7 days ago" +%Y-%m-%d) \
+  --format="JobID,User,JobName,Partition,Account,AllocCPUS,State,ExitCode"
+
+sreport cluster AccountUtilizationByUser \
+  start=$(date -d "30 days ago" +%Y-%m-%d) end=$(date +%Y-%m-%d) \
+  -t percent format="Accounts,Login,Proper,Used"
+
+sreport user topusage start=$(date -d "30 days ago" +%Y-%m-%d) end=$(date +%Y-%m-%d)
+
+sacct -u alice --starttime=$(date -d "7 days ago" +%Y-%m-%d) \
+  --format="JobID,JobName,State,ExitCode,Start,End,MaxRSS,MaxVMSize,Comment"
+```
+
+Expected: `sacct` returns the jobs submitted above; `sreport` may print
+zero `Used` values for freshly-completed jobs — that's the hourly
+slurmdbd rollup lag, not a failure (see USER-MANAGEMENT §4 note #2).
+
+### F5. Cleanup
+
+```bash
+sudo sacctmgr -i remove user       where User=alice   Account=proj_physics
+sudo sacctmgr -i remove user       where User=bob     Account=proj_physics
+sudo sacctmgr -i remove user       where User=carol   Account=proj_chemistry
+sudo sacctmgr -i remove account    where Account=proj_physics
+sudo sacctmgr -i remove account    where Account=proj_chemistry
+```


### PR DESCRIPTION
## Summary

Refresh of the customer-facing docs (`USER-MANAGEMENT.md`, `JUPYTER.md`, `IAM.md`) after end-to-end verbatim verification on a live Tokyo cluster, plus a related script bug fix, a cluster.yaml default tweak, regression tests, and a new PCS-Ready DLAMI version-history doc.

- `USER-MANAGEMENT.md` opens with the single-user default and treats multi-user as opt-in. Adds a §2 walkthrough that takes a first-time admin from recovering the admin password through adding a user, logging in, and running an `srun` on a compute node, then reorganises the remaining operations and Slurm accounting for day-to-day use.
- `JUPYTER.md` fixes the friction in Steps 1–3, adds a notebook cell that verifies GPU visibility, and documents a token-less mode for single-user clusters only.
- `IAM.md` is trimmed to a role table plus a short Considerations section.
- `PCS-READY-DLAMI.md` is new: version history of the AWS-published PCS-Ready DLAMI (Ubuntu 24.04).

## Test plan

Deployed a fresh cluster in `ap-northeast-1` with `DirectoryService=OpenLDAP-LoginNode`, `ManagedAccounting=enabled`, `AccountingPolicyEnforcement=associations,limits,safe`, and `MonitoringStack=Prometheus-LoginNode`. Ran the fenced blocks in README §6/§7/§8.2, USER-MANAGEMENT §2/§3/§4, JUPYTER Step 1–3, and the load-bearing blocks in `multi-user-test.md` verbatim. `lint-docs.sh` PASS.

One gap surfaced during verification and fixed in this PR: on clusters with `AccountingPolicyEnforcement` set, the README §7 `srun` example is rejected because the submitter must be registered in Slurm accounting first. Added a short callout in §7 that points to USER-MANAGEMENT §4 for the details.